### PR TITLE
Add HTTPHeadersPatch for patching headers in ResponsePatch

### DIFF
--- a/Sources/Hummingbird/Server/ResponsePatch.swift
+++ b/Sources/Hummingbird/Server/ResponsePatch.swift
@@ -101,7 +101,7 @@ public struct HTTPHeadersPatch: ExpressibleByDictionaryLiteral {
     ///     names are strongly recommended.
     @inlinable
     public mutating func add<S: Sequence>(contentsOf other: S) where S.Element == (String, String) {
-        addHeaders.add(contentsOf: other)
+        self.addHeaders.add(contentsOf: other)
     }
 
     /// Add a header name/value pair to the block, replacing any previous values for the

--- a/Sources/Hummingbird/Server/ResponsePatch.swift
+++ b/Sources/Hummingbird/Server/ResponsePatch.swift
@@ -31,7 +31,7 @@ extension HBRequest {
         /// patch status of reponse
         public var status: HTTPResponseStatus?
         /// headers to add to response
-        public var headers: HTTPHeaders
+        public var headers: HTTPHeadersPatch
 
         init() {
             self.status = nil
@@ -58,7 +58,89 @@ extension HBResponse {
         if let status = patch.status {
             self.status = status
         }
-        self.headers.add(contentsOf: patch.headers)
+        self.headers.apply(patch: patch.headers)
         return self
+    }
+}
+
+/// Used to Patch HTTPHeaders. Remembers if a header was added in with `add` or `replaceOrAdd`
+public struct HTTPHeadersPatch: ExpressibleByDictionaryLiteral {
+    @usableFromInline
+    internal var addHeaders: HTTPHeaders
+    internal var replaceHeaders: HTTPHeaders
+
+    /// Construct a `HTTPHeaders` structure.
+    ///
+    /// - parameters
+    ///     - elements: name, value pairs provided by a dictionary literal.
+    public init(dictionaryLiteral elements: (String, String)...) {
+        self.replaceHeaders = .init(elements)
+        self.addHeaders = .init()
+    }
+
+    /// Add a header name/value pair to the block.
+    ///
+    /// This method is strictly additive: if there are other values for the given header name
+    /// already in the block, this will add a new entry.
+    ///
+    /// - Parameter name: The header field name. For maximum compatibility this should be an
+    ///     ASCII string. For future-proofing with HTTP/2 lowercase header names are strongly
+    ///     recommended.
+    /// - Parameter value: The header field value to add for the given name.
+    public mutating func add(name: String, value: String) {
+        self.addHeaders.add(name: name, value: value)
+    }
+
+    /// Add a sequence of header name/value pairs to the block.
+    ///
+    /// This method is strictly additive: if there are other entries with the same header
+    /// name already in the block, this will add new entries.
+    ///
+    /// - Parameter contentsOf: The sequence of header name/value pairs. For maximum compatibility
+    ///     the header should be an ASCII string. For future-proofing with HTTP/2 lowercase header
+    ///     names are strongly recommended.
+    @inlinable
+    public mutating func add<S: Sequence>(contentsOf other: S) where S.Element == (String, String) {
+        addHeaders.add(contentsOf: other)
+    }
+
+    /// Add a header name/value pair to the block, replacing any previous values for the
+    /// same header name that are already in the block.
+    ///
+    /// This is a supplemental method to `add` that essentially combines `remove` and `add`
+    /// in a single function. It can be used to ensure that a header block is in a
+    /// well-defined form without having to check whether the value was previously there.
+    /// Like `add`, this method performs case-insensitive comparisons of the header field
+    /// names.
+    ///
+    /// - Parameter name: The header field name. For maximum compatibility this should be an
+    ///     ASCII string. For future-proofing with HTTP/2 lowercase header names are strongly
+    //      recommended.
+    /// - Parameter value: The header field value to add for the given name.
+    public mutating func replaceOrAdd(name: String, value: String) {
+        self.addHeaders.remove(name: name)
+        self.replaceHeaders.remove(name: name)
+        self.replaceHeaders.add(name: name, value: value)
+    }
+
+    /// Remove all values for a given header name from the block.
+    ///
+    /// This method uses case-insensitive comparisons for the header field name.
+    ///
+    /// - Parameter name: The name of the header field to remove from the block.
+    public mutating func remove(name nameToRemove: String) {
+        self.addHeaders.remove(name: nameToRemove)
+        self.replaceHeaders.remove(name: nameToRemove)
+    }
+}
+
+extension HTTPHeaders {
+    /// Apply header patch to headers
+    /// - Parameter patch: header patch
+    mutating func apply(patch: HTTPHeadersPatch) {
+        self.add(contentsOf: patch.addHeaders)
+        for header in patch.replaceHeaders {
+            self.replaceOrAdd(name: header.name, value: header.value)
+        }
     }
 }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -280,6 +280,7 @@ final class ApplicationTests: XCTestCase {
         let app = HBApplication(testing: .embedded)
         app.router.delete("/hello") { request -> String in
             request.response.headers.add(name: "test", value: "value")
+            request.response.headers.replaceOrAdd(name: "content-type", value: "application/json")
             request.response.status = .imATeapot
             return "Hello"
         }
@@ -291,6 +292,8 @@ final class ApplicationTests: XCTestCase {
             let string = body.readString(length: body.readableBytes)
             XCTAssertEqual(response.status, .imATeapot)
             XCTAssertEqual(response.headers["test"].first, "value")
+            XCTAssertEqual(response.headers["content-type"].count, 1)
+            XCTAssertEqual(response.headers["content-type"].first, "application/json")
             XCTAssertEqual(string, "Hello")
         }
     }


### PR DESCRIPTION
Remembers if a header was added with `add` or `replaceOrAdd`. This means you can replace `content-type` headers while still adding `set-cookie` headers in a `ResponsePatch`