### PR TITLE
Memory leak fixes

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -105,6 +105,10 @@ public final class HBApplication: HBExtensible {
             label: "Application", .sync(self.shutdownApplication)
         )
 
+        self.lifecycle.registerShutdown(
+            label: "DateCache", .eventLoopFuture { HBDateCache.shutdownDataCaches(eventLoopGroup: self.eventLoopGroup) }
+        )
+
         // register server startup and shutdown with lifecycle
         self.lifecycle.register(
             label: "HTTP Server",

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -50,7 +50,7 @@ struct HBXCTLive: HBXCT {
         XCTAssertNoThrow(_ = try self.client.syncShutdown())
         application.stop()
         application.wait()
-        try? eventLoopGroup.syncShutdownGracefully()
+        try? self.eventLoopGroup.syncShutdownGracefully()
     }
 
     /// Send request and call test callback on the response returned

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -49,6 +49,8 @@ struct HBXCTLive: HBXCT {
     func stop(application: HBApplication) {
         XCTAssertNoThrow(_ = try self.client.syncShutdown())
         application.stop()
+        application.wait()
+        try? eventLoopGroup.syncShutdownGracefully()
     }
 
     /// Send request and call test callback on the response returned


### PR DESCRIPTION
- Shutdown Date Caches when you shut down the application
- HBXCTLive should shutdown its EventLoopGroup