### PR TITLE
Call run on embeddedEventLoop in XCT

### DIFF
--- a/Sources/HummingbirdXCT/HBXCTEmbedded.swift
+++ b/Sources/HummingbirdXCT/HBXCTEmbedded.swift
@@ -57,8 +57,7 @@ struct HBXCTEmbedded: HBXCT {
             }
             try self.writeInbound(.end(nil))
 
-            // flush
-            self.embeddedChannel.flush()
+            self.embeddedChannel.embeddedEventLoop.run()
 
             // read response
             guard case .head(let head) = try readOutbound() else { throw HBXCTError.noHead }

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -19,7 +19,7 @@ final class PersistTests: XCTestCase {
     static let redisHostname = HBEnvironment.shared.get("REDIS_HOSTNAME") ?? "localhost"
 
     func createApplication() throws -> HBApplication {
-        let app = HBApplication(testing: .live)
+        let app = HBApplication(testing: .embedded)
         // add persist
         app.addPersist(using: .memory)
 


### PR DESCRIPTION
This means `submit` and `execute` calls will be run
Convert persists tests back to using embedded XCT framework