### PR TITLE
HBRouteHandler changes

### DIFF
--- a/Sources/Hummingbird/Codable/RequestDecodable.swift
+++ b/Sources/Hummingbird/Codable/RequestDecodable.swift
@@ -23,4 +23,3 @@ extension HBRequestDecodable {
         self = try request.decode(as: Self.self)
     }
 }
-

--- a/Sources/Hummingbird/Router/RouteHandler.swift
+++ b/Sources/Hummingbird/Router/RouteHandler.swift
@@ -24,20 +24,20 @@
 /// }
 /// ```
 public protocol HBRouteHandler {
-    associatedtype Output
+    associatedtype _Output
     init(from: HBRequest) throws
-    func handle(request: HBRequest) throws -> Output
+    func handle(request: HBRequest) throws -> _Output
 }
 
 extension HBRouterMethods {
     /// Add path for `HBRouteHandler` that returns a value conforming to `HBResponseGenerator`
-    @discardableResult public func on<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func on<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String,
         method: HTTPMethod,
         body: HBBodyCollation = .collate,
         use handlerType: Handler.Type
-    ) -> Self where Handler.Output == Output {
-        return self.on(path, method: method, body: body) { request -> Output in
+    ) -> Self where Handler._Output == _Output {
+        return self.on(path, method: method, body: body) { request -> _Output in
             let handler = try Handler(from: request)
             return try handler.handle(request: request)
         }
@@ -45,13 +45,13 @@ extension HBRouterMethods {
 
     /// Add path for `HBRouteHandler` that returns an `EventLoopFuture` specialized with a type conforming
     /// to `HBResponseGenerator`
-    @discardableResult func on<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult func on<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String,
         method: HTTPMethod,
         body: HBBodyCollation = .collate,
         use handlerType: Handler.Type
-    ) -> Self where Handler.Output == EventLoopFuture<Output> {
-        return self.on(path, method: method, body: body) { request -> EventLoopFuture<Output> in
+    ) -> Self where Handler._Output == EventLoopFuture<_Output> {
+        return self.on(path, method: method, body: body) { request -> EventLoopFuture<_Output> in
             do {
                 let handler = try Handler(from: request)
                 return try handler.handle(request: request)
@@ -62,110 +62,110 @@ extension HBRouterMethods {
     }
 
     /// GET path for closure returning type conforming to HBResponseGenerator
-    @discardableResult public func get<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func get<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == Output {
+    ) -> Self where Handler._Output == _Output {
         return self.on(path, method: .GET, body: body, use: handler)
     }
 
     /// PUT path for closure returning type conforming to HBResponseGenerator
-    @discardableResult public func put<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func put<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == Output {
+    ) -> Self where Handler._Output == _Output {
         return self.on(path, method: .PUT, body: body, use: handler)
     }
 
     /// POST path for closure returning type conforming to HBResponseGenerator
-    @discardableResult public func post<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func post<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == Output {
+    ) -> Self where Handler._Output == _Output {
         return self.on(path, method: .POST, body: body, use: handler)
     }
 
     /// HEAD path for closure returning type conforming to HBResponseGenerator
-    @discardableResult public func head<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func head<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == Output {
+    ) -> Self where Handler._Output == _Output {
         return self.on(path, method: .HEAD, body: body, use: handler)
     }
 
     /// DELETE path for closure returning type conforming to HBResponseGenerator
-    @discardableResult public func delete<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func delete<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == Output {
+    ) -> Self where Handler._Output == _Output {
         return self.on(path, method: .DELETE, body: body, use: handler)
     }
 
     /// PATCH path for closure returning type conforming to HBResponseGenerator
-    @discardableResult public func patch<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func patch<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == Output {
+    ) -> Self where Handler._Output == _Output {
         return self.on(path, method: .PATCH, body: body, use: handler)
     }
 
     /// GET path for closure returning type conforming to ResponseFutureEncodable
-    @discardableResult public func get<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func get<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+    ) -> Self where Handler._Output == EventLoopFuture<_Output> {
         return self.on(path, method: .GET, body: body, use: handler)
     }
 
     /// PUT path for closure returning type conforming to ResponseFutureEncodable
-    @discardableResult public func put<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func put<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+    ) -> Self where Handler._Output == EventLoopFuture<_Output> {
         return self.on(path, method: .PUT, body: body, use: handler)
     }
 
     /// POST path for closure returning type conforming to ResponseFutureEncodable
-    @discardableResult public func post<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func post<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+    ) -> Self where Handler._Output == EventLoopFuture<_Output> {
         return self.on(path, method: .POST, body: body, use: handler)
     }
 
     /// HEAD path for closure returning type conforming to ResponseFutureEncodable
-    @discardableResult public func head<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func head<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+    ) -> Self where Handler._Output == EventLoopFuture<_Output> {
         return self.on(path, method: .HEAD, body: body, use: handler)
     }
 
     /// DELETE path for closure returning type conforming to ResponseFutureEncodable
-    @discardableResult public func delete<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func delete<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+    ) -> Self where Handler._Output == EventLoopFuture<_Output> {
         return self.on(path, method: .DELETE, body: body, use: handler)
     }
 
     /// PATCH path for closure returning type conforming to ResponseFutureEncodable
-    @discardableResult public func patch<Handler: HBRouteHandler, Output: HBResponseGenerator>(
+    @discardableResult public func patch<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
         body: HBBodyCollation = .collate,
         use handler: Handler.Type
-    ) -> Self where Handler.Output == EventLoopFuture<Output> {
+    ) -> Self where Handler._Output == EventLoopFuture<_Output> {
         return self.on(path, method: .PATCH, body: body, use: handler)
     }
 }

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -74,7 +74,7 @@ public final class HBRequest: HBExtensible {
         do {
             return try self.application.decoder.decode(type, from: self)
         } catch {
-            logger.debug("Decode Error: \(error)")
+            self.logger.debug("Decode Error: \(error)")
             throw HBHTTPError(.badRequest)
         }
     }


### PR DESCRIPTION
- Change associated type of `HBRouteHandler` to `_Output` so it doesn't clash if user uses `Output` internally.