### PR TITLE
Replace bodyCollation with HBRouterMethodOptions.streamBody

### DIFF
--- a/Sources/Hummingbird/Router/RouteHandler.swift
+++ b/Sources/Hummingbird/Router/RouteHandler.swift
@@ -48,10 +48,10 @@ extension HBRouterMethods {
     @discardableResult public func on<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String,
         method: HTTPMethod,
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handlerType: Handler.Type
     ) -> Self where Handler._Output == _Output {
-        return self.on(path, method: method, body: body) { request -> _Output in
+        return self.on(path, method: method, options: options) { request -> _Output in
             let handler = try Handler(from: request)
             return try handler.handle(request: request)
         }
@@ -62,10 +62,10 @@ extension HBRouterMethods {
     @discardableResult func on<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String,
         method: HTTPMethod,
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handlerType: Handler.Type
     ) -> Self where Handler._Output == EventLoopFuture<_Output> {
-        return self.on(path, method: method, body: body) { request -> EventLoopFuture<_Output> in
+        return self.on(path, method: method, options: options) { request -> EventLoopFuture<_Output> in
             do {
                 let handler = try Handler(from: request)
                 return try handler.handle(request: request)
@@ -78,108 +78,108 @@ extension HBRouterMethods {
     /// GET path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func get<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == _Output {
-        return self.on(path, method: .GET, body: body, use: handler)
+        return self.on(path, method: .GET, options: options, use: handler)
     }
 
     /// PUT path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func put<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == _Output {
-        return self.on(path, method: .PUT, body: body, use: handler)
+        return self.on(path, method: .PUT, options: options, use: handler)
     }
 
     /// POST path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func post<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == _Output {
-        return self.on(path, method: .POST, body: body, use: handler)
+        return self.on(path, method: .POST, options: options, use: handler)
     }
 
     /// HEAD path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func head<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == _Output {
-        return self.on(path, method: .HEAD, body: body, use: handler)
+        return self.on(path, method: .HEAD, options: options, use: handler)
     }
 
     /// DELETE path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func delete<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == _Output {
-        return self.on(path, method: .DELETE, body: body, use: handler)
+        return self.on(path, method: .DELETE, options: options, use: handler)
     }
 
     /// PATCH path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func patch<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == _Output {
-        return self.on(path, method: .PATCH, body: body, use: handler)
+        return self.on(path, method: .PATCH, options: options, use: handler)
     }
 
     /// GET path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func get<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == EventLoopFuture<_Output> {
-        return self.on(path, method: .GET, body: body, use: handler)
+        return self.on(path, method: .GET, options: options, use: handler)
     }
 
     /// PUT path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func put<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == EventLoopFuture<_Output> {
-        return self.on(path, method: .PUT, body: body, use: handler)
+        return self.on(path, method: .PUT, options: options, use: handler)
     }
 
     /// POST path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func post<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == EventLoopFuture<_Output> {
-        return self.on(path, method: .POST, body: body, use: handler)
+        return self.on(path, method: .POST, options: options, use: handler)
     }
 
     /// HEAD path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func head<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == EventLoopFuture<_Output> {
-        return self.on(path, method: .HEAD, body: body, use: handler)
+        return self.on(path, method: .HEAD, options: options, use: handler)
     }
 
     /// DELETE path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func delete<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == EventLoopFuture<_Output> {
-        return self.on(path, method: .DELETE, body: body, use: handler)
+        return self.on(path, method: .DELETE, options: options, use: handler)
     }
 
     /// PATCH path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func patch<Handler: HBRouteHandler, _Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: Handler.Type
     ) -> Self where Handler._Output == EventLoopFuture<_Output> {
-        return self.on(path, method: .PATCH, body: body, use: handler)
+        return self.on(path, method: .PATCH, options: options, use: handler)
     }
 }

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -58,10 +58,10 @@ extension HBRouter {
     @discardableResult public func on<Output: HBResponseGenerator>(
         _ path: String,
         method: HTTPMethod,
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) throws -> Output
     ) -> Self {
-        let responder = constructResponder(body: body, use: closure)
+        let responder = constructResponder(options: options, use: closure)
         add(path, method: method, responder: responder)
         return self
     }
