### PR TITLE
Metrics tidyup

### DIFF
--- a/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
@@ -30,14 +30,15 @@ public struct HBMetricsMiddleware: HBMiddleware {
             // need to create dimensions once request has been responded to ensure
             // we have the correct endpoint path
             let dimensions: [(String, String)]
-            if let error = error as? HBHTTPError, error.status == .notFound {
-                // Don't record uri in 404 errors, to avoid spamming of metrics
+            // Don't record uri in 404 errors, to avoid spamming of metrics
+            if let endpointPath = request.endpointPath {
                 dimensions = [
+                    ("hb_uri", endpointPath),
                     ("hb_method", request.method.rawValue),
                 ]
+                Counter(label: "hb_requests", dimensions: dimensions).increment()
             } else {
                 dimensions = [
-                    ("hb_uri", request.endpointPath ?? request.uri.path),
                     ("hb_method", request.method.rawValue),
                 ]
             }

--- a/Sources/Hummingbird/Router/EndpointResponder.swift
+++ b/Sources/Hummingbird/Router/EndpointResponder.swift
@@ -3,7 +3,8 @@ import NIOHTTP1
 
 /// Responder that chooses the next responder to call based on the request method
 class HBEndpointResponder: HBResponder {
-    init() {
+    init(path: String) {
+        self.path = path
         self.methods = [:]
     }
 
@@ -22,4 +23,5 @@ class HBEndpointResponder: HBResponder {
     }
 
     var methods: [String: HBResponder]
+    var path: String
 }

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -14,7 +14,7 @@ struct TrieRouter: HBRouter {
     ///   - method: http method
     ///   - responder: handler to call
     public func add(_ path: String, method: HTTPMethod, responder: HBResponder) {
-        self.trie.addEntry(.init(path), value: HBEndpointResponder()) { node in
+        self.trie.addEntry(.init(path), value: HBEndpointResponder(path: path)) { node in
             node.value!.addResponder(for: method, responder: responder)
         }
     }
@@ -34,6 +34,8 @@ struct TrieRouter: HBRouter {
         if result.parameters.count > 0 {
             request.parameters = result.parameters
         }
+        // store endpoint path in request (mainly for metrics)
+        request.endpointPath = result.value.path
         return result.value.respond(to: request)
     }
 }

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -28,6 +28,8 @@ public final class HBRequest: HBExtensible {
     public var allocator: ByteBufferAllocator
     /// Request extensions
     public var extensions: HBExtensions<HBRequest>
+    /// endpoint that services this request
+    public var endpointPath: String?
 
     /// Parameters extracted during processing of request URI. These are available to you inside the route handler
     public var parameters: HBParameters {
@@ -61,6 +63,7 @@ public final class HBRequest: HBExtensible {
         self.eventLoop = eventLoop
         self.allocator = allocator
         self.extensions = HBExtensions()
+        self.endpointPath = nil
     }
 
     // MARK: Methods

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -165,8 +165,8 @@ internal class TestTimer: TimerHandler, Equatable {
 final class MetricsTests: XCTestCase {
     static var testMetrics = TestMetrics()
 
-    enum override func setUp() {
-        MetricsSystem.bootstrap(testMetrics)
+    override class func setUp() {
+        MetricsSystem.bootstrap(self.testMetrics)
     }
 
     func testCounter() throws {

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -1,0 +1,246 @@
+import Hummingbird
+import HummingbirdXCT
+import Metrics
+import NIOConcurrencyHelpers
+import XCTest
+
+internal final class TestMetrics: MetricsFactory {
+    private let lock = Lock()
+    var counters = [String: CounterHandler]()
+    var recorders = [String: RecorderHandler]()
+    var timers = [String: TimerHandler]()
+
+    public func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
+        return self.make(label: label, dimensions: dimensions, registry: &self.counters, maker: TestCounter.init)
+    }
+
+    public func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
+        let maker = { (label: String, dimensions: [(String, String)]) -> RecorderHandler in
+            TestRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
+        }
+        return self.make(label: label, dimensions: dimensions, registry: &self.recorders, maker: maker)
+    }
+
+    public func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
+        return self.make(label: label, dimensions: dimensions, registry: &self.timers, maker: TestTimer.init)
+    }
+
+    private func make<Item>(label: String, dimensions: [(String, String)], registry: inout [String: Item], maker: (String, [(String, String)]) -> Item) -> Item {
+        return self.lock.withLock {
+            let item = maker(label, dimensions)
+            registry[label] = item
+            return item
+        }
+    }
+
+    func destroyCounter(_ handler: CounterHandler) {
+        if let testCounter = handler as? TestCounter {
+            self.counters.removeValue(forKey: testCounter.label)
+        }
+    }
+
+    func destroyRecorder(_ handler: RecorderHandler) {
+        if let testRecorder = handler as? TestRecorder {
+            self.recorders.removeValue(forKey: testRecorder.label)
+        }
+    }
+
+    func destroyTimer(_ handler: TimerHandler) {
+        if let testTimer = handler as? TestTimer {
+            self.timers.removeValue(forKey: testTimer.label)
+        }
+    }
+}
+
+internal class TestCounter: CounterHandler, Equatable {
+    let id: String
+    let label: String
+    let dimensions: [(String, String)]
+
+    let lock = Lock()
+    var values = [(Date, Int64)]()
+
+    init(label: String, dimensions: [(String, String)]) {
+        self.id = NSUUID().uuidString
+        self.label = label
+        self.dimensions = dimensions
+    }
+
+    func increment(by amount: Int64) {
+        self.lock.withLock {
+            self.values.append((Date(), amount))
+        }
+        print("adding \(amount) to \(self.label)")
+    }
+
+    func reset() {
+        self.lock.withLock {
+            self.values = []
+        }
+        print("reseting \(self.label)")
+    }
+
+    public static func == (lhs: TestCounter, rhs: TestCounter) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
+internal class TestRecorder: RecorderHandler, Equatable {
+    let id: String
+    let label: String
+    let dimensions: [(String, String)]
+    let aggregate: Bool
+
+    let lock = Lock()
+    var values = [(Date, Double)]()
+
+    init(label: String, dimensions: [(String, String)], aggregate: Bool) {
+        self.id = NSUUID().uuidString
+        self.label = label
+        self.dimensions = dimensions
+        self.aggregate = aggregate
+    }
+
+    func record(_ value: Int64) {
+        self.record(Double(value))
+    }
+
+    func record(_ value: Double) {
+        self.lock.withLock {
+            // this may loose precision but good enough as an example
+            values.append((Date(), Double(value)))
+        }
+        print("recording \(value) in \(self.label)")
+    }
+
+    public static func == (lhs: TestRecorder, rhs: TestRecorder) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
+internal class TestTimer: TimerHandler, Equatable {
+    let id: String
+    let label: String
+    var displayUnit: TimeUnit?
+    let dimensions: [(String, String)]
+
+    let lock = Lock()
+    var values = [(Date, Int64)]()
+
+    init(label: String, dimensions: [(String, String)]) {
+        self.id = NSUUID().uuidString
+        self.label = label
+        self.displayUnit = nil
+        self.dimensions = dimensions
+    }
+
+    func preferDisplayUnit(_ unit: TimeUnit) {
+        self.lock.withLock {
+            self.displayUnit = unit
+        }
+    }
+
+    func retriveValueInPreferredUnit(atIndex i: Int) -> Double {
+        return self.lock.withLock {
+            let value = values[i].1
+            guard let displayUnit = self.displayUnit else {
+                return Double(value)
+            }
+            return Double(value) / Double(displayUnit.scaleFromNanoseconds)
+        }
+    }
+
+    func recordNanoseconds(_ duration: Int64) {
+        self.lock.withLock {
+            values.append((Date(), duration))
+        }
+        print("recording \(duration) \(self.label)")
+    }
+
+    public static func == (lhs: TestTimer, rhs: TestTimer) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
+final class MetricsTests: XCTestCase {
+    static var testMetrics = TestMetrics()
+
+    enum override func setUp() {
+        MetricsSystem.bootstrap(testMetrics)
+    }
+
+    func testCounter() throws {
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(HBMetricsMiddleware())
+        app.router.get("/hello") { _ -> String in
+            return "Hello"
+        }
+        app.XCTStart()
+        defer { app.XCTStop() }
+        app.XCTExecute(uri: "/hello", method: .GET) { _ in }
+
+        let counter = try XCTUnwrap(Self.testMetrics.counters["hb_requests"] as? TestCounter)
+        XCTAssertEqual(counter.values[0].1, 1)
+        XCTAssertEqual(counter.dimensions[0].0, "hb_uri")
+        XCTAssertEqual(counter.dimensions[0].1, "/hello")
+        XCTAssertEqual(counter.dimensions[1].0, "hb_method")
+        XCTAssertEqual(counter.dimensions[1].1, "GET")
+    }
+
+    func testError() throws {
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(HBMetricsMiddleware())
+        app.router.get("/hello") { _ -> String in
+            throw HBHTTPError(.badRequest)
+        }
+        app.XCTStart()
+        defer { app.XCTStop() }
+        app.XCTExecute(uri: "/hello", method: .GET) { _ in }
+
+        let counter = try XCTUnwrap(Self.testMetrics.counters["hb_errors"] as? TestCounter)
+        XCTAssertEqual(counter.values.count, 1)
+        XCTAssertEqual(counter.values[0].1, 1)
+        XCTAssertEqual(counter.dimensions[0].0, "hb_uri")
+        XCTAssertEqual(counter.dimensions[0].1, "/hello")
+        XCTAssertEqual(counter.dimensions[1].0, "hb_method")
+        XCTAssertEqual(counter.dimensions[1].1, "GET")
+    }
+
+    func testNotFoundError() throws {
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(HBMetricsMiddleware())
+        app.router.get("/hello") { _ -> String in
+            return "hello"
+        }
+        app.XCTStart()
+        defer { app.XCTStop() }
+        app.XCTExecute(uri: "/hello2", method: .GET) { _ in }
+
+        let counter = try XCTUnwrap(Self.testMetrics.counters["hb_errors"] as? TestCounter)
+        XCTAssertEqual(counter.values.count, 1)
+        XCTAssertEqual(counter.values[0].1, 1)
+        XCTAssertEqual(counter.dimensions.count, 1)
+        XCTAssertEqual(counter.dimensions[0].0, "hb_method")
+        XCTAssertEqual(counter.dimensions[0].1, "GET")
+    }
+
+    func testParameterEndpoint() throws {
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(HBMetricsMiddleware())
+        app.router.get("/user/:id") { _ -> String in
+            throw HBHTTPError(.badRequest)
+        }
+        app.XCTStart()
+        defer { app.XCTStop() }
+        app.XCTExecute(uri: "/user/765", method: .GET) { _ in }
+
+        let counter = try XCTUnwrap(Self.testMetrics.counters["hb_errors"] as? TestCounter)
+        XCTAssertEqual(counter.values.count, 1)
+        XCTAssertEqual(counter.values[0].1, 1)
+        XCTAssertEqual(counter.dimensions.count, 2)
+        XCTAssertEqual(counter.dimensions[0].0, "hb_uri")
+        XCTAssertEqual(counter.dimensions[0].1, "/user/:id")
+        XCTAssertEqual(counter.dimensions[1].0, "hb_method")
+        XCTAssertEqual(counter.dimensions[1].1, "GET")
+    }
+}

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -123,19 +123,4 @@ final class MiddlewareTests: XCTestCase {
         app.XCTExecute(uri: "/hello", method: .PUT) { _ in
         }
     }
-
-    func testMetricsMiddleware() {
-        let app = HBApplication(testing: .embedded)
-        app.middleware.add(HBMetricsMiddleware())
-        app.router.delete("/hello") { request -> EventLoopFuture<String> in
-            return request.failure(.badRequest)
-        }
-        app.XCTStart()
-        defer { app.XCTStop() }
-
-        app.XCTExecute(uri: "/hello", method: .DELETE) { _ in
-        }
-        app.XCTExecute(uri: "/hello", method: .GET) { _ in
-        }
-    }
 }


### PR DESCRIPTION
Metrics now record path in router not path in uri ie `/user/:id` instead of `/user/2343`.
Added tests for metrics recording