### PR TITLE
Change HBRequest/HBResponse to struct

### DIFF
--- a/Sources/Hummingbird/Middleware/CORSMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/CORSMiddleware.swift
@@ -111,6 +111,7 @@ public struct HBCORSMiddleware: HBMiddleware {
         } else {
             // if not OPTIONS then run rest of middleware chain and add origin value at the end
             return next.respond(to: request).map { response in
+                var response = response
                 response.headers.add(name: "access-control-allow-origin", value: self.allowOrigin.value(for: request) ?? "")
                 if case .originBased = self.allowOrigin {
                     response.headers.add(name: "vary", value: "Origin")

--- a/Sources/Hummingbird/Router/ResponseGenerator.swift
+++ b/Sources/Hummingbird/Router/ResponseGenerator.swift
@@ -26,8 +26,8 @@ public protocol HBResponseGenerator {
 extension HBResponseGenerator {
     /// Generate reponse based on the request this object came from and apply request patches
     func patchedResponse(from request: HBRequest) throws -> HBResponse {
-        var response = try response(from: request)
-        return response.apply(patch: request.optionalResponse)
+        var r = try response(from: request)
+        return r.apply(patch: request.optionalResponse)
     }
 }
 

--- a/Sources/Hummingbird/Router/ResponseGenerator.swift
+++ b/Sources/Hummingbird/Router/ResponseGenerator.swift
@@ -26,7 +26,8 @@ public protocol HBResponseGenerator {
 extension HBResponseGenerator {
     /// Generate reponse based on the request this object came from and apply request patches
     func patchedResponse(from request: HBRequest) throws -> HBResponse {
-        try response(from: request).apply(patch: request.optionalResponse)
+        var response = try response(from: request)
+        return response.apply(patch: request.optionalResponse)
     }
 }
 

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -165,6 +165,7 @@ extension HBRouterMethods {
     ) -> HBResponder {
         if options.contains(.streamBody) {
             return HBCallbackResponder { request in
+                var request = request
                 if options.contains(.editResponse) {
                     request.response = .init()
                 }
@@ -177,6 +178,7 @@ extension HBRouterMethods {
             }
         } else {
             return HBCallbackResponder { request in
+                var request = request
                 if options.contains(.editResponse) {
                     request.response = .init()
                 }
@@ -203,6 +205,7 @@ extension HBRouterMethods {
     ) -> HBResponder {
         if options.contains(.streamBody) {
             return HBCallbackResponder { request in
+                var request = request
                 if options.contains(.editResponse) {
                     request.response = .init()
                 }
@@ -211,6 +214,7 @@ extension HBRouterMethods {
             }
         } else {
             return HBCallbackResponder { request in
+                var request = request
                 if options.contains(.editResponse) {
                     request.response = .init()
                 }

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -45,6 +45,7 @@ struct TrieRouter: HBRouter {
         guard let result = trie.getValueAndParameters(path) else {
             return request.eventLoop.makeFailedFuture(HBHTTPError(.notFound))
         }
+        var request = request
         if result.parameters.count > 0 {
             request.parameters = result.parameters
         }

--- a/Sources/Hummingbird/Server/Application+HTTPResponder.swift
+++ b/Sources/Hummingbird/Server/Application+HTTPResponder.swift
@@ -55,6 +55,7 @@ extension HBApplication {
             self.responder.respond(to: request).whenComplete { result in
                 switch result {
                 case .success(let response):
+                    var response = response
                     response.headers.add(name: "Date", value: HBDateCache.getDateCache(on: context.eventLoop).currentDate)
                     let responseHead = HTTPResponseHead(version: request.version, status: response.status, headers: response.headers)
                     onComplete(.success(HBHTTPResponse(head: responseHead, body: response.body)))

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -19,35 +19,72 @@ import NIOConcurrencyHelpers
 import NIOHTTP1
 
 /// Holds all the values required to process a request
-public final class HBRequest: HBExtensible {
+public struct HBRequest: HBExtensible {
     // MARK: Member variables
 
+    class Internal {
+        internal init(uri: HBURL, version: HTTPVersion, method: HTTPMethod, headers: HTTPHeaders, logger: Logger, application: HBApplication, context: HBRequestContext, endpointPath: String? = nil) {
+            self.uri = uri
+            self.version = version
+            self.method = method
+            self.headers = headers
+            self.logger = logger
+            self.application = application
+            self.context = context
+            self.endpointPath = endpointPath
+        }
+
+        /// URI path
+        let uri: HBURL
+        /// HTTP version
+        let version: HTTPVersion
+        /// Request HTTP method
+        let method: HTTPMethod
+        /// Request HTTP headers
+        let headers: HTTPHeaders
+        /// Logger to use
+        let logger: Logger
+        /// reference to application
+        let application: HBApplication
+        /// request context
+        let context: HBRequestContext
+        /// Endpoint path. This is stored a var so it can be edited by the router. In theory this could
+        /// be accessed on multiple thread/tasks at the same point but it is only ever edited by router
+        var endpointPath: String?
+    }
+
+    private var _internal: Internal
+
     /// URI path
-    public var uri: HBURL
+    public var uri: HBURL { self._internal.uri }
     /// HTTP version
-    public var version: HTTPVersion
+    public var version: HTTPVersion { self._internal.version }
     /// Request HTTP method
-    public var method: HTTPMethod
+    public var method: HTTPMethod { self._internal.method }
     /// Request HTTP headers
-    public var headers: HTTPHeaders
+    public var headers: HTTPHeaders { self._internal.headers }
     /// Body of HTTP request
     public var body: HBRequestBody
     /// Logger to use
-    public var logger: Logger
+    public var logger: Logger { self._internal.logger }
     /// reference to application
-    public var application: HBApplication
+    public var application: HBApplication { self._internal.application }
     /// Request extensions
     public var extensions: HBExtensions<HBRequest>
-    /// endpoint that services this request
-    public var endpointPath: String?
+    /// endpoint that services this request.
+    internal var endpointPath: String? {
+        get { self._internal.endpointPath }
+        set { self._internal.endpointPath = newValue }
+    }
 
-    public var context: HBRequestContext
+    /// Request context (eventLoop, bytebuffer allocator and remote address)
+    public var context: HBRequestContext { self._internal.context }
     /// EventLoop request is running on
-    public var eventLoop: EventLoop { self.context.eventLoop }
+    public var eventLoop: EventLoop { self._internal.context.eventLoop }
     /// ByteBuffer allocator used by request
-    public var allocator: ByteBufferAllocator { self.context.allocator }
+    public var allocator: ByteBufferAllocator { self._internal.context.allocator }
     /// IP request came from
-    public var remoteAddress: SocketAddress? { self.context.remoteAddress }
+    public var remoteAddress: SocketAddress? { self._internal.context.remoteAddress }
 
     /// Parameters extracted during processing of request URI. These are available to you inside the route handler
     public var parameters: HBParameters {
@@ -75,16 +112,25 @@ public final class HBRequest: HBExtensible {
         application: HBApplication,
         context: HBRequestContext
     ) {
-        self.uri = .init(head.uri)
-        self.version = head.version
-        self.method = head.method
-        self.headers = head.headers
+        self._internal = .init(
+            uri: .init(head.uri),
+            version: head.version,
+            method: head.method,
+            headers: head.headers,
+            logger: application.logger.with(metadataKey: "hb_id", value: .stringConvertible(Self.globalRequestID.add(1))),
+            application: application,
+            context: context
+        )
+//        self.uri = .init(head.uri)
+//        self.version = head.version
+//        self.method = head.method
+//        self.headers = head.headers
         self.body = body
-        self.logger = application.logger.with(metadataKey: "hb_id", value: .stringConvertible(Self.globalRequestID.add(1)))
-        self.application = application
+//        self.logger = application.logger.with(metadataKey: "hb_id", value: .stringConvertible(Self.globalRequestID.add(1)))
+//        self.application = application
         self.extensions = HBExtensions()
-        self.endpointPath = nil
-        self.context = context
+//        self.endpointPath = nil
+//        self.context = context
     }
 
     // MARK: Methods

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -33,7 +33,7 @@ public struct HBRequest: HBExtensible {
     /// Body of HTTP request
     public var body: HBRequestBody
     /// Logger to use
-    public var logger: Logger { self._internal.logger }
+    public var logger: Logger
     /// reference to application
     public var application: HBApplication { self._internal.application }
     /// Request extensions
@@ -84,20 +84,12 @@ public struct HBRequest: HBExtensible {
             version: head.version,
             method: head.method,
             headers: head.headers,
-            logger: application.logger.with(metadataKey: "hb_id", value: .stringConvertible(Self.globalRequestID.add(1))),
             application: application,
             context: context
         )
-//        self.uri = .init(head.uri)
-//        self.version = head.version
-//        self.method = head.method
-//        self.headers = head.headers
         self.body = body
-//        self.logger = application.logger.with(metadataKey: "hb_id", value: .stringConvertible(Self.globalRequestID.add(1)))
-//        self.application = application
+        self.logger = application.logger.with(metadataKey: "hb_id", value: .stringConvertible(Self.globalRequestID.add(1)))
         self.extensions = HBExtensions()
-//        self.endpointPath = nil
-//        self.context = context
     }
 
     // MARK: Methods
@@ -136,12 +128,11 @@ public struct HBRequest: HBExtensible {
     /// Store all the read-only values of the request in a class to avoid copying them
     /// everytime we pass the `HBRequest` struct about
     class _Internal {
-        internal init(uri: HBURL, version: HTTPVersion, method: HTTPMethod, headers: HTTPHeaders, logger: Logger, application: HBApplication, context: HBRequestContext, endpointPath: String? = nil) {
+        internal init(uri: HBURL, version: HTTPVersion, method: HTTPMethod, headers: HTTPHeaders, application: HBApplication, context: HBRequestContext, endpointPath: String? = nil) {
             self.uri = uri
             self.version = version
             self.method = method
             self.headers = headers
-            self.logger = logger
             self.application = application
             self.context = context
             self.endpointPath = endpointPath
@@ -155,8 +146,6 @@ public struct HBRequest: HBExtensible {
         let method: HTTPMethod
         /// Request HTTP headers
         let headers: HTTPHeaders
-        /// Logger to use
-        let logger: Logger
         /// reference to application
         let application: HBApplication
         /// request context

--- a/Sources/Hummingbird/Server/Response.swift
+++ b/Sources/Hummingbird/Server/Response.swift
@@ -17,7 +17,7 @@ import NIO
 import NIOHTTP1
 
 /// Holds all the required to generate a HTTP Response
-public final class HBResponse: HBExtensible {
+public struct HBResponse: HBExtensible {
     /// response status
     public var status: HTTPResponseStatus
     /// response headers

--- a/Sources/Hummingbird/Server/ResponsePatch.swift
+++ b/Sources/Hummingbird/Server/ResponsePatch.swift
@@ -58,7 +58,7 @@ extension HBRequest {
 
 extension HBResponse {
     /// apply `HBRequest.ResponsePatch` to `HBResponse`
-    func apply(patch: HBRequest.ResponsePatch?) -> Self {
+    mutating func apply(patch: HBRequest.ResponsePatch?) -> Self {
         guard let patch = patch else { return self }
         if let status = patch.status {
             self.status = status

--- a/Sources/Hummingbird/Server/ResponsePatch.swift
+++ b/Sources/Hummingbird/Server/ResponsePatch.swift
@@ -39,12 +39,15 @@ extension HBRequest {
         }
     }
 
-    /// Allows you to edit the status and headers of the response
+    /// Allows you to edit the status and headers of the response.
+    ///
+    /// `HBRequest.response` is only available within route handlers that have had the option `.editResponse`.
+    /// Trying to access it outside of one of these will cause the application to crash
     public var response: ResponsePatch {
         get {
             self.extensions.get(
                 \.response,
-                error: "Cannot edit response via HBRequest.response on a route with the .editResponse option set"
+                error: "Cannot edit response via HBRequest.response outside of a route with the .editResponse option set"
             )
         }
         set { self.extensions.set(\.response, value: newValue) }

--- a/Sources/HummingbirdFoundation/Cookies/Response+Cookies.swift
+++ b/Sources/HummingbirdFoundation/Cookies/Response+Cookies.swift
@@ -16,7 +16,7 @@ import Hummingbird
 
 extension HBResponse {
     /// Set cookie on response
-    public func setCookie(_ cookie: HBCookie) {
+    public mutating func setCookie(_ cookie: HBCookie) {
         self.headers.add(name: "Set-Cookie", value: cookie.description)
     }
 }

--- a/Tests/HummingbirdFoundationTests/CookiesTests.swift
+++ b/Tests/HummingbirdFoundationTests/CookiesTests.swift
@@ -66,7 +66,7 @@ class CookieTests: XCTestCase {
     func testSetCookie() throws {
         let app = HBApplication(testing: .embedded)
         app.router.post("/") { _ -> HBResponse in
-            let response = HBResponse(status: .ok, headers: [:], body: .empty)
+            var response = HBResponse(status: .ok, headers: [:], body: .empty)
             response.setCookie(.init(name: "test", value: "value"))
             return response
         }

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -21,6 +21,7 @@ final class MiddlewareTests: XCTestCase {
         struct TestMiddleware: HBMiddleware {
             func apply(to request: HBRequest, next: HBResponder) -> EventLoopFuture<HBResponse> {
                 return next.respond(to: request).map { response in
+                    var response = response
                     response.headers.replaceOrAdd(name: "middleware", value: "TestMiddleware")
                     return response
                 }
@@ -44,6 +45,7 @@ final class MiddlewareTests: XCTestCase {
             let string: String
             func apply(to request: HBRequest, next: HBResponder) -> EventLoopFuture<HBResponse> {
                 return next.respond(to: request).map { response in
+                    var response = response
                     response.headers.add(name: "middleware", value: string)
                     return response
                 }

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -20,6 +20,7 @@ final class RouterTests: XCTestCase {
     struct TestMiddleware: HBMiddleware {
         func apply(to request: HBRequest, next: HBResponder) -> EventLoopFuture<HBResponse> {
             return next.respond(to: request).map { response in
+                var response = response
                 response.headers.replaceOrAdd(name: "middleware", value: "TestMiddleware")
                 return response
             }


### PR DESCRIPTION
Made `HBRequest` and `HBResponse` structs. This should make moving to a full async/await implementation a little easier as they become automatically `Sendable` as long as all their members are `Sendable`. 

For most situations, code changes related to `HBResponse` becoming a struct involves making a mutable instance of the response. 

It is slightly more complex for `HBRequest`. `HBRequest` is large enough such that converting it to a `struct` actually reduces performance. To fix this I have moved all the parameters of `HBRequest` that are read only into an internal class. There is no point copying all this data through all the response generators. Storing it in a class means only a reference to the data is passed through.

Having `HBRequest` as a struct also means some APIs that would have edited the request have had to change. You can see this in changes to [hummingbird-auth](https://github.com/hummingbird-project/hummingbird-auth/pull/10)