@@ -70,10 +70,10 @@ extension HBRouter {
     @discardableResult public func on<Output: HBResponseGenerator>(
         _ path: String,
         method: HTTPMethod,
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
-        let responder = constructResponder(body: body, use: closure)
+        let responder = constructResponder(options: options, use: closure)
         add(path, method: method, responder: responder)
         return self
     }

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -57,10 +57,10 @@ public struct HBRouterGroup: HBRouterMethods {
     @discardableResult public func on<Output: HBResponseGenerator>(
         _ path: String = "",
         method: HTTPMethod,
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) throws -> Output
     ) -> Self {
-        let responder = constructResponder(body: body, use: closure)
+        let responder = constructResponder(options: options, use: closure)
         let path = self.combinePaths(self.path, path)
         self.router.add(path, method: method, responder: self.middlewares.constructResponder(finalResponder: responder))
         return self
@@ -70,10 +70,10 @@ public struct HBRouterGroup: HBRouterMethods {
     @discardableResult public func on<Output: HBResponseGenerator>(
         _ path: String = "",
         method: HTTPMethod,
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
-        let responder = constructResponder(body: body, use: closure)
+        let responder = constructResponder(options: options, use: closure)
         let path = self.combinePaths(self.path, path)
         self.router.add(path, method: method, responder: self.middlewares.constructResponder(finalResponder: responder))
         return self

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -22,9 +22,9 @@ public struct HBRouterMethodOptions: OptionSet {
     }
 
     /// don't collate the request body, all handler to stream it
-    public static var streamBody: HBRouterMethodOptions = .init(rawValue: 1<<0)
+    public static var streamBody: HBRouterMethodOptions = .init(rawValue: 1 << 0)
     /// allow handler to edit response via `request.response`
-    public static var editResponse: HBRouterMethodOptions = .init(rawValue: 1<<1)
+    public static var editResponse: HBRouterMethodOptions = .init(rawValue: 1 << 1)
 }
 
 public protocol HBRouterMethods {

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -15,9 +15,16 @@
 import NIO
 import NIOHTTP1
 
-public enum HBBodyCollation {
-    case collate
-    case stream
+public struct HBRouterMethodOptions: OptionSet {
+    public let rawValue: Int
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    /// don't collate the request body, all handler to stream it
+    public static var streamBody: HBRouterMethodOptions = .init(rawValue: 1<<0)
+    /// allow handler to edit response via `request.response`
+    public static var editResponse: HBRouterMethodOptions = .init(rawValue: 1<<1)
 }
 
 public protocol HBRouterMethods {
@@ -25,7 +32,7 @@ public protocol HBRouterMethods {
     @discardableResult func on<Output: HBResponseGenerator>(
         _ path: String,
         method: HTTPMethod,
-        body: HBBodyCollation,
+        options: HBRouterMethodOptions,
         use: @escaping (HBRequest) throws -> Output
     ) -> Self
 
@@ -33,7 +40,7 @@ public protocol HBRouterMethods {
     @discardableResult func on<Output: HBResponseGenerator>(
         _ path: String,
         method: HTTPMethod,
-        body: HBBodyCollation,
+        options: HBRouterMethodOptions,
         use: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self
 
@@ -45,120 +52,134 @@ extension HBRouterMethods {
     /// GET path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func get<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) throws -> Output
     ) -> Self {
-        return on(path, method: .GET, body: body, use: handler)
+        return on(path, method: .GET, options: options, use: handler)
     }
 
     /// PUT path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func put<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) throws -> Output
     ) -> Self {
-        return on(path, method: .PUT, body: body, use: handler)
+        return on(path, method: .PUT, options: options, use: handler)
     }
 
     /// POST path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func post<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) throws -> Output
     ) -> Self {
-        return on(path, method: .POST, body: body, use: handler)
+        return on(path, method: .POST, options: options, use: handler)
     }
 
     /// HEAD path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func head<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) throws -> Output
     ) -> Self {
-        return on(path, method: .HEAD, body: body, use: handler)
+        return on(path, method: .HEAD, options: options, use: handler)
     }
 
     /// DELETE path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func delete<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) throws -> Output
     ) -> Self {
-        return on(path, method: .DELETE, body: body, use: handler)
+        return on(path, method: .DELETE, options: options, use: handler)
     }
 
     /// PATCH path for closure returning type conforming to HBResponseGenerator
     @discardableResult public func patch<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) throws -> Output
     ) -> Self {
-        return on(path, method: .PATCH, body: body, use: handler)
+        return on(path, method: .PATCH, options: options, use: handler)
     }
 
     /// GET path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func get<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
-        return on(path, method: .GET, body: body, use: handler)
+        return on(path, method: .GET, options: options, use: handler)
     }
 
     /// PUT path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func put<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
-        return on(path, method: .PUT, body: body, use: handler)
+        return on(path, method: .PUT, options: options, use: handler)
     }
 
     /// POST path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func delete<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
-        return on(path, method: .DELETE, body: body, use: handler)
+        return on(path, method: .DELETE, options: options, use: handler)
     }
 
     /// HEAD path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func head<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
