### PR TITLE
Add `HBRequestHandler` and `HBRequestDecodable`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
         // test targets
         .testTarget(name: "HummingbirdTests", dependencies: [
             .byName(name: "Hummingbird"),
+            .byName(name: "HummingbirdFoundation"),
             .byName(name: "HummingbirdXCT"),
         ]),
         .testTarget(name: "HummingbirdFoundationTests", dependencies: [

--- a/Sources/Hummingbird/Codable/CodableProtocols.swift
+++ b/Sources/Hummingbird/Codable/CodableProtocols.swift
@@ -33,6 +33,6 @@ struct NullEncoder: HBResponseEncoder {
 /// Default decoder. there is no default decoder path so this generates an error
 struct NullDecoder: HBRequestDecoder {
     func decode<T: Decodable>(_ type: T.Type, from request: HBRequest) throws -> T {
-        preconditionFailure("Application.decoder has not been set")
+        preconditionFailure("HBApplication.decoder has not been set")
     }
 }

--- a/Sources/Hummingbird/Codable/RequestHandler.swift
+++ b/Sources/Hummingbird/Codable/RequestHandler.swift
@@ -1,0 +1,164 @@
+
+public protocol HBRequestHandler: Decodable {
+    associatedtype Output
+    init(from: HBRequest) throws
+    func handle(request: HBRequest) throws -> Output
+}
+
+extension HBRequestHandler {
+    public init(from request: HBRequest) throws {
+        self = try request.application.decoder.decode(Self.self, from: request)
+    }
+}
+
+extension HBRouterMethods {
+    /// Add path for `HBRouteHandler` that returns a value conforming to `HBResponseGenerator`
+    @discardableResult public func on<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String,
+        method: HTTPMethod,
+        body: HBBodyCollation = .collate,
+        use handlerType: Handler.Type
+    ) -> Self where Handler.Output == Output {
+        return on(path, method: method, body: body) { request -> Output in
+            let handler: Handler
+            do {
+                handler = try Handler.init(from: request)
+            } catch {
+                request.logger.debug("Decode Error: \(error)")
+                throw HBHTTPError(.badRequest)
+            }
+            return try handler.handle(request: request)
+        }
+    }
+
+    /// Add path for `HBRouteHandler` that returns an `EventLoopFuture` specialized with a type conforming
+    /// to `HBResponseGenerator`
+    @discardableResult func on<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String,
+        method: HTTPMethod,
+        body: HBBodyCollation = .collate,
+        use handlerType: Handler.Type
+    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+        return on(path, method: method, body: body) { request -> EventLoopFuture<Output> in
+            let handler: Handler
+            do {
+                handler = try Handler.init(from: request)
+            } catch {
+                request.logger.debug("Decode Error: \(error)")
+                return request.failure(.badRequest)
+            }
+            do {
+                return try handler.handle(request: request)
+            } catch {
+                return request.failure(error)
+            }
+        }
+    }
+
+    /// GET path for closure returning type conforming to HBResponseGenerator
+    @discardableResult public func get<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == Output {
+        return on(path, method: .GET, body: body, use: handler)
+    }
+
+    /// PUT path for closure returning type conforming to HBResponseGenerator
+    @discardableResult public func put<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == Output {
+        return on(path, method: .PUT, body: body, use: handler)
+    }
+
+    /// POST path for closure returning type conforming to HBResponseGenerator
+    @discardableResult public func post<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == Output {
+        return on(path, method: .POST, body: body, use: handler)
+    }
+
+    /// HEAD path for closure returning type conforming to HBResponseGenerator
+    @discardableResult public func head<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == Output {
+        return on(path, method: .HEAD, body: body, use: handler)
+    }
+
+    /// DELETE path for closure returning type conforming to HBResponseGenerator
+    @discardableResult public func delete<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == Output {
+        return on(path, method: .DELETE, body: body, use: handler)
+    }
+
+    /// PATCH path for closure returning type conforming to HBResponseGenerator
+    @discardableResult public func patch<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == Output {
+        return on(path, method: .PATCH, body: body, use: handler)
+    }
+
+    /// GET path for closure returning type conforming to ResponseFutureEncodable
+    @discardableResult public func get<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+        return on(path, method: .GET, body: body, use: handler)
+    }
+
+    /// PUT path for closure returning type conforming to ResponseFutureEncodable
+    @discardableResult public func put<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+        return on(path, method: .PUT, body: body, use: handler)
+    }
+
+    /// POST path for closure returning type conforming to ResponseFutureEncodable
+    @discardableResult public func post<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+        return on(path, method: .POST, body: body, use: handler)
+    }
+
+    /// HEAD path for closure returning type conforming to ResponseFutureEncodable
+    @discardableResult public func head<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+        return on(path, method: .HEAD, body: body, use: handler)
+    }
+
+    /// DELETE path for closure returning type conforming to ResponseFutureEncodable
+    @discardableResult public func delete<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+        return on(path, method: .DELETE, body: body, use: handler)
+    }
+
+    /// PATCH path for closure returning type conforming to ResponseFutureEncodable
+    @discardableResult public func patch<Handler: HBRequestHandler, Output: HBResponseGenerator>(
+        _ path: String = "",
+        body: HBBodyCollation = .collate,
+        use handler: Handler.Type
+    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+        return on(path, method: .PATCH, body: body, use: handler)
+    }}

