### PR TITLE
Add Framework for storing persistent key/value pairs to be used between requests

### DIFF
--- a/Sources/Hummingbird/Extensions/Extensions.swift
+++ b/Sources/Hummingbird/Extensions/Extensions.swift
@@ -35,15 +35,20 @@ public struct HBExtensions<ParentObject> {
         self.items = [:]
     }
 
-    /// Get extension from a `KeyPath`
+    /// Get optional extension from a `KeyPath`
     public func get<Type>(_ key: KeyPath<ParentObject, Type>) -> Type? {
         self.items[key]?.value as? Type
     }
 
     /// Get extension from a `KeyPath`
     public func get<Type>(_ key: KeyPath<ParentObject, Type>) -> Type {
-        guard let value = items[key]?.value as? Type else { preconditionFailure("Cannot get extension without having set it") }
+        guard let value = items[key]?.value as? Type else { preconditionFailure("Cannot get extension of type \(Type.self) without having set it") }
         return value
+    }
+
+    /// Return if extension has been set
+    public func exists<Type>(_ key: KeyPath<ParentObject, Type>) -> Bool {
+        self.items[key]?.value != nil
     }
 
     /// Get extension from a `KeyPath`. If it doesn't exist then create it. Use this with care it may cause race conditions

--- a/Sources/Hummingbird/Storage/Application+Persist.swift
+++ b/Sources/Hummingbird/Storage/Application+Persist.swift
@@ -32,7 +32,9 @@ extension HBApplication {
     /// Add persist framework to `HBApplication`.
     /// - Parameter using: Factory struct that will create the persist driver when required
     public func addPersist(using: HBPersistDriverFactory) {
-        self.extensions.set(\.persist, value: .init(using, application: self))
+        self.extensions.set(\.persist, value: .init(using, application: self)) { persist in
+            persist.driver.shutdown()
+        }
     }
 }
 