-        return on(path, method: .HEAD, body: body, use: handler)
+        return on(path, method: .HEAD, options: options, use: handler)
     }
 
     /// DELETE path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func post<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
-        return on(path, method: .POST, body: body, use: handler)
+        return on(path, method: .POST, options: options, use: handler)
     }
 
     /// PATCH path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func patch<Output: HBResponseGenerator>(
         _ path: String = "",
-        body: HBBodyCollation = .collate,
+        options: HBRouterMethodOptions = [],
         use handler: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
-        return on(path, method: .PATCH, body: body, use: handler)
+        return on(path, method: .PATCH, options: options, use: handler)
     }
 }
 
 extension HBRouterMethods {
     func constructResponder<Output: HBResponseGenerator>(
-        body: HBBodyCollation,
+        options: HBRouterMethodOptions,
         use closure: @escaping (HBRequest) throws -> Output
     ) -> HBResponder {
-        switch body {
-        case .collate:
+        if options.contains(.streamBody) {
             return HBCallbackResponder { request in
+                if options.contains(.editResponse) {
+                    request.response = .init()
+                }
+                do {
+                    let response = try closure(request).patchedResponse(from: request)
+                    return request.success(response)
+                } catch {
+                    return request.failure(error)
+                }
+            }
+        } else {
+            return HBCallbackResponder { request in
+                if options.contains(.editResponse) {
+                    request.response = .init()
+                }
                 if case .byteBuffer = request.body {
                     do {
                         let response = try closure(request).patchedResponse(from: request)
@@ -173,25 +194,26 @@ extension HBRouterMethods {
                     }
                 }
             }
-        case .stream:
-            return HBCallbackResponder { request in
-                do {
-                    let response = try closure(request).patchedResponse(from: request)
-                    return request.success(response)
-                } catch {
-                    return request.failure(error)
-                }
-            }
         }
     }
 
     func constructResponder<Output: HBResponseGenerator>(
-        body: HBBodyCollation,
+        options: HBRouterMethodOptions,
         use closure: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> HBResponder {
-        switch body {
-        case .collate:
+        if options.contains(.streamBody) {
             return HBCallbackResponder { request in
+                if options.contains(.editResponse) {
+                    request.response = .init()
+                }
+                return closure(request).flatMapThrowing { try $0.patchedResponse(from: request) }
+                    .hop(to: request.eventLoop)
+            }
+        } else {
+            return HBCallbackResponder { request in
+                if options.contains(.editResponse) {
+                    request.response = .init()
+                }
                 if case .byteBuffer = request.body {
                     return closure(request).flatMapThrowing { try $0.patchedResponse(from: request) }
                         .hop(to: request.eventLoop)
@@ -202,11 +224,6 @@ extension HBRouterMethods {
                             .hop(to: request.eventLoop)
                     }
                 }
-            }
-        case .stream:
-            return HBCallbackResponder { request in
-                return closure(request).flatMapThrowing { try $0.patchedResponse(from: request) }
-                    .hop(to: request.eventLoop)
             }
         }
     }

--- a/Sources/Hummingbird/Server/ResponsePatch.swift
+++ b/Sources/Hummingbird/Server/ResponsePatch.swift
@@ -41,7 +41,7 @@ extension HBRequest {
 
     /// Allows you to edit the status and headers of the response
     public var response: ResponsePatch {
-        get { self.extensions.getOrCreate(\.response, ResponsePatch()) }
+        get { self.extensions.get(\.response) }
         set { self.extensions.set(\.response, value: newValue) }
     }
 

--- a/Sources/Hummingbird/Server/ResponsePatch.swift
+++ b/Sources/Hummingbird/Server/ResponsePatch.swift
@@ -44,7 +44,8 @@ extension HBRequest {
         get {
             self.extensions.get(
                 \.response,
-                error: "Cannot edit response via HBRequest.response on a route with the .editResponse option set")
+                error: "Cannot edit response via HBRequest.response on a route with the .editResponse option set"
+            )
         }
         set { self.extensions.set(\.response, value: newValue) }
     }

--- a/Sources/Hummingbird/Server/ResponsePatch.swift
+++ b/Sources/Hummingbird/Server/ResponsePatch.swift
@@ -41,7 +41,11 @@ extension HBRequest {
 
     /// Allows you to edit the status and headers of the response
     public var response: ResponsePatch {
-        get { self.extensions.get(\.response) }
+        get {
+            self.extensions.get(
+                \.response,
+                error: "Cannot edit response via HBRequest.response on a route with the .editResponse option set")
+        }
         set { self.extensions.set(\.response, value: newValue) }
     }
 

--- a/Tests/HummingbirdFoundationTests/CookiesTests.swift
+++ b/Tests/HummingbirdFoundationTests/CookiesTests.swift
@@ -80,7 +80,7 @@ class CookieTests: XCTestCase {
 
     func testSetCookieViaRequest() throws {
         let app = HBApplication(testing: .embedded)
-        app.router.post("/") { request -> String in
+        app.router.post("/", options: .editResponse) { request -> String in
             request.response.setCookie(.init(name: "test", value: "value"))
             return "Hello"
         }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -205,7 +205,7 @@ final class ApplicationTests: XCTestCase {
     /// Test streaming of requests and streaming of responses by streaming the request body into a response streamer
     func testStreaming() throws {
         let app = HBApplication(testing: .embedded)
-        app.router.post("streaming", body: .stream) { request -> HBResponse in
+        app.router.post("streaming", options: .streamBody) { request -> HBResponse in
             guard let stream = request.body.stream else { throw HBHTTPError(.badRequest) }
             struct RequestStreamer: HBResponseBodyStreamer {
                 let stream: HBStreamerProtocol
@@ -239,7 +239,7 @@ final class ApplicationTests: XCTestCase {
     /// Test streaming of requests and streaming of responses by streaming the request body into a response streamer
     func testStreamingSmallBuffer() throws {
         let app = HBApplication(testing: .embedded)
-        app.router.post("streaming", body: .stream) { request -> HBResponse in
+        app.router.post("streaming", options: .streamBody) { request -> HBResponse in
             guard let stream = request.body.stream else { throw HBHTTPError(.badRequest) }
             struct RequestStreamer: HBResponseBodyStreamer {
                 let stream: HBStreamerProtocol
@@ -332,7 +332,7 @@ final class ApplicationTests: XCTestCase {
 
     func testEditResponse() throws {
         let app = HBApplication(testing: .embedded)
-        app.router.delete("/hello") { request -> String in
+        app.router.delete("/hello", options: .editResponse) { request -> String in
             request.response.headers.add(name: "test", value: "value")
             request.response.headers.replaceOrAdd(name: "content-type", value: "application/json")
             request.response.status = .imATeapot

--- a/documentation/Router.md
+++ b/documentation/Router.md
@@ -104,7 +104,7 @@ application.router.put("order", use: AddOrder.self)
 
 ## Streaming request body
 
-By default Hummingbird will collate the contents of your request body into one ByteBuffer. You can access this via `HBRequest.body.buffer`. If you'd prefer to stream the content of the request body, you can add a `.streamBody` option to the route handler to receive a streaming body instead of a single `ByteBuffer`. Inside the route handler you can access this stream via `HBRequest.body.stream`. The request body parts are then accessed either via `consume` function which will return everything that has been streamed so far or a `consumeAll` function which takes a closure processing each part. Here is an example which reads the request buffer and returns it size
+By default Hummingbird will collate the contents of your request body into one ByteBuffer. You can access this via `HBRequest.body.buffer`. If you'd prefer to stream the content of the request body, you can add a `.streamBody` option to the route handler to receive a streaming body instead of a single `ByteBuffer`. Inside the route handler you access this stream via `HBRequest.body.stream`. The request body parts are then accessed either via `consume` function which will return everything that has been streamed so far or a `consumeAll` function which takes a closure processing each part. Here is an example which reads the request buffer and returns it size
 ```swift
 application.router.post("size", options: .streamBody) { request -> EventLoopFuture<String> in
     guard let stream = request.body.stream else { 


### PR DESCRIPTION
Added `HBRouterMethodOptions` which includes `.streamBody` which replaces `HBBodyCollation.stream`. This options set also includes new option `.editResponse`.

If you want to edit the handler response via `HBRequest.response` you need to set this flag on the route
```swift
app.router.get("/hello", options: .editResponse) { request -> String in
    request.response.status = .imATeapot
    return "Teapot"
}
```