### PR TITLE
Allow HBApplication.start() to throw errors

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -113,7 +113,7 @@ public final class HBApplication: HBExtensible {
     // MARK: Methods
 
     /// Run application
-    public func start() {
+    public func start() throws {
         let promise = self.eventLoopGroup.next().makePromise(of: Void.self)
         self.lifecycle.start { error in
             if let error = error {
@@ -124,7 +124,7 @@ public final class HBApplication: HBExtensible {
                 promise.succeed(())
             }
         }
-        try? promise.futureResult.wait()
+        try promise.futureResult.wait()
     }
 
     /// wait while server is running

--- a/Sources/HummingbirdXCT/Application+XCT.swift
+++ b/Sources/HummingbirdXCT/Application+XCT.swift
@@ -78,8 +78,8 @@ extension HBApplication {
     // MARK: Methods
 
     /// Start tests
-    public func XCTStart() {
-        self.xct.start(application: self)
+    public func XCTStart() throws {
+        try self.xct.start(application: self)
     }
 
     /// Stop tests

--- a/Sources/HummingbirdXCT/HBXCT.swift
+++ b/Sources/HummingbirdXCT/HBXCT.swift
@@ -34,7 +34,7 @@ enum HBXCTError: Error {
 /// Protocol for XCT framework.
 public protocol HBXCT {
     /// Called to start testing of application
-    func start(application: HBApplication)
+    func start(application: HBApplication) throws
     /// Called to stop testing of application
     func stop(application: HBApplication)
     /// Execute URL request and provide response

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -30,8 +30,8 @@ struct HBXCTLive: HBXCT {
     }
 
     /// Start tests
-    func start(application: HBApplication) {
-        application.start()
+    func start(application: HBApplication) throws {
+        try application.start()
     }
 
     /// Stop tests

--- a/Tests/HummingbirdFoundationTests/CookiesTests.swift
+++ b/Tests/HummingbirdFoundationTests/CookiesTests.swift
@@ -63,14 +63,14 @@ class CookieTests: XCTestCase {
         XCTAssertEqual(cookie?.sameSite, .secure)
     }
 
-    func testSetCookie() {
+    func testSetCookie() throws {
         let app = HBApplication(testing: .embedded)
         app.router.post("/") { _ -> HBResponse in
             let response = HBResponse(status: .ok, headers: [:], body: .empty)
             response.setCookie(.init(name: "test", value: "value"))
             return response
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/", method: .POST) { response in
@@ -78,13 +78,13 @@ class CookieTests: XCTestCase {
         }
     }
 
-    func testSetCookieViaRequest() {
+    func testSetCookieViaRequest() throws {
         let app = HBApplication(testing: .embedded)
         app.router.post("/") { request -> String in
             request.response.setCookie(.init(name: "test", value: "value"))
             return "Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/", method: .POST) { response in
@@ -92,12 +92,12 @@ class CookieTests: XCTestCase {
         }
     }
 
-    func testReadCookieFromRequest() {
+    func testReadCookieFromRequest() throws {
         let app = HBApplication(testing: .embedded)
         app.router.post("/") { request -> String? in
             return request.cookies["test"]?.value
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/", method: .POST, headers: ["cookie": "test=value"]) { response in

--- a/Tests/HummingbirdFoundationTests/FilesTests.swift
+++ b/Tests/HummingbirdFoundationTests/FilesTests.swift
@@ -34,7 +34,7 @@ class HummingbirdFilesTests: XCTestCase {
         return formatter
     }
 
-    func testRead() {
+    func testRead() throws {
         let app = HBApplication(testing: .live)
         app.middleware.add(HBFileMiddleware(".", application: app))
 
@@ -44,7 +44,7 @@ class HummingbirdFilesTests: XCTestCase {
         XCTAssertNoThrow(try data.write(to: fileURL))
         defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL)) }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/test.jpg", method: .GET) { response in
@@ -54,7 +54,7 @@ class HummingbirdFilesTests: XCTestCase {
         }
     }
 
-    func testReadLargeFile() {
+    func testReadLargeFile() throws {
         let app = HBApplication(testing: .live)
         app.middleware.add(HBFileMiddleware(".", application: app))
 
@@ -64,7 +64,7 @@ class HummingbirdFilesTests: XCTestCase {
         XCTAssertNoThrow(try data.write(to: fileURL))
         defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL)) }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/test.txt", method: .GET) { response in
@@ -73,7 +73,7 @@ class HummingbirdFilesTests: XCTestCase {
         }
     }
 
-    func testReadRange() {
+    func testReadRange() throws {
         let app = HBApplication(testing: .live)
         app.middleware.add(HBFileMiddleware(".", application: app))
 
@@ -83,7 +83,7 @@ class HummingbirdFilesTests: XCTestCase {
         XCTAssertNoThrow(try data.write(to: fileURL))
         defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL)) }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/test.txt", method: .GET, headers: ["Range": "bytes=100-3999"]) { response in
@@ -121,7 +121,7 @@ class HummingbirdFilesTests: XCTestCase {
         XCTAssertNoThrow(try data.write(to: fileURL))
         defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL)) }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/testHead.txt", method: .HEAD) { response in
@@ -144,7 +144,7 @@ class HummingbirdFilesTests: XCTestCase {
         XCTAssertNoThrow(try data.write(to: fileURL))
         defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL)) }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         var eTag: String?
@@ -166,7 +166,7 @@ class HummingbirdFilesTests: XCTestCase {
         XCTAssertNoThrow(try data.write(to: fileURL))
         defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL)) }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         var eTag: String?
@@ -196,7 +196,7 @@ class HummingbirdFilesTests: XCTestCase {
         XCTAssertNoThrow(try data.write(to: fileURL))
         defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL)) }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         var modifiedDate: String?
@@ -230,7 +230,7 @@ class HummingbirdFilesTests: XCTestCase {
         XCTAssertNoThrow(try data.write(to: fileURL2))
         defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL2)) }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/test.txt", method: .GET) { response in
@@ -250,7 +250,7 @@ class HummingbirdFilesTests: XCTestCase {
                 .map { .ok }
         }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let buffer = ByteBufferAllocator().buffer(string: "This is a test")
@@ -273,7 +273,7 @@ class HummingbirdFilesTests: XCTestCase {
                 .map { .ok }
         }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 400_000)

--- a/Tests/HummingbirdFoundationTests/HummingBirdJSONTests.swift
+++ b/Tests/HummingbirdFoundationTests/HummingBirdJSONTests.swift
@@ -26,7 +26,7 @@ class HummingbirdJSONTests: XCTestCase {
 
     struct Error: Swift.Error {}
 
-    func testDecode() {
+    func testDecode() throws {
         let app = HBApplication(testing: .embedded)
         app.decoder = JSONDecoder()
         app.router.put("/user") { request -> HTTPResponseStatus in
@@ -36,7 +36,7 @@ class HummingbirdJSONTests: XCTestCase {
             XCTAssertEqual(user.age, 25)
             return .ok
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let body = #"{"name": "John Smith", "email": "john.smith@email.com", "age": 25}"#
@@ -45,13 +45,13 @@ class HummingbirdJSONTests: XCTestCase {
         }
     }
 
-    func testEncode() {
+    func testEncode() throws {
         let app = HBApplication(testing: .embedded)
         app.encoder = JSONEncoder()
         app.router.get("/user") { _ -> User in
             return User(name: "John Smith", email: "john.smith@email.com", age: 25)
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/user", method: .GET) { response in
@@ -63,13 +63,13 @@ class HummingbirdJSONTests: XCTestCase {
         }
     }
 
-    func testEncode2() {
+    func testEncode2() throws {
         let app = HBApplication(testing: .embedded)
         app.encoder = JSONEncoder()
         app.router.get("/json") { _ in
             return ["message": "Hello, world!"]
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/json", method: .GET) { response in

--- a/Tests/HummingbirdFoundationTests/URLEncodedForm/Application+URLEncodedFormTests.swift
+++ b/Tests/HummingbirdFoundationTests/URLEncodedForm/Application+URLEncodedFormTests.swift
@@ -26,7 +26,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
 
     struct Error: Swift.Error {}
 
-    func testDecode() {
+    func testDecode() throws {
         let app = HBApplication(testing: .embedded)
         app.decoder = URLEncodedFormDecoder()
         app.router.put("/user") { request -> HTTPResponseStatus in
@@ -36,7 +36,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
             XCTAssertEqual(user.age, 25)
             return .ok
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let body = "name=John%20Smith&email=john.smith%40email.com&age=25"
@@ -45,13 +45,13 @@ class HummingBirdURLEncodedTests: XCTestCase {
         }
     }
 
-    func testEncode() {
+    func testEncode() throws {
         let app = HBApplication(testing: .embedded)
         app.encoder = URLEncodedFormEncoder()
         app.router.get("/user") { _ -> User in
             return User(name: "John Smith", email: "john.smith@email.com", age: 25)
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/user", method: .GET) { response in

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -30,7 +30,7 @@ final class ApplicationTests: XCTestCase {
             let buffer = request.allocator.buffer(string: "GET: Hello")
             return request.eventLoop.makeSucceededFuture(buffer)
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .GET) { response in
@@ -41,12 +41,12 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testHTTPStatusRoute() {
+    func testHTTPStatusRoute() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get("/accepted") { _ -> HTTPResponseStatus in
             return .accepted
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/accepted", method: .GET) { response in
@@ -54,12 +54,12 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testStandardHeaders() {
+    func testStandardHeaders() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get("/hello") { _ in
             return "Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .GET) { response in
@@ -68,12 +68,12 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testServerHeaders() {
+    func testServerHeaders() throws {
         let app = HBApplication(testing: .embedded, configuration: .init(serverName: "Hummingbird"))
         app.router.get("/hello") { _ in
             return "Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .GET) { response in
@@ -81,12 +81,12 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testPostRoute() {
+    func testPostRoute() throws {
         let app = HBApplication(testing: .embedded)
         app.router.post("/hello") { _ -> String in
             return "POST: Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .POST) { response in
@@ -97,7 +97,7 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testMultipleMethods() {
+    func testMultipleMethods() throws {
         let app = HBApplication(testing: .embedded)
         app.router.post("/hello") { _ -> String in
             return "POST"
@@ -105,7 +105,7 @@ final class ApplicationTests: XCTestCase {
         app.router.get("/hello") { _ -> String in
             return "GET"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .GET) { response in
@@ -118,7 +118,7 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testMultipleGroupMethods() {
+    func testMultipleGroupMethods() throws {
         let app = HBApplication(testing: .embedded)
         app.router.group("hello")
             .post { _ -> String in
@@ -127,7 +127,7 @@ final class ApplicationTests: XCTestCase {
             .get { _ -> String in
                 return "GET"
             }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .GET) { response in
@@ -140,13 +140,13 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testQueryRoute() {
+    func testQueryRoute() throws {
         let app = HBApplication(testing: .embedded)
         app.router.post("/query") { request -> EventLoopFuture<ByteBuffer> in
             let buffer = request.allocator.buffer(string: request.uri.queryParameters["test"].map { String($0) } ?? "")
             return request.eventLoop.makeSucceededFuture(buffer)
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/query?test=test%20data%C3%A9", method: .POST) { response in
@@ -157,12 +157,12 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testArray() {
+    func testArray() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get("array") { _ -> [String] in
             return ["yes", "no"]
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/array", method: .GET) { response in
@@ -171,12 +171,12 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testEventLoopFutureArray() {
+    func testEventLoopFutureArray() throws {
         let app = HBApplication(testing: .embedded)
         app.router.patch("array") { request -> EventLoopFuture<[String]> in
             return request.success(["yes", "no"])
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/array", method: .PATCH) { response in
@@ -185,7 +185,7 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testResponseBody() {
+    func testResponseBody() throws {
         let app = HBApplication(testing: .embedded)
         app.router
             .group("/echo-body")
@@ -193,7 +193,7 @@ final class ApplicationTests: XCTestCase {
                 let body: HBResponseBody = request.body.buffer.map { .byteBuffer($0) } ?? .empty
                 return .init(status: .ok, headers: [:], body: body)
             }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 1_140_000)
@@ -203,7 +203,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     /// Test streaming of requests and streaming of responses by streaming the request body into a response streamer
-    func testStreaming() {
+    func testStreaming() throws {
         let app = HBApplication(testing: .embedded)
         app.router.post("streaming", body: .stream) { request -> HBResponse in
             guard let stream = request.body.stream else { throw HBHTTPError(.badRequest) }
@@ -223,7 +223,7 @@ final class ApplicationTests: XCTestCase {
             }
             return HBResponse(status: .ok, headers: [:], body: .stream(RequestStreamer(stream: stream)))
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 640_001)
@@ -236,14 +236,14 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testOptional() {
+    func testOptional() throws {
         let app = HBApplication(testing: .embedded)
         app.router
             .group("/echo-body")
             .post { request -> ByteBuffer? in
                 return request.body.buffer
             }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 64)
@@ -256,14 +256,14 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testELFOptional() {
+    func testELFOptional() throws {
         let app = HBApplication(testing: .embedded)
         app.router
             .group("/echo-body")
             .post { request -> EventLoopFuture<ByteBuffer?> in
                 return request.success(request.body.buffer)
             }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 64)
@@ -276,7 +276,7 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testOptionalCodable() {
+    func testOptionalCodable() throws {
         struct Name: HBResponseCodable {
             let first: String
             let last: String
@@ -287,7 +287,7 @@ final class ApplicationTests: XCTestCase {
             .patch { _ -> Name? in
                 return Name(first: "john", last: "smith")
             }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/name", method: .PATCH) { response in
@@ -304,7 +304,7 @@ final class ApplicationTests: XCTestCase {
             request.response.status = .imATeapot
             return "Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .DELETE) { response in
@@ -326,7 +326,7 @@ final class ApplicationTests: XCTestCase {
             }
             throw HBHTTPError(.internalServerError)
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/", method: .GET) { response in

--- a/Tests/HummingbirdTests/DateCacheTests.swift
+++ b/Tests/HummingbirdTests/DateCacheTests.swift
@@ -30,13 +30,13 @@ class HummingbirdDateTests: XCTestCase {
         }
     }
 
-    func testDateHeader() {
+    func testDateHeader() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get("date") { _ in
             return "hello"
         }
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/date", method: .GET) { response in

--- a/Tests/HummingbirdTests/HandlerTests.swift
+++ b/Tests/HummingbirdTests/HandlerTests.swift
@@ -19,7 +19,7 @@ import NIOHTTP1
 import XCTest
 
 final class HandlerTests: XCTestCase {
-    func testDecode() {
+    func testDecode() throws {
         struct DecodeTest: HBRequestDecodable {
             let name: String
             func handle(request: HBRequest) -> String {
@@ -30,7 +30,7 @@ final class HandlerTests: XCTestCase {
         app.decoder = JSONDecoder()
         app.router.post("/hello", use: DecodeTest.self)
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .POST, body: ByteBufferAllocator().buffer(string: #"{"name": "Adam"}"#)) { response in
@@ -39,7 +39,7 @@ final class HandlerTests: XCTestCase {
         }
     }
 
-    func testDecodeFutureResponse() {
+    func testDecodeFutureResponse() throws {
         struct DecodeTest: HBRequestDecodable {
             let name: String
             func handle(request: HBRequest) -> EventLoopFuture<String> {
@@ -50,7 +50,7 @@ final class HandlerTests: XCTestCase {
         app.decoder = JSONDecoder()
         app.router.put("/hello", use: DecodeTest.self)
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .PUT, body: ByteBufferAllocator().buffer(string: #"{"name": "Adam"}"#)) { response in
@@ -59,7 +59,7 @@ final class HandlerTests: XCTestCase {
         }
     }
 
-    func testDecodeFail() {
+    func testDecodeFail() throws {
         struct DecodeTest: HBRequestDecodable {
             let name: String
             func handle(request: HBRequest) -> HTTPResponseStatus {
@@ -70,7 +70,7 @@ final class HandlerTests: XCTestCase {
         app.decoder = JSONDecoder()
         app.router.get("/hello", use: DecodeTest.self)
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .GET, body: ByteBufferAllocator().buffer(string: #"{"name2": "Adam"}"#)) { response in
@@ -78,7 +78,7 @@ final class HandlerTests: XCTestCase {
         }
     }
 
-    func testEmptyRequest() {
+    func testEmptyRequest() throws {
         struct ParameterTest: HBRouteHandler {
             let parameter: Int
             init(from request: HBRequest) throws {
@@ -93,7 +93,7 @@ final class HandlerTests: XCTestCase {
         let app = HBApplication(testing: .embedded)
         app.router.put("/:test", use: ParameterTest.self)
 
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/23", method: .PUT) { response in

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -189,7 +189,7 @@ final class MetricsTests: XCTestCase {
         app.router.get("/hello") { _ -> String in
             return "Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
         app.XCTExecute(uri: "/hello", method: .GET) { _ in }
 
@@ -207,7 +207,7 @@ final class MetricsTests: XCTestCase {
         app.router.get("/hello") { _ -> String in
             throw HBHTTPError(.badRequest)
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
         app.XCTExecute(uri: "/hello", method: .GET) { _ in }
 
@@ -226,7 +226,7 @@ final class MetricsTests: XCTestCase {
         app.router.get("/hello") { _ -> String in
             return "hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
         app.XCTExecute(uri: "/hello2", method: .GET) { _ in }
 
@@ -244,7 +244,7 @@ final class MetricsTests: XCTestCase {
         app.router.get("/user/:id") { _ -> String in
             throw HBHTTPError(.badRequest)
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
         app.XCTExecute(uri: "/user/765", method: .GET) { _ in }
 

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -17,7 +17,7 @@ import HummingbirdXCT
 import XCTest
 
 final class MiddlewareTests: XCTestCase {
-    func testMiddleware() {
+    func testMiddleware() throws {
         struct TestMiddleware: HBMiddleware {
             func apply(to request: HBRequest, next: HBResponder) -> EventLoopFuture<HBResponse> {
                 return next.respond(to: request).map { response in
@@ -31,7 +31,7 @@ final class MiddlewareTests: XCTestCase {
         app.router.get("/hello") { _ -> String in
             return "Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .GET) { response in
@@ -39,7 +39,7 @@ final class MiddlewareTests: XCTestCase {
         }
     }
 
-    func testMiddlewareOrder() {
+    func testMiddlewareOrder() throws {
         struct TestMiddleware: HBMiddleware {
             let string: String
             func apply(to request: HBRequest, next: HBResponder) -> EventLoopFuture<HBResponse> {
@@ -55,7 +55,7 @@ final class MiddlewareTests: XCTestCase {
         app.router.get("/hello") { _ -> String in
             return "Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .GET) { response in
@@ -65,13 +65,13 @@ final class MiddlewareTests: XCTestCase {
         }
     }
 
-    func testCORSUseOrigin() {
+    func testCORSUseOrigin() throws {
         let app = HBApplication(testing: .embedded)
         app.middleware.add(HBCORSMiddleware())
         app.router.get("/hello") { _ -> String in
             return "Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .GET, headers: ["origin": "foo.com"]) { response in
@@ -80,13 +80,13 @@ final class MiddlewareTests: XCTestCase {
         }
     }
 
-    func testCORSUseAll() {
+    func testCORSUseAll() throws {
         let app = HBApplication(testing: .embedded)
         app.middleware.add(HBCORSMiddleware(allowOrigin: .all))
         app.router.get("/hello") { _ -> String in
             return "Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .GET, headers: ["origin": "foo.com"]) { response in
@@ -95,7 +95,7 @@ final class MiddlewareTests: XCTestCase {
         }
     }
 
-    func testCORSOptions() {
+    func testCORSOptions() throws {
         let app = HBApplication(testing: .embedded)
         app.middleware.add(HBCORSMiddleware(
             allowOrigin: .all,
@@ -108,7 +108,7 @@ final class MiddlewareTests: XCTestCase {
         app.router.get("/hello") { _ -> String in
             return "Hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .OPTIONS, headers: ["origin": "foo.com"]) { response in
@@ -125,13 +125,13 @@ final class MiddlewareTests: XCTestCase {
         }
     }
 
-    func testRouteLoggingMiddleware() {
+    func testRouteLoggingMiddleware() throws {
         let app = HBApplication(testing: .embedded)
         app.middleware.add(HBLogRequestsMiddleware(.debug))
         app.router.put("/hello") { request -> EventLoopFuture<String> in
             return request.failure(.badRequest)
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/hello", method: .PUT) { _ in

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -50,7 +50,7 @@ final class PersistTests: XCTestCase {
 
     func testSetGet() throws {
         let app = try createApplication()
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
         let tag = UUID().uuidString
         app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
@@ -68,7 +68,7 @@ final class PersistTests: XCTestCase {
             return request.persist.create(key: tag, value: String(buffer: buffer))
                 .map { _ in .ok }
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
         let tag = UUID().uuidString
         app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
@@ -80,7 +80,7 @@ final class PersistTests: XCTestCase {
 
     func testSetTwice() throws {
         let app = try createApplication()
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
@@ -96,7 +96,7 @@ final class PersistTests: XCTestCase {
 
     func testExpires() throws {
         let app = try createApplication()
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let tag1 = UUID().uuidString
@@ -130,7 +130,7 @@ final class PersistTests: XCTestCase {
             guard let tag = request.parameters.get("tag") else { return request.failure(.badRequest) }
             return request.persist.get(key: tag, as: TestCodable.self).map { $0.map(\.buffer) }
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
@@ -143,7 +143,7 @@ final class PersistTests: XCTestCase {
 
     func testRemove() throws {
         let app = try createApplication()
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
@@ -156,7 +156,7 @@ final class PersistTests: XCTestCase {
 
     func testExpireAndAdd() throws {
         let app = try createApplication()
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -26,7 +26,7 @@ final class RouterTests: XCTestCase {
         }
     }
 
-    func testEndpoint() {
+    func testEndpoint() throws {
         let app = HBApplication(testing: .embedded)
         app.router
             .group("/endpoint")
@@ -36,7 +36,7 @@ final class RouterTests: XCTestCase {
             .put { _ in
                 return "PUT"
             }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/endpoint", method: .GET) { response in
@@ -50,7 +50,7 @@ final class RouterTests: XCTestCase {
         }
     }
 
-    func testGroupMiddleware() {
+    func testGroupMiddleware() throws {
         let app = HBApplication(testing: .embedded)
         app.router
             .group()
@@ -61,7 +61,7 @@ final class RouterTests: XCTestCase {
         app.router.get("/not-group") { _ in
             return "hello"
         }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/group", method: .GET) { response in
@@ -73,7 +73,7 @@ final class RouterTests: XCTestCase {
         }
     }
 
-    func testEndpointMiddleware() {
+    func testEndpointMiddleware() throws {
         let app = HBApplication(testing: .embedded)
         app.router
             .group("/group")
@@ -81,7 +81,7 @@ final class RouterTests: XCTestCase {
             .head { _ in
                 return "hello"
             }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/group", method: .HEAD) { response in
@@ -89,7 +89,7 @@ final class RouterTests: XCTestCase {
         }
     }
 
-    func testGroupGroupMiddleware() {
+    func testGroupGroupMiddleware() throws {
         let app = HBApplication(testing: .embedded)
         app.router
             .group("/test")
@@ -98,7 +98,7 @@ final class RouterTests: XCTestCase {
             .get { request in
                 return request.success("hello")
             }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/test/group", method: .GET) { response in
@@ -106,13 +106,13 @@ final class RouterTests: XCTestCase {
         }
     }
 
-    func testParameters() {
+    func testParameters() throws {
         let app = HBApplication(testing: .embedded)
         app.router
             .delete("/user/:id") { request -> String? in
                 return request.parameters.get("id", as: String.self)
             }
-        app.XCTStart()
+        try app.XCTStart()
         defer { app.XCTStop() }
 
         app.XCTExecute(uri: "/user/1234", method: .DELETE) { response in


### PR DESCRIPTION
For some reason I had it ignoring errors. This has been rectified