--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -8,7 +8,7 @@ import Darwin.C
 public struct HBEnvironment: Decodable, ExpressibleByDictionaryLiteral {
     // shared environment
     public static let shared: HBEnvironment = .init()
-    
+
     /// initialize from environment variables
     public init() {
         self.values = Self.getEnvironment()

--- a/Sources/Hummingbird/Router/Parameters.swift
+++ b/Sources/Hummingbird/Router/Parameters.swift
@@ -20,6 +20,27 @@ public struct HBParameters {
         return self.parameters[s[...]].map { T(String($0)) } ?? nil
     }
 
+    /// Return parameter with specified id
+    /// - Parameter s: parameter id
+    public func require(_ s: String) throws -> String {
+        guard let param = self.parameters[s[...]].map({ String($0) }) else {
+            throw HBHTTPError(.badRequest)
+        }
+        return param
+    }
+
+    /// Return parameter with specified id as a certain type
+    /// - Parameters:
+    ///   - s: parameter id
+    ///   - as: type we want returned
+    public func require<T: LosslessStringConvertible>(_ s: String, as: T.Type) throws -> T {
+        guard let param = self.parameters[s[...]],
+              let result = T(String(param)) else {
+            throw HBHTTPError(.badRequest)
+        }
+        return result
+    }
+
     /// Set parameter
     /// - Parameters:
     ///   - s: parameter id

--- a/Sources/Hummingbird/Router/Parameters.swift
+++ b/Sources/Hummingbird/Router/Parameters.swift
@@ -35,7 +35,8 @@ public struct HBParameters {
     ///   - as: type we want returned
     public func require<T: LosslessStringConvertible>(_ s: String, as: T.Type) throws -> T {
         guard let param = self.parameters[s[...]],
-              let result = T(String(param)) else {
+              let result = T(String(param))
+        else {
             throw HBHTTPError(.badRequest)
         }
         return result

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -22,7 +22,7 @@ public protocol HBRouterMethods {
         body: HBBodyCollation,
         use: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self
-    
+
     /// add group
     func group(_ path: String) -> HBRouterGroup
 }

--- a/Tests/HummingbirdTests/HandlerTests.swift
+++ b/Tests/HummingbirdTests/HandlerTests.swift
@@ -15,7 +15,7 @@ final class HandlerTests: XCTestCase {
         let app = HBApplication(testing: .embedded)
         app.decoder = JSONDecoder()
         app.router.post("/hello", use: DecodeTest.self)
-        
+
         app.XCTStart()
         defer { app.XCTStop() }
 
@@ -24,7 +24,7 @@ final class HandlerTests: XCTestCase {
             XCTAssertEqual(String(buffer: body), "Hello Adam")
         }
     }
-    
+
     func testDecodeFutureResponse() {
         struct DecodeTest: HBRequestDecodable {
             let name: String
@@ -35,7 +35,7 @@ final class HandlerTests: XCTestCase {
         let app = HBApplication(testing: .embedded)
         app.decoder = JSONDecoder()
         app.router.put("/hello", use: DecodeTest.self)
-        
+
         app.XCTStart()
         defer { app.XCTStop() }
 
@@ -44,7 +44,7 @@ final class HandlerTests: XCTestCase {
             XCTAssertEqual(String(buffer: body), "Hello Adam")
         }
     }
-    
+
     func testDecodeFail() {
         struct DecodeTest: HBRequestDecodable {
             let name: String
@@ -55,7 +55,7 @@ final class HandlerTests: XCTestCase {
         let app = HBApplication(testing: .embedded)
         app.decoder = JSONDecoder()
         app.router.get("/hello", use: DecodeTest.self)
-        
+
         app.XCTStart()
         defer { app.XCTStop() }
 
@@ -63,21 +63,22 @@ final class HandlerTests: XCTestCase {
             XCTAssertEqual(response.status, .badRequest)
         }
     }
-    
+
     func testEmptyRequest() {
         struct ParameterTest: HBRequestHandler {
             let parameter: Int
             init(from request: HBRequest) throws {
                 self.parameter = try request.parameters.require("test", as: Int.self)
             }
+
             func handle(request: HBRequest) -> String {
-                return "\(parameter)"
+                return "\(self.parameter)"
             }
         }
-        
+
         let app = HBApplication(testing: .embedded)
         app.router.put("/:test", use: ParameterTest.self)
-        
+
         app.XCTStart()
         defer { app.XCTStop() }
 

--- a/Tests/HummingbirdTests/HandlerTests.swift
+++ b/Tests/HummingbirdTests/HandlerTests.swift
@@ -1,0 +1,89 @@
+import Hummingbird
+import HummingbirdFoundation
+import HummingbirdXCT
+import NIOHTTP1
+import XCTest
+
+final class HandlerTests: XCTestCase {
+    func testDecode() {
+        struct DecodeTest: HBRequestDecodable {
+            let name: String
+            func handle(request: HBRequest) -> String {
+                return "Hello \(self.name)"
+            }
+        }
+        let app = HBApplication(testing: .embedded)
+        app.decoder = JSONDecoder()
+        app.router.post("/hello", use: DecodeTest.self)
+        
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        app.XCTExecute(uri: "/hello", method: .POST, body: ByteBufferAllocator().buffer(string: #"{"name": "Adam"}"#)) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "Hello Adam")
+        }
+    }
+    
+    func testDecodeFutureResponse() {
+        struct DecodeTest: HBRequestDecodable {
+            let name: String
+            func handle(request: HBRequest) -> EventLoopFuture<String> {
+                return request.success("Hello \(self.name)")
+            }
+        }
+        let app = HBApplication(testing: .embedded)
+        app.decoder = JSONDecoder()
+        app.router.put("/hello", use: DecodeTest.self)
+        
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        app.XCTExecute(uri: "/hello", method: .PUT, body: ByteBufferAllocator().buffer(string: #"{"name": "Adam"}"#)) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "Hello Adam")
+        }
+    }
+    
+    func testDecodeFail() {
+        struct DecodeTest: HBRequestDecodable {
+            let name: String
+            func handle(request: HBRequest) -> HTTPResponseStatus {
+                return .ok
+            }
+        }
+        let app = HBApplication(testing: .embedded)
+        app.decoder = JSONDecoder()
+        app.router.get("/hello", use: DecodeTest.self)
+        
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        app.XCTExecute(uri: "/hello", method: .GET, body: ByteBufferAllocator().buffer(string: #"{"name2": "Adam"}"#)) { response in
+            XCTAssertEqual(response.status, .badRequest)
+        }
+    }
+    
+    func testEmptyRequest() {
+        struct ParameterTest: HBRequestHandler {
+            let parameter: Int
+            init(from request: HBRequest) throws {
+                self.parameter = try request.parameters.require("test", as: Int.self)
+            }
+            func handle(request: HBRequest) -> String {
+                return "\(parameter)"
+            }
+        }
+        
+        let app = HBApplication(testing: .embedded)
+        app.router.put("/:test", use: ParameterTest.self)
+        
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        app.XCTExecute(uri: "/23", method: .PUT) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "23")
+        }
+    }
+}


### PR DESCRIPTION
`HBRequestHandler` is a protocol for an object created from a request that is then used to serve that request. This moves all the initialization out of the request handler.

Created `HBRequestDecodable` a specialization of `HBRequestHandler` which uses `Codable` to initialize itself.

example
```swift
struct CreateUser: HBRequestDecodable {
    let username: String
    let password: String
    func handle(request: HBRequest) -> EventLoopFuture<HTTPResponseStatus> {
        return addUserToDatabase(
            name: self.username,
            password: self.password
        ).map { _ in .ok }
}
application.router.put("user", use: CreateUser.self)
```