--- a/Sources/Hummingbird/Storage/Application+Persist.swift
+++ b/Sources/Hummingbird/Storage/Application+Persist.swift
@@ -38,21 +38,13 @@ extension HBApplication {
 
 extension HBRequest {
     public struct Persist {
-        /// Set value for key
-        /// - Parameters:
-        ///   - key: key string
-        ///   - value: value
-        /// - Returns: EventLoopFuture for when value has been set
-        public func set<Object: Codable>(key: String, value: Object) -> EventLoopFuture<Void> {
-            return self.request.application.persist.driver.set(key: key, value: value, request: self.request)
-        }
-
         /// Set value for key that will expire after a certain time
         /// - Parameters:
         ///   - key: key string
         ///   - value: value
+        ///   - expires: time key/value pair will expire
         /// - Returns: EventLoopFuture for when value has been set
-        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount) -> EventLoopFuture<Void> {
+        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount? = nil) -> EventLoopFuture<Void> {
             return self.request.application.persist.driver.set(key: key, value: value, expires: expires, request: self.request)
         }
 
@@ -73,6 +65,7 @@ extension HBRequest {
 
         let request: HBRequest
     }
+
     /// Accessor for persist framework
     public var persist: HBRequest.Persist { .init(request: self) }
 }

--- a/Sources/Hummingbird/Storage/Application+Persist.swift
+++ b/Sources/Hummingbird/Storage/Application+Persist.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2021 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension HBApplication {
+    public struct Persist {
+        let driver: HBPersistDriver
+
+        public init(_ factory: HBPersistDriverFactory, application: HBApplication) {
+            self.driver = factory.create(application)
+        }
+
+        public func set(key: String, value: String) {
+            self.driver.set(key: key, value: value)
+        }
+
+        public func set(key: String, value: String, expires: TimeAmount) {
+            self.driver.set(key: key, value: value, expires: expires)
+        }
+
+        public func get(key: String) -> EventLoopFuture<String?> {
+            return self.driver.get(key: key)
+        }
+
+        public func remove(key: String) {
+            self.driver.remove(key: key)
+        }
+    }
+
+    public var persist: Persist { self.extensions.get(\.persist) }
+
+    public func addPersist(using: HBPersistDriverFactory) {
+        self.extensions.set(\.persist, value: .init(using, application: self))
+    }
+}
+
+extension HBRequest {
+    public var persist: HBApplication.Persist { self.application.persist }
+}

--- a/Sources/Hummingbird/Storage/Application+Persist.swift
+++ b/Sources/Hummingbird/Storage/Application+Persist.swift
@@ -40,6 +40,18 @@ extension HBApplication {
 
 extension HBRequest {
     public struct Persist {
+        /// Set value for key that will expire after a certain time.
+        ///
+        /// Doesn't check to see if key already exists. Some drivers may fail it key already exists
+        /// - Parameters:
+        ///   - key: key string
+        ///   - value: value
+        ///   - expires: time key/value pair will expire
+        /// - Returns: EventLoopFuture for when value has been set
+        public func create<Object: Codable>(key: String, value: Object, expires: TimeAmount? = nil) -> EventLoopFuture<Void> {
+            return self.request.application.persist.driver.create(key: key, value: value, expires: expires, request: self.request)
+        }
+
         /// Set value for key that will expire after a certain time
         /// - Parameters:
         ///   - key: key string

--- a/Sources/Hummingbird/Storage/Application+Persist.swift
+++ b/Sources/Hummingbird/Storage/Application+Persist.swift
@@ -30,8 +30,8 @@ extension HBApplication {
         ///   - key: key string
         ///   - value: value
         /// - Returns: EventLoopFuture for when value has been set
-        public func set<Object: Codable>(key: String, value: Object) -> EventLoopFuture<Void> {
-            return self.driver.set(key: key, value: value)
+        public func set<Object: Codable>(key: String, value: Object, request: HBRequest) -> EventLoopFuture<Void> {
+            return self.driver.set(key: key, value: value, request: request)
         }
 
         /// Set value for key that will expire after a certain time
@@ -39,8 +39,8 @@ extension HBApplication {
         ///   - key: key string
         ///   - value: value
         /// - Returns: EventLoopFuture for when value has been set
-        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount) -> EventLoopFuture<Void> {
-            return self.driver.set(key: key, value: value, expires: expires)
+        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, request: HBRequest) -> EventLoopFuture<Void> {
+            return self.driver.set(key: key, value: value, expires: expires, request: request)
         }
 
         /// Get value for key
@@ -48,14 +48,14 @@ extension HBApplication {
         ///   - key: key string
         ///   - type: Type of value
         /// - Returns: EventLoopFuture that will be filled with value
-        public func get<Object: Codable>(key: String, as type: Object.Type) -> EventLoopFuture<Object?> {
-            return self.driver.get(key: key, as: type)
+        public func get<Object: Codable>(key: String, as type: Object.Type, request: HBRequest) -> EventLoopFuture<Object?> {
+            return self.driver.get(key: key, as: type, request: request)
         }
 
         /// Remove value for key
         /// - Parameter key: key string
-        public func remove(key: String) -> EventLoopFuture<Void> {
-            return self.driver.remove(key: key)
+        public func remove(key: String, request: HBRequest) -> EventLoopFuture<Void> {
+            return self.driver.remove(key: key, request: request)
         }
     }
 

--- a/Sources/Hummingbird/Storage/Application+Persist.swift
+++ b/Sources/Hummingbird/Storage/Application+Persist.swift
@@ -15,8 +15,6 @@
 extension HBApplication {
     /// Framework for storing persistent key/value pairs between mulitple requests
     public struct Persist {
-        let driver: HBPersistDriver
-
         /// Initialise Persist struct
         /// - Parameters
         ///   - factory: Persist driver factory
@@ -25,38 +23,7 @@ extension HBApplication {
             self.driver = factory.create(application)
         }
 
-        /// Set value for key
-        /// - Parameters:
-        ///   - key: key string
-        ///   - value: value
-        /// - Returns: EventLoopFuture for when value has been set
-        public func set<Object: Codable>(key: String, value: Object, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-            return self.driver.set(key: key, value: value, on: eventLoop)
-        }
-
-        /// Set value for key that will expire after a certain time
-        /// - Parameters:
-        ///   - key: key string
-        ///   - value: value
-        /// - Returns: EventLoopFuture for when value has been set
-        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-            return self.driver.set(key: key, value: value, expires: expires, on: eventLoop)
-        }
-
-        /// Get value for key
-        /// - Parameters:
-        ///   - key: key string
-        ///   - type: Type of value
-        /// - Returns: EventLoopFuture that will be filled with value
-        public func get<Object: Codable>(key: String, as type: Object.Type, on eventLoop: EventLoop) -> EventLoopFuture<Object?> {
-            return self.driver.get(key: key, as: type, on: eventLoop)
-        }
-
-        /// Remove value for key
-        /// - Parameter key: key string
-        public func remove(key: String, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-            return self.driver.remove(key: key, on: eventLoop)
-        }
+        let driver: HBPersistDriver
     }
 
     /// Accessor for persist framework
@@ -70,6 +37,42 @@ extension HBApplication {
 }
 
 extension HBRequest {
+    public struct Persist {
+        /// Set value for key
+        /// - Parameters:
+        ///   - key: key string
+        ///   - value: value
+        /// - Returns: EventLoopFuture for when value has been set
+        public func set<Object: Codable>(key: String, value: Object) -> EventLoopFuture<Void> {
+            return self.request.application.persist.driver.set(key: key, value: value, request: self.request)
+        }
+
+        /// Set value for key that will expire after a certain time
+        /// - Parameters:
+        ///   - key: key string
+        ///   - value: value
+        /// - Returns: EventLoopFuture for when value has been set
+        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount) -> EventLoopFuture<Void> {
+            return self.request.application.persist.driver.set(key: key, value: value, expires: expires, request: self.request)
+        }
+
+        /// Get value for key
+        /// - Parameters:
+        ///   - key: key string
+        ///   - type: Type of value
+        /// - Returns: EventLoopFuture that will be filled with value
+        public func get<Object: Codable>(key: String, as type: Object.Type) -> EventLoopFuture<Object?> {
+            return self.request.application.persist.driver.get(key: key, as: type, request: self.request)
+        }
+
+        /// Remove value for key
+        /// - Parameter key: key string
+        public func remove(key: String) -> EventLoopFuture<Void> {
+            return self.request.application.persist.driver.remove(key: key, request: self.request)
+        }
+
+        let request: HBRequest
+    }
     /// Accessor for persist framework
-    public var persist: HBApplication.Persist { self.application.persist }
+    public var persist: HBRequest.Persist { .init(request: self) }
 }

--- a/Sources/Hummingbird/Storage/Application+Persist.swift
+++ b/Sources/Hummingbird/Storage/Application+Persist.swift
@@ -30,8 +30,8 @@ extension HBApplication {
         ///   - key: key string
         ///   - value: value
         /// - Returns: EventLoopFuture for when value has been set
-        public func set<Object: Codable>(key: String, value: Object, request: HBRequest) -> EventLoopFuture<Void> {
-            return self.driver.set(key: key, value: value, request: request)
+        public func set<Object: Codable>(key: String, value: Object, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+            return self.driver.set(key: key, value: value, on: eventLoop)
         }
 
         /// Set value for key that will expire after a certain time
@@ -39,8 +39,8 @@ extension HBApplication {
         ///   - key: key string
         ///   - value: value
         /// - Returns: EventLoopFuture for when value has been set
-        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, request: HBRequest) -> EventLoopFuture<Void> {
-            return self.driver.set(key: key, value: value, expires: expires, request: request)
+        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+            return self.driver.set(key: key, value: value, expires: expires, on: eventLoop)
         }
 
         /// Get value for key
@@ -48,14 +48,14 @@ extension HBApplication {
         ///   - key: key string
         ///   - type: Type of value
         /// - Returns: EventLoopFuture that will be filled with value
-        public func get<Object: Codable>(key: String, as type: Object.Type, request: HBRequest) -> EventLoopFuture<Object?> {
-            return self.driver.get(key: key, as: type, request: request)
+        public func get<Object: Codable>(key: String, as type: Object.Type, on eventLoop: EventLoop) -> EventLoopFuture<Object?> {
+            return self.driver.get(key: key, as: type, on: eventLoop)
         }
 
         /// Remove value for key
         /// - Parameter key: key string
-        public func remove(key: String, request: HBRequest) -> EventLoopFuture<Void> {
-            return self.driver.remove(key: key, request: request)
+        public func remove(key: String, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+            return self.driver.remove(key: key, on: eventLoop)
         }
     }
 

--- a/Sources/Hummingbird/Storage/Application+Persist.swift
+++ b/Sources/Hummingbird/Storage/Application+Persist.swift
@@ -13,37 +13,63 @@
 //===----------------------------------------------------------------------===//
 
 extension HBApplication {
+    /// Framework for storing persistent key/value pairs between mulitple requests
     public struct Persist {
         let driver: HBPersistDriver
 
+        /// Initialise Persist struct
+        /// - Parameters
+        ///   - factory: Persist driver factory
+        ///   - application: reference to application that can be used during persist driver creation
         public init(_ factory: HBPersistDriverFactory, application: HBApplication) {
             self.driver = factory.create(application)
         }
 
-        public func set<Object: Codable>(key: String, value: Object) {
-            self.driver.set(key: key, value: value)
+        /// Set value for key
+        /// - Parameters:
+        ///   - key: key string
+        ///   - value: value
+        /// - Returns: EventLoopFuture for when value has been set
+        public func set<Object: Codable>(key: String, value: Object) -> EventLoopFuture<Void> {
+            return self.driver.set(key: key, value: value)
         }
 
-        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount) {
-            self.driver.set(key: key, value: value, expires: expires)
+        /// Set value for key that will expire after a certain time
+        /// - Parameters:
+        ///   - key: key string
+        ///   - value: value
+        /// - Returns: EventLoopFuture for when value has been set
+        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount) -> EventLoopFuture<Void> {
+            return self.driver.set(key: key, value: value, expires: expires)
         }
 
+        /// Get value for key
+        /// - Parameters:
+        ///   - key: key string
+        ///   - type: Type of value
+        /// - Returns: EventLoopFuture that will be filled with value
         public func get<Object: Codable>(key: String, as type: Object.Type) -> EventLoopFuture<Object?> {
             return self.driver.get(key: key, as: type)
         }
 
-        public func remove(key: String) {
-            self.driver.remove(key: key)
+        /// Remove value for key
+        /// - Parameter key: key string
+        public func remove(key: String) -> EventLoopFuture<Void> {
+            return self.driver.remove(key: key)
         }
     }
 
+    /// Accessor for persist framework
     public var persist: Persist { self.extensions.get(\.persist) }
 
+    /// Add persist framework to `HBApplication`.
+    /// - Parameter using: Factory struct that will create the persist driver when required
     public func addPersist(using: HBPersistDriverFactory) {
         self.extensions.set(\.persist, value: .init(using, application: self))
     }
 }
 
 extension HBRequest {
+    /// Accessor for persist framework
     public var persist: HBApplication.Persist { self.application.persist }
 }

--- a/Sources/Hummingbird/Storage/Application+Persist.swift
+++ b/Sources/Hummingbird/Storage/Application+Persist.swift
@@ -20,16 +20,16 @@ extension HBApplication {
             self.driver = factory.create(application)
         }
 
-        public func set(key: String, value: String) {
+        public func set<Object: Codable>(key: String, value: Object) {
             self.driver.set(key: key, value: value)
         }
 
-        public func set(key: String, value: String, expires: TimeAmount) {
+        public func set<Object: Codable>(key: String, value: Object, expires: TimeAmount) {
             self.driver.set(key: key, value: value, expires: expires)
         }
 
-        public func get(key: String) -> EventLoopFuture<String?> {
-            return self.driver.get(key: key)
+        public func get<Object: Codable>(key: String, as type: Object.Type) -> EventLoopFuture<Object?> {
+            return self.driver.get(key: key, as: type)
         }
 
         public func remove(key: String) {

--- a/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
+++ b/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
@@ -21,20 +21,20 @@ class HBMemoryPersistDriver: HBPersistDriver {
         }
     }
 
-    func set<Object: Codable>(key: String, value: Object, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-        return eventLoop.submit {
+    func set<Object: Codable>(key: String, value: Object, request: HBRequest) -> EventLoopFuture<Void> {
+        return request.eventLoop.submit {
             self.values[key] = .init(value: value)
         }
     }
 
-    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-        return eventLoop.submit {
+    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, request: HBRequest) -> EventLoopFuture<Void> {
+        return request.eventLoop.submit {
             self.values[key] = .init(value: value, expires: expires)
         }
     }
 
-    func get<Object: Codable>(key: String, as: Object.Type, on eventLoop: EventLoop) -> EventLoopFuture<Object?> {
-        return eventLoop.submit {
+    func get<Object: Codable>(key: String, as: Object.Type, request: HBRequest) -> EventLoopFuture<Object?> {
+        return request.eventLoop.submit {
             guard let item = self.values[key] else { return nil }
             guard let expires = item.epochExpires else { return item.value as? Object }
             guard Item.getEpochTime() <= expires else { return nil }
@@ -42,8 +42,8 @@ class HBMemoryPersistDriver: HBPersistDriver {
         }
     }
 
-    func remove(key: String, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-        return eventLoop.submit {
+    func remove(key: String, request: HBRequest) -> EventLoopFuture<Void> {
+        return request.eventLoop.submit {
             self.values[key] = nil
         }
     }

--- a/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
+++ b/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
@@ -21,13 +21,13 @@ class HBMemoryPersistDriver: HBPersistDriver {
         }
     }
 
-    func set<Object: Codable>(key: String, value: Object, request: HBRequest) -> EventLoopFuture<Void> {
+    func create<Object: Codable>(key: String, value: Object, expires: TimeAmount? = nil, request: HBRequest) -> EventLoopFuture<Void> {
         return request.eventLoop.submit {
-            self.values[key] = .init(value: value)
+            self.values[key] = .init(value: value, expires: expires)
         }
     }
 
-    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, request: HBRequest) -> EventLoopFuture<Void> {
+    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount? = nil, request: HBRequest) -> EventLoopFuture<Void> {
         return request.eventLoop.submit {
             self.values[key] = .init(value: value, expires: expires)
         }
@@ -72,14 +72,9 @@ class HBMemoryPersistDriver: HBPersistDriver {
         /// epoch time for when item expires
         let epochExpires: Int?
 
-        init(value: Codable, expires: TimeAmount) {
+        init(value: Codable, expires: TimeAmount?) {
             self.value = value
-            self.epochExpires = Self.getEpochTime() + Int(expires.nanoseconds / 1_000_000_000)
-        }
-
-        init(value: Codable) {
-            self.value = value
-            self.epochExpires = nil
+            self.epochExpires = expires.map { Self.getEpochTime() + Int($0.nanoseconds / 1_000_000_000) }
         }
 
         static func getEpochTime() -> Int {

--- a/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
+++ b/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2021 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// In memory driver for persist system for storing persistent cross request key/value pairs
+class HBMemoryPersistDriver: HBPersistDriver {
+    init(eventLoopGroup: EventLoopGroup) {
+        self.values = [:]
+        self.eventLoop = eventLoopGroup.next()
+        self.eventLoop.scheduleRepeatedTask(initialDelay: .hours(1), delay: .hours(1)) { _ in
+            self._tidy()
+        }
+    }
+
+    func set(key: String, value: String) {
+        self.eventLoop.execute {
+            self.values[key] = .init(value: value)
+        }
+    }
+
+    func set(key: String, value: String, expires: TimeAmount) {
+        self.eventLoop.execute {
+            self.values[key] = .init(value: value, expires: expires)
+        }
+    }
+
+    func get(key: String) -> EventLoopFuture<String?> {
+        return self.eventLoop.submit {
+            guard let item = self.values[key] else { return nil }
+            guard let expires = item.epochExpires else { return item.value }
+            guard Item.getEpochTime() <= expires else { return nil }
+            return item.value
+        }
+    }
+
+    func remove(key: String) {
+        self.eventLoop.execute {
+            self.values[key] = nil
+        }
+    }
+
+    func tidy() {
+        self.eventLoop.execute {
+            self._tidy()
+        }
+    }
+
+    private func _tidy() {
+        let currentTime = Item.getEpochTime()
+        self.values = self.values.compactMapValues {
+            if let expires = $0.epochExpires {
+                if expires > currentTime {
+                    return nil
+                }
+            }
+            return $0
+        }
+    }
+    
+    struct Item {
+        /// value stored
+        let value: String
+        /// epoch time for when item expires
+        let epochExpires: Int?
+
+        init(value: String, expires: TimeAmount) {
+            self.value = value
+            self.epochExpires = Self.getEpochTime() + Int(expires.nanoseconds / 1_000_000_000)
+        }
+
+        init(value: String) {
+            self.value = value
+            self.epochExpires = nil
+        }
+
+        static func getEpochTime() -> Int {
+            var timeVal = timeval.init()
+            gettimeofday(&timeVal, nil)
+            return timeVal.tv_sec
+        }
+    }
+
+    var values: [String: Item]
+    let eventLoop: EventLoop
+}

--- a/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
+++ b/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
@@ -22,14 +22,14 @@ class HBMemoryPersistDriver: HBPersistDriver {
         }
     }
 
-    func set<Object: Codable>(key: String, value: Object) {
-        self.eventLoop.execute {
+    func set<Object: Codable>(key: String, value: Object) -> EventLoopFuture<Void> {
+        return self.eventLoop.submit {
             self.values[key] = .init(value: value)
         }
     }
 
-    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount) {
-        self.eventLoop.execute {
+    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount) -> EventLoopFuture<Void> {
+        return self.eventLoop.submit {
             self.values[key] = .init(value: value, expires: expires)
         }
     }
@@ -43,8 +43,8 @@ class HBMemoryPersistDriver: HBPersistDriver {
         }
     }
 
-    func remove(key: String) {
-        self.eventLoop.execute {
+    func remove(key: String) -> EventLoopFuture<Void> {
+        return self.eventLoop.submit {
             self.values[key] = nil
         }
     }

--- a/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
+++ b/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
@@ -66,7 +66,7 @@ class HBMemoryPersistDriver: HBPersistDriver {
             return $0
         }
     }
-    
+
     struct Item {
         /// value stored
         let value: Codable

--- a/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
+++ b/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
@@ -21,20 +21,20 @@ class HBMemoryPersistDriver: HBPersistDriver {
         }
     }
 
-    func set<Object: Codable>(key: String, value: Object, request: HBRequest) -> EventLoopFuture<Void> {
-        return request.eventLoop.submit {
+    func set<Object: Codable>(key: String, value: Object, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        return eventLoop.submit {
             self.values[key] = .init(value: value)
         }
     }
 
-    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, request: HBRequest) -> EventLoopFuture<Void> {
-        return request.eventLoop.submit {
+    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        return eventLoop.submit {
             self.values[key] = .init(value: value, expires: expires)
         }
     }
 
-    func get<Object: Codable>(key: String, as: Object.Type, request: HBRequest) -> EventLoopFuture<Object?> {
-        return request.eventLoop.submit {
+    func get<Object: Codable>(key: String, as: Object.Type, on eventLoop: EventLoop) -> EventLoopFuture<Object?> {
+        return eventLoop.submit {
             guard let item = self.values[key] else { return nil }
             guard let expires = item.epochExpires else { return item.value as? Object }
             guard Item.getEpochTime() <= expires else { return nil }
@@ -42,8 +42,8 @@ class HBMemoryPersistDriver: HBPersistDriver {
         }
     }
 
-    func remove(key: String, request: HBRequest) -> EventLoopFuture<Void> {
-        return request.eventLoop.submit {
+    func remove(key: String, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        return eventLoop.submit {
             self.values[key] = nil
         }
     }

--- a/Sources/Hummingbird/Storage/PersistDriver.swift
+++ b/Sources/Hummingbird/Storage/PersistDriver.swift
@@ -17,11 +17,11 @@ import NIO
 /// Protocol for driver supporting persistent Key/Value pairs across requests
 public protocol HBPersistDriver {
     /// set value for key
-    func set(key: String, value: String)
+    func set<Object: Codable>(key: String, value: Object)
     /// set value for key with how before the value expires
-    func set(key: String, value: String, expires: TimeAmount)
+    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount)
     /// get value for key
-    func get(key: String) -> EventLoopFuture<String?>
+    func get<Object: Codable>(key: String, as: Object.Type) -> EventLoopFuture<Object?>
     /// remove value for key
     func remove(key: String)
 }

--- a/Sources/Hummingbird/Storage/PersistDriver.swift
+++ b/Sources/Hummingbird/Storage/PersistDriver.swift
@@ -17,13 +17,13 @@ import NIO
 /// Protocol for driver supporting persistent Key/Value pairs across requests
 public protocol HBPersistDriver {
     /// set value for key
-    func set<Object: Codable>(key: String, value: Object, on eventLoop: EventLoop) -> EventLoopFuture<Void>
+    func set<Object: Codable>(key: String, value: Object, request: HBRequest) -> EventLoopFuture<Void>
     /// set value for key with how before the value expires
-    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, on eventLoop: EventLoop) -> EventLoopFuture<Void>
+    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, request: HBRequest) -> EventLoopFuture<Void>
     /// get value for key
-    func get<Object: Codable>(key: String, as: Object.Type, on eventLoop: EventLoop) -> EventLoopFuture<Object?>
+    func get<Object: Codable>(key: String, as: Object.Type, request: HBRequest) -> EventLoopFuture<Object?>
     /// remove value for key
-    func remove(key: String, on eventLoop: EventLoop) -> EventLoopFuture<Void>
+    func remove(key: String, request: HBRequest) -> EventLoopFuture<Void>
 }
 
 /// Factory class for persist drivers

--- a/Sources/Hummingbird/Storage/PersistDriver.swift
+++ b/Sources/Hummingbird/Storage/PersistDriver.swift
@@ -17,9 +17,9 @@ import NIO
 /// Protocol for driver supporting persistent Key/Value pairs across requests
 public protocol HBPersistDriver {
     /// set value for key
-    func set<Object: Codable>(key: String, value: Object, request: HBRequest) -> EventLoopFuture<Void>
-    /// set value for key with how before the value expires
-    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, request: HBRequest) -> EventLoopFuture<Void>
+    func create<Object: Codable>(key: String, value: Object, expires: TimeAmount?, request: HBRequest) -> EventLoopFuture<Void>
+    /// set value for key
+    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount?, request: HBRequest) -> EventLoopFuture<Void>
     /// get value for key
     func get<Object: Codable>(key: String, as: Object.Type, request: HBRequest) -> EventLoopFuture<Object?>
     /// remove value for key

--- a/Sources/Hummingbird/Storage/PersistDriver.swift
+++ b/Sources/Hummingbird/Storage/PersistDriver.swift
@@ -30,6 +30,12 @@ public protocol HBPersistDriver {
 public struct HBPersistDriverFactory {
     public let create: (HBApplication) -> HBPersistDriver
 
+    /// Initialize HBPersistDriverFactory
+    /// - Parameter create: HBPersistDriver factory function
+    public init(create: @escaping (HBApplication) -> HBPersistDriver) {
+        self.create = create
+    }
+
     /// In memory driver for persist system
     public static var memory: HBPersistDriverFactory {
         .init(create: { app in HBMemoryPersistDriver(eventLoopGroup: app.eventLoopGroup) })

--- a/Sources/Hummingbird/Storage/PersistDriver.swift
+++ b/Sources/Hummingbird/Storage/PersistDriver.swift
@@ -17,13 +17,13 @@ import NIO
 /// Protocol for driver supporting persistent Key/Value pairs across requests
 public protocol HBPersistDriver {
     /// set value for key
-    func set<Object: Codable>(key: String, value: Object)
+    func set<Object: Codable>(key: String, value: Object) -> EventLoopFuture<Void>
     /// set value for key with how before the value expires
-    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount)
+    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount) -> EventLoopFuture<Void>
     /// get value for key
     func get<Object: Codable>(key: String, as: Object.Type) -> EventLoopFuture<Object?>
     /// remove value for key
-    func remove(key: String)
+    func remove(key: String) -> EventLoopFuture<Void>
 }
 
 /// Factory class for persist drivers

--- a/Sources/Hummingbird/Storage/PersistDriver.swift
+++ b/Sources/Hummingbird/Storage/PersistDriver.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2021 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+/// Protocol for driver supporting persistent Key/Value pairs across requests
+public protocol HBPersistDriver {
+    /// set value for key
+    func set(key: String, value: String)
+    /// set value for key with how before the value expires
+    func set(key: String, value: String, expires: TimeAmount)
+    /// get value for key
+    func get(key: String) -> EventLoopFuture<String?>
+    /// remove value for key
+    func remove(key: String)
+}
+
+/// Factory class for persist drivers
+public struct HBPersistDriverFactory {
+    public let create: (HBApplication) -> HBPersistDriver
+
+    /// In memory driver for persist system
+    public static var memory: HBPersistDriverFactory {
+        .init(create: { app in HBMemoryPersistDriver(eventLoopGroup: app.eventLoopGroup) })
+    }
+}

--- a/Sources/Hummingbird/Storage/PersistDriver.swift
+++ b/Sources/Hummingbird/Storage/PersistDriver.swift
@@ -17,13 +17,13 @@ import NIO
 /// Protocol for driver supporting persistent Key/Value pairs across requests
 public protocol HBPersistDriver {
     /// set value for key
-    func set<Object: Codable>(key: String, value: Object, request: HBRequest) -> EventLoopFuture<Void>
+    func set<Object: Codable>(key: String, value: Object, on eventLoop: EventLoop) -> EventLoopFuture<Void>
     /// set value for key with how before the value expires
-    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, request: HBRequest) -> EventLoopFuture<Void>
+    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, on eventLoop: EventLoop) -> EventLoopFuture<Void>
     /// get value for key
-    func get<Object: Codable>(key: String, as: Object.Type, request: HBRequest) -> EventLoopFuture<Object?>
+    func get<Object: Codable>(key: String, as: Object.Type, on eventLoop: EventLoop) -> EventLoopFuture<Object?>
     /// remove value for key
-    func remove(key: String, request: HBRequest) -> EventLoopFuture<Void>
+    func remove(key: String, on eventLoop: EventLoop) -> EventLoopFuture<Void>
 }
 
 /// Factory class for persist drivers

--- a/Sources/Hummingbird/Storage/PersistDriver.swift
+++ b/Sources/Hummingbird/Storage/PersistDriver.swift
@@ -17,13 +17,13 @@ import NIO
 /// Protocol for driver supporting persistent Key/Value pairs across requests
 public protocol HBPersistDriver {
     /// set value for key
-    func set<Object: Codable>(key: String, value: Object) -> EventLoopFuture<Void>
+    func set<Object: Codable>(key: String, value: Object, request: HBRequest) -> EventLoopFuture<Void>
     /// set value for key with how before the value expires
-    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount) -> EventLoopFuture<Void>
+    func set<Object: Codable>(key: String, value: Object, expires: TimeAmount, request: HBRequest) -> EventLoopFuture<Void>
     /// get value for key
-    func get<Object: Codable>(key: String, as: Object.Type) -> EventLoopFuture<Object?>
+    func get<Object: Codable>(key: String, as: Object.Type, request: HBRequest) -> EventLoopFuture<Object?>
     /// remove value for key
-    func remove(key: String) -> EventLoopFuture<Void>
+    func remove(key: String, request: HBRequest) -> EventLoopFuture<Void>
 }
 
 /// Factory class for persist drivers

--- a/Sources/Hummingbird/Storage/PersistDriver.swift
+++ b/Sources/Hummingbird/Storage/PersistDriver.swift
@@ -16,6 +16,8 @@ import NIO
 
 /// Protocol for driver supporting persistent Key/Value pairs across requests
 public protocol HBPersistDriver {
+    /// shutdown driver
+    func shutdown()
     /// set value for key
     func create<Object: Codable>(key: String, value: Object, expires: TimeAmount?, request: HBRequest) -> EventLoopFuture<Void>
     /// set value for key
@@ -24,6 +26,11 @@ public protocol HBPersistDriver {
     func get<Object: Codable>(key: String, as: Object.Type, request: HBRequest) -> EventLoopFuture<Object?>
     /// remove value for key
     func remove(key: String, request: HBRequest) -> EventLoopFuture<Void>
+}
+
+extension HBPersistDriver {
+    /// default implemenation of shutdown()
+    public func shutdown() {}
 }
 
 /// Factory class for persist drivers

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -256,6 +256,26 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
+    func testELFOptional() {
+        let app = HBApplication(testing: .embedded)
+        app.router
+            .group("/echo-body")
+            .post { request -> EventLoopFuture<ByteBuffer?> in
+                return request.success(request.body.buffer)
+            }
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        let buffer = self.randomBuffer(size: 64)
+        app.XCTExecute(uri: "/echo-body", method: .POST, body: buffer) { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(response.body, buffer)
+        }
+        app.XCTExecute(uri: "/echo-body", method: .POST) { response in
+            XCTAssertEqual(response.status, .notFound)
+        }
+    }
+
     func testOptionalCodable() {
         struct Name: HBResponseCodable {
             let first: String

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -77,7 +77,7 @@ final class PersistTests: XCTestCase {
             return .ok
         }
         app.router.get("/") { request in
-            return request.persist.get(key: "test", as: TestCodable.self).map { $0.map { $0.buffer} }
+            return request.persist.get(key: "test", as: TestCodable.self).map { $0.map(\.buffer) }
         }
         app.XCTStart()
         defer { app.XCTStop() }

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -60,6 +60,24 @@ final class PersistTests: XCTestCase {
         }
     }
 
+    func testCreateGet() throws {
+        let app = try createApplication()
+        app.router.put("/create/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
+            guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
+            guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
+            return request.persist.create(key: tag, value: String(buffer: buffer))
+                .map { _ in .ok }
+        }
+        app.XCTStart()
+        defer { app.XCTStop() }
+        let tag = UUID().uuidString
+        app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
+        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "Persist")
+        }
+    }
+
     func testSetTwice() throws {
         let app = try createApplication()
         app.XCTStart()

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -21,10 +21,10 @@ final class PersistTests: XCTestCase {
         app.addPersist(using: .memory)
         app.router.put("/") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: "test", value: String(buffer: buffer), on: request.eventLoop).map { _ in .ok }
+            return request.persist.set(key: "test", value: String(buffer: buffer)).map { _ in .ok }
         }
         app.router.get("/") { request in
-            return request.persist.get(key: "test", as: String.self, on: request.eventLoop)
+            return request.persist.get(key: "test", as: String.self)
         }
         app.XCTStart()
         defer { app.XCTStop() }
@@ -43,12 +43,12 @@ final class PersistTests: XCTestCase {
             guard let time = request.parameters.get("time", as: Int.self) else { return request.failure(.badRequest) }
             guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: tag, value: String(buffer: buffer), expires: .seconds(numericCast(time)), on: request.eventLoop)
+            return request.persist.set(key: tag, value: String(buffer: buffer), expires: .seconds(numericCast(time)))
                 .map { _ in .ok }
         }
         app.router.get("/persist/:tag") { request -> EventLoopFuture<String?> in
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
-            return request.persist.get(key: tag, as: String.self, on: request.eventLoop)
+            return request.persist.get(key: tag, as: String.self)
         }
         app.XCTStart()
         defer { app.XCTStop() }
@@ -72,11 +72,11 @@ final class PersistTests: XCTestCase {
         app.addPersist(using: .memory)
         app.router.put("/") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: "test", value: TestCodable(buffer: String(buffer: buffer)), on: request.eventLoop)
+            return request.persist.set(key: "test", value: TestCodable(buffer: String(buffer: buffer)))
                 .map { _ in .ok }
         }
         app.router.get("/") { request in
-            return request.persist.get(key: "test", as: TestCodable.self, on: request.eventLoop).map { $0.map(\.buffer) }
+            return request.persist.get(key: "test", as: TestCodable.self).map { $0.map(\.buffer) }
         }
         app.XCTStart()
         defer { app.XCTStop() }
@@ -94,16 +94,16 @@ final class PersistTests: XCTestCase {
         app.router.put("/persist/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: tag, value: String(buffer: buffer), on: request.eventLoop)
+            return request.persist.set(key: tag, value: String(buffer: buffer))
                 .map { _ in .ok }
         }
         app.router.get("/persist/:tag") { request -> EventLoopFuture<String?> in
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
-            return request.persist.get(key: tag, as: String.self, on: request.eventLoop)
+            return request.persist.get(key: tag, as: String.self)
         }
         app.router.delete("/persist/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
-            return request.persist.remove(key: tag, on: request.eventLoop)
+            return request.persist.remove(key: tag)
                 .map { _ in .noContent }
         }
         app.XCTStart()

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -21,10 +21,10 @@ final class PersistTests: XCTestCase {
         app.addPersist(using: .memory)
         app.router.put("/") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: "test", value: String(buffer: buffer), request: request).map { _ in .ok }
+            return request.persist.set(key: "test", value: String(buffer: buffer), on: request.eventLoop).map { _ in .ok }
         }
         app.router.get("/") { request in
-            return request.persist.get(key: "test", as: String.self, request: request)
+            return request.persist.get(key: "test", as: String.self, on: request.eventLoop)
         }
         app.XCTStart()
         defer { app.XCTStop() }
@@ -43,12 +43,12 @@ final class PersistTests: XCTestCase {
             guard let time = request.parameters.get("time", as: Int.self) else { return request.failure(.badRequest) }
             guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: tag, value: String(buffer: buffer), expires: .seconds(numericCast(time)), request: request)
-                .map { _ in .ok}
+            return request.persist.set(key: tag, value: String(buffer: buffer), expires: .seconds(numericCast(time)), on: request.eventLoop)
+                .map { _ in .ok }
         }
         app.router.get("/persist/:tag") { request -> EventLoopFuture<String?> in
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
-            return request.persist.get(key: tag, as: String.self, request: request)
+            return request.persist.get(key: tag, as: String.self, on: request.eventLoop)
         }
         app.XCTStart()
         defer { app.XCTStop() }
@@ -72,11 +72,11 @@ final class PersistTests: XCTestCase {
         app.addPersist(using: .memory)
         app.router.put("/") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: "test", value: TestCodable(buffer: String(buffer: buffer)), request: request)
+            return request.persist.set(key: "test", value: TestCodable(buffer: String(buffer: buffer)), on: request.eventLoop)
                 .map { _ in .ok }
         }
         app.router.get("/") { request in
-            return request.persist.get(key: "test", as: TestCodable.self, request: request).map { $0.map(\.buffer) }
+            return request.persist.get(key: "test", as: TestCodable.self, on: request.eventLoop).map { $0.map(\.buffer) }
         }
         app.XCTStart()
         defer { app.XCTStop() }
@@ -94,16 +94,16 @@ final class PersistTests: XCTestCase {
         app.router.put("/persist/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: tag, value: String(buffer: buffer), request: request)
+            return request.persist.set(key: tag, value: String(buffer: buffer), on: request.eventLoop)
                 .map { _ in .ok }
         }
         app.router.get("/persist/:tag") { request -> EventLoopFuture<String?> in
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
-            return request.persist.get(key: tag, as: String.self, request: request)
+            return request.persist.get(key: tag, as: String.self, on: request.eventLoop)
         }
         app.router.delete("/persist/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
-            return request.persist.remove(key: tag, request: request)
+            return request.persist.remove(key: tag, on: request.eventLoop)
                 .map { _ in .noContent }
         }
         app.XCTStart()

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2021 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import Hummingbird
+import XCTest
+
+final class PersistTests: XCTestCase {
+    func testSetGet() {
+        let app = HBApplication(testing: .live)
+        app.addPersist(using: .memory)
+        app.router.put("/") { request -> HTTPResponseStatus in
+            guard let buffer = request.body.buffer else { throw HBHTTPError(.badRequest) }
+            request.persist.set(key: "test", value: String(buffer: buffer))
+            return .ok
+        }
+        app.router.get("/") { request in
+            return request.persist.get(key: "test")
+        }
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        app.XCTExecute(uri: "/", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
+        app.XCTExecute(uri: "/", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "Persist")
+        }
+    }
+
+    func testExpires() {
+        let app = HBApplication(testing: .live)
+        app.addPersist(using: .memory)
+        app.router.put("/persist/:tag/:time") { request -> HTTPResponseStatus in
+            let time = try request.parameters.require("time", as: Int.self)
+            let tag = try request.parameters.require("tag")
+            guard let buffer = request.body.buffer else { throw HBHTTPError(.badRequest) }
+            request.persist.set(key: tag, value: String(buffer: buffer), expires: .seconds(numericCast(time)))
+            return .ok
+        }
+        app.router.get("/persist/:tag") { request -> EventLoopFuture<String?> in
+            guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
+            return request.persist.get(key: tag)
+        }
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        app.XCTExecute(uri: "/persist/test1/-5", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        app.XCTExecute(uri: "/persist/test2/5", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest2")) { _ in }
+        app.XCTExecute(uri: "/persist/test1", method: .GET) { response in
+            XCTAssertEqual(response.status, .notFound)
+        }
+        app.XCTExecute(uri: "/persist/test2", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "ThisIsTest2")
+        }
+    }
+
+    func testRemove() {
+        let app = HBApplication(testing: .live)
+        app.addPersist(using: .memory)
+        app.router.put("/persist/:tag") { request -> HTTPResponseStatus in
+            let tag = try request.parameters.require("tag")
+            guard let buffer = request.body.buffer else { throw HBHTTPError(.badRequest) }
+            request.persist.set(key: tag, value: String(buffer: buffer))
+            return .ok
+        }
+        app.router.get("/persist/:tag") { request -> EventLoopFuture<String?> in
+            guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
+            return request.persist.get(key: tag)
+        }
+        app.router.delete("/persist/:tag") { request -> HTTPResponseStatus in
+            guard let tag = request.parameters.get("tag", as: String.self) else { throw HBHTTPError(.badRequest) }
+            request.persist.remove(key: tag)
+            return .noContent
+        }
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        app.XCTExecute(uri: "/persist/test1", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        app.XCTExecute(uri: "/persist/test1", method: .DELETE) { _ in }
+        app.XCTExecute(uri: "/persist/test1", method: .GET) { response in
+            XCTAssertEqual(response.status, .notFound)
+        }
+    }
+}

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -16,29 +16,19 @@
 import XCTest
 
 final class PersistTests: XCTestCase {
-    func testSetGet() {
+    static let redisHostname = HBEnvironment.shared.get("REDIS_HOSTNAME") ?? "localhost"
+
+    func createApplication() throws -> HBApplication {
         let app = HBApplication(testing: .live)
+        // add persist
         app.addPersist(using: .memory)
-        app.router.put("/") { request -> EventLoopFuture<HTTPResponseStatus> in
+
+        app.router.put("/persist/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
+            guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: "test", value: String(buffer: buffer)).map { _ in .ok }
+            return request.persist.set(key: tag, value: String(buffer: buffer))
+                .map { _ in .ok }
         }
-        app.router.get("/") { request in
-            return request.persist.get(key: "test", as: String.self)
-        }
-        app.XCTStart()
-        defer { app.XCTStop() }
-
-        app.XCTExecute(uri: "/", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
-        app.XCTExecute(uri: "/", method: .GET) { response in
-            let body = try XCTUnwrap(response.body)
-            XCTAssertEqual(String(buffer: body), "Persist")
-        }
-    }
-
-    func testExpires() {
-        let app = HBApplication(testing: .live)
-        app.addPersist(using: .memory)
         app.router.put("/persist/:tag/:time") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let time = request.parameters.get("time", as: Int.self) else { return request.failure(.badRequest) }
             guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
@@ -50,69 +40,120 @@ final class PersistTests: XCTestCase {
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
             return request.persist.get(key: tag, as: String.self)
         }
-        app.XCTStart()
-        defer { app.XCTStop() }
-
-        app.XCTExecute(uri: "/persist/test1/-5", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
-        app.XCTExecute(uri: "/persist/test2/5", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest2")) { _ in }
-        app.XCTExecute(uri: "/persist/test1", method: .GET) { response in
-            XCTAssertEqual(response.status, .notFound)
-        }
-        app.XCTExecute(uri: "/persist/test2", method: .GET) { response in
-            let body = try XCTUnwrap(response.body)
-            XCTAssertEqual(String(buffer: body), "ThisIsTest2")
-        }
-    }
-
-    func testCodable() {
-        struct TestCodable: Codable {
-            let buffer: String
-        }
-        let app = HBApplication(testing: .live)
-        app.addPersist(using: .memory)
-        app.router.put("/") { request -> EventLoopFuture<HTTPResponseStatus> in
-            guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: "test", value: TestCodable(buffer: String(buffer: buffer)))
-                .map { _ in .ok }
-        }
-        app.router.get("/") { request in
-            return request.persist.get(key: "test", as: TestCodable.self).map { $0.map(\.buffer) }
-        }
-        app.XCTStart()
-        defer { app.XCTStop() }
-
-        app.XCTExecute(uri: "/", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
-        app.XCTExecute(uri: "/", method: .GET) { response in
-            let body = try XCTUnwrap(response.body)
-            XCTAssertEqual(String(buffer: body), "Persist")
-        }
-    }
-
-    func testRemove() {
-        let app = HBApplication(testing: .live)
-        app.addPersist(using: .memory)
-        app.router.put("/persist/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
-            guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
-            guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: tag, value: String(buffer: buffer))
-                .map { _ in .ok }
-        }
-        app.router.get("/persist/:tag") { request -> EventLoopFuture<String?> in
-            guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
-            return request.persist.get(key: tag, as: String.self)
-        }
         app.router.delete("/persist/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
             return request.persist.remove(key: tag)
                 .map { _ in .noContent }
         }
+        return app
+    }
+
+    func testSetGet() throws {
+        let app = try createApplication()
+        app.XCTStart()
+        defer { app.XCTStop() }
+        let tag = UUID().uuidString
+        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
+        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "Persist")
+        }
+    }
+
+    func testSetTwice() throws {
+        let app = try createApplication()
         app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/persist/test1", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
-        app.XCTExecute(uri: "/persist/test1", method: .DELETE) { _ in }
-        app.XCTExecute(uri: "/persist/test1", method: .GET) { response in
+        let tag = UUID().uuidString
+        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "test1")) { _ in }
+        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "test2")) { response in
+            XCTAssertEqual(response.status, .ok)
+        }
+        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "test2")
+        }
+    }
+
+    func testExpires() throws {
+        let app = try createApplication()
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        let tag1 = UUID().uuidString
+        let tag2 = UUID().uuidString
+
+        app.XCTExecute(uri: "/persist/\(tag1)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        app.XCTExecute(uri: "/persist/\(tag2)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest2")) { _ in }
+        Thread.sleep(forTimeInterval: 1)
+        app.XCTExecute(uri: "/persist/\(tag1)", method: .GET) { response in
             XCTAssertEqual(response.status, .notFound)
+        }
+        app.XCTExecute(uri: "/persist/\(tag2)", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "ThisIsTest2")
+        }
+    }
+
+    func testCodable() throws {
+        struct TestCodable: Codable {
+            let buffer: String
+        }
+        let app = try createApplication()
+
+        app.router.put("/codable/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
+            guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
+            guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
+            return request.persist.set(key: tag, value: TestCodable(buffer: String(buffer: buffer)))
+                .map { _ in .ok }
+        }
+        app.router.get("/codable/:tag") { request -> EventLoopFuture<String?> in
+            guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
+            return request.persist.get(key: tag, as: TestCodable.self).map { $0.map(\.buffer) }
+        }
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        let tag = UUID().uuidString
+        app.XCTExecute(uri: "/codable/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
+        app.XCTExecute(uri: "/codable/\(tag)", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "Persist")
+        }
+    }
+
+    func testRemove() throws {
+        let app = try createApplication()
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        let tag = UUID().uuidString
+        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        app.XCTExecute(uri: "/persist/\(tag)", method: .DELETE) { _ in }
+        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+            XCTAssertEqual(response.status, .notFound)
+        }
+    }
+
+    func testExpireAndAdd() throws {
+        let app = try createApplication()
+        app.XCTStart()
+        defer { app.XCTStop() }
+
+        let tag = UUID().uuidString
+        app.XCTExecute(uri: "/persist/\(tag)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        Thread.sleep(forTimeInterval: 1)
+        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+            XCTAssertEqual(response.status, .notFound)
+        }
+        app.XCTExecute(uri: "/persist/\(tag)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { response in
+            XCTAssertEqual(response.status, .ok)
+        }
+        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+            XCTAssertEqual(response.status, .ok)
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "ThisIsTest1")
         }
     }
 }

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -21,10 +21,10 @@ final class PersistTests: XCTestCase {
         app.addPersist(using: .memory)
         app.router.put("/") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: "test", value: String(buffer: buffer)).map { _ in .ok }
+            return request.persist.set(key: "test", value: String(buffer: buffer), request: request).map { _ in .ok }
         }
         app.router.get("/") { request in
-            return request.persist.get(key: "test", as: String.self)
+            return request.persist.get(key: "test", as: String.self, request: request)
         }
         app.XCTStart()
         defer { app.XCTStop() }
@@ -43,12 +43,12 @@ final class PersistTests: XCTestCase {
             guard let time = request.parameters.get("time", as: Int.self) else { return request.failure(.badRequest) }
             guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: tag, value: String(buffer: buffer), expires: .seconds(numericCast(time)))
+            return request.persist.set(key: tag, value: String(buffer: buffer), expires: .seconds(numericCast(time)), request: request)
                 .map { _ in .ok}
         }
         app.router.get("/persist/:tag") { request -> EventLoopFuture<String?> in
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
-            return request.persist.get(key: tag, as: String.self)
+            return request.persist.get(key: tag, as: String.self, request: request)
         }
         app.XCTStart()
         defer { app.XCTStop() }
@@ -72,11 +72,11 @@ final class PersistTests: XCTestCase {
         app.addPersist(using: .memory)
         app.router.put("/") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: "test", value: TestCodable(buffer: String(buffer: buffer)))
+            return request.persist.set(key: "test", value: TestCodable(buffer: String(buffer: buffer)), request: request)
                 .map { _ in .ok }
         }
         app.router.get("/") { request in
-            return request.persist.get(key: "test", as: TestCodable.self).map { $0.map(\.buffer) }
+            return request.persist.get(key: "test", as: TestCodable.self, request: request).map { $0.map(\.buffer) }
         }
         app.XCTStart()
         defer { app.XCTStop() }
@@ -94,16 +94,16 @@ final class PersistTests: XCTestCase {
         app.router.put("/persist/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
             guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
-            return request.persist.set(key: tag, value: String(buffer: buffer))
+            return request.persist.set(key: tag, value: String(buffer: buffer), request: request)
                 .map { _ in .ok }
         }
         app.router.get("/persist/:tag") { request -> EventLoopFuture<String?> in
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
-            return request.persist.get(key: tag, as: String.self)
+            return request.persist.get(key: tag, as: String.self, request: request)
         }
         app.router.delete("/persist/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
             guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
-            return request.persist.remove(key: tag)
+            return request.persist.remove(key: tag, request: request)
                 .map { _ in .noContent }
         }
         app.XCTStart()


### PR DESCRIPTION
Can be used for sessions
Temporary keys
```swift
app.addPersist(using: .memory)
app.router.put("/persist/:tag") { request -> EventLoopFuture<HTTPResponseStatus> in
    guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
    guard let buffer = request.body.buffer else { return request.failure(.badRequest) }
    return request.persist.set(key: tag, value: String(buffer: buffer))
        .map { _ in .ok }
}
app.router.get("/persist/:tag") { request -> EventLoopFuture<String?> in
    guard let tag = request.parameters.get("tag", as: String.self) else { return request.failure(.badRequest) }
    return request.persist.get(key: tag, as: String.self)
}
```

The persist system can be used to store any object that conforms to `Codable`