### PR TITLE
Adds 'errorResponseHandler' to HBApplication to allow HBHTTPResponseErrors to be intercepted and a custom response returned

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -43,6 +43,8 @@ public final class HBApplication: HBExtensible {
     public var encoder: HBResponseEncoder
     /// decoder used by router
     public var decoder: HBRequestDecoder
+    /// Optional response handler for HBHTTPResponseError
+    public var errorResponseHandler: ((HBRequest, HBHTTPResponseError) -> EventLoopFuture<HBHTTPResponse>)?
 
     /// who provided the eventLoopGroup
     let eventLoopGroupProvider: NIOEventLoopGroupProvider

--- a/Sources/Hummingbird/Server/Application+HTTPResponder.swift
+++ b/Sources/Hummingbird/Server/Application+HTTPResponder.swift
@@ -52,6 +52,9 @@ extension HBApplication {
                     if let error = error as? HBHTTPResponseError {
                         // this is a processed error so don't log as Error
                         request.logger.info("Error: \(error)")
+                        if let errorResponseHandler = application.errorResponseHandler {
+                            return errorResponseHandler(request, error).whenComplete(onComplete)
+                        }
                         response = error.response(version: request.version, allocator: request.allocator)
                     } else {
                         request.logger.error("\(error)")

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -283,7 +283,7 @@ final class ApplicationTests: XCTestCase {
     
     func testDefaultHTTPErrorResponse() throws {
         let app = HBApplication(testing: .embedded)
-        app.router.get("/hello") { request -> String in
+        app.router.get("/hello") { _ -> String in
             return "Hello"
         }
         app.XCTStart()
@@ -298,7 +298,7 @@ final class ApplicationTests: XCTestCase {
     
     func testCustomHTTPErrorResponseHandler() throws {
         let app = HBApplication(testing: .embedded)
-        app.router.get("/hello") { request -> String in
+        app.router.get("/hello") { _ -> String in
             return "Hello"
         }
         app.errorResponseHandler = { (request, httpResponseError) -> EventLoopFuture<HBHTTPResponse> in
@@ -306,7 +306,7 @@ final class ApplicationTests: XCTestCase {
             promise.completeWith(
                 .success(.init(
                     head: .init(version: request.version, status: .imATeapot),
-                    body: .byteBuffer(.init(string: "Custom Error Handling"))
+                    body: .byteBuffer(.init(string: "Custom Error Handling for \(httpResponseError.status)"))
                 ))
             )
             return promise.futureResult
@@ -317,7 +317,7 @@ final class ApplicationTests: XCTestCase {
         app.XCTExecute(uri: "/world", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(response.status, .imATeapot)
-            XCTAssertEqual(String(buffer: body), "Custom Error Handling")
+            XCTAssertEqual(String(buffer: body), "Custom Error Handling for notFound")
         }
     }
 }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -280,7 +280,7 @@ final class ApplicationTests: XCTestCase {
             XCTAssertEqual(string, "Hello")
         }
     }
-    
+
     func testDefaultHTTPErrorResponse() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get("/hello") { _ -> String in
@@ -295,7 +295,7 @@ final class ApplicationTests: XCTestCase {
             XCTAssertTrue(String(buffer: body).isEmpty)
         }
     }
-    
+
     func testCustomHTTPErrorResponseHandler() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get("/hello") { _ -> String in


### PR DESCRIPTION
As promised, this is the second PR. It introduces the ability to handle a `HBHTTPResponseError` and provide a custom response, falling back to the default implementation in `HTTPResponder` using `HBHTTPResponseError` if the `errorResponseHandler` is not provided.

The reason for this PR is that I wanted to continue using standard `HBHTTPErrors` e.g. `HBHTTPError(.notFound)` at the higher-levels of the application, but have the ability to create/manipulate a custom response in-place of the ones provided by `HBHTTPResponseError` itself at a global level.