### PR TITLE
Adjust file handling to handle loading from bundles

### DIFF
--- a/Sources/HummingbirdFoundation/Cookies/Cookie.swift
+++ b/Sources/HummingbirdFoundation/Cookies/Cookie.swift
@@ -144,7 +144,7 @@ public struct HBCookie: CustomStringConvertible {
 
     /// Output cookie string
     public var description: String {
-        var output: String = "\(self.name)=\(self.value)"
+        var output = "\(self.name)=\(self.value)"
         for property in self.properties.table {
             if property.value == "" {
                 output += "; \(property.key)"

--- a/Sources/HummingbirdFoundation/Files/FileMiddleware.swift
+++ b/Sources/HummingbirdFoundation/Files/FileMiddleware.swift
@@ -195,31 +195,32 @@ extension HBFileMiddleware {
     ///
     /// Also supports open ended ranges
     private func getRangeFromHeaderValue(_ header: String) -> ClosedRange<Int>? {
-        let groups = matchRegex(header, expression: "^bytes=([\\d]*)-([\\d]*)$")
+        let groups = self.matchRegex(header, expression: "^bytes=([\\d]*)-([\\d]*)$")
         guard groups.count == 3 else { return nil }
 
         if groups[1] == "" {
             guard let upperBound = Int(groups[2]) else { return nil }
-            return Int.min ... upperBound
+            return Int.min...upperBound
         } else if groups[2] == "" {
             guard let lowerBound = Int(groups[1]) else { return nil }
-            return lowerBound ... Int.max
+            return lowerBound...Int.max
         } else {
             guard let lowerBound = Int(groups[1]),
                   let upperBound = Int(groups[2]) else { return nil }
-            return lowerBound ... upperBound
+            return lowerBound...upperBound
         }
     }
 
     private func matchRegex(_ string: String, expression: String) -> [Substring] {
         guard let regularExpression = try? NSRegularExpression(pattern: expression, options: []),
-              let firstMatch = regularExpression.firstMatch(in: string, range: NSMakeRange(0, string.count)) else {
+              let firstMatch = regularExpression.firstMatch(in: string, range: NSMakeRange(0, string.count))
+        else {
             return []
         }
 
         var groups: [Substring] = []
         groups.reserveCapacity(firstMatch.numberOfRanges)
-        for i in 0 ..< firstMatch.numberOfRanges {
+        for i in 0..<firstMatch.numberOfRanges {
             guard let range = Range(firstMatch.range(at: i), in: string) else { continue }
             groups.append(string[range])
         }
@@ -230,7 +231,7 @@ extension HBFileMiddleware {
         let string = strings.joined(separator: "-")
         let buffer = Array<UInt8>.init(unsafeUninitializedCapacity: 16) { bytes, size in
             var index = 0
-            for i in 0 ..< 16 {
+            for i in 0..<16 {
                 bytes[i] = 0
             }
             for c in string.utf8 {
@@ -250,6 +251,6 @@ extension HBFileMiddleware {
 extension Sequence where Element == UInt8 {
     /// return a hexEncoded string buffer from an array of bytes
     func hexDigest() -> String {
-        return map { String(format: "%02x", $0) }.joined(separator: "")
+        return self.map { String(format: "%02x", $0) }.joined(separator: "")
     }
 }

--- a/Sources/HummingbirdFoundation/Files/FileMiddleware.swift
+++ b/Sources/HummingbirdFoundation/Files/FileMiddleware.swift
@@ -44,16 +44,23 @@ public struct HBFileMiddleware: HBMiddleware {
         searchForIndexHtml: Bool = false,
         application: HBApplication
     ) {
-        var rootFolder = rootFolder
-        if rootFolder.last == "/" {
-            rootFolder = String(rootFolder.dropLast())
-        }
         self.rootFolder = URL(fileURLWithPath: rootFolder)
         fileIO = .init(application: application)
         self.cacheControl = cacheControl
         self.searchForIndexHtml = searchForIndexHtml
 
-        application.logger.info("FileMiddleware serving from \(rootFolder)")
+        let workingFolder: String
+        if rootFolder.first == "/" {
+            workingFolder = ""
+        } else {
+            if let cwd = getcwd(nil, Int(PATH_MAX)) {
+                workingFolder = String(cString: cwd) + "/"
+                free(cwd)
+            } else {
+                workingFolder = "./"
+            }
+        }
+        application.logger.info("FileMiddleware serving from \(workingFolder)\(rootFolder)")
     }
 
     public func apply(to request: HBRequest, next: HBResponder) -> EventLoopFuture<HBResponse> {

--- a/Sources/HummingbirdFoundation/Files/FileMiddleware.swift
+++ b/Sources/HummingbirdFoundation/Files/FileMiddleware.swift
@@ -45,7 +45,7 @@ public struct HBFileMiddleware: HBMiddleware {
         application: HBApplication
     ) {
         self.rootFolder = URL(fileURLWithPath: rootFolder)
-        fileIO = .init(application: application)
+        self.fileIO = .init(application: application)
         self.cacheControl = cacheControl
         self.searchForIndexHtml = searchForIndexHtml
 
@@ -130,7 +130,8 @@ public struct HBFileMiddleware: HBMiddleware {
             }
             // verify if-modified-since
             else if let ifModifiedSince = request.headers["if-modified-since"].first,
-                    let modificationDate = modificationDate {
+                    let modificationDate = modificationDate
+            {
                 if let ifModifiedSinceDate = HBDateCache.rfc1123Formatter.date(from: ifModifiedSince) {
                     // round modification date of file down to seconds for comparison
                     let modificationDateTimeInterval = modificationDate.timeIntervalSince1970.rounded(.down)

--- a/Tests/HummingbirdTests/ConnectionPoolTests.swift
+++ b/Tests/HummingbirdTests/ConnectionPoolTests.swift
@@ -172,7 +172,7 @@ final class ConnectionPoolTests: XCTestCase {
                     // close connection
                     c.isClosed = true
                     return pool.request(logger: Self.logger)
-                }.map { _ -> Void in
+                }.map { _ in
                     XCTAssertEqual(ConnectionCounter.deletedCounter, 1)
                     XCTAssertEqual(ConnectionCounter.counter, 2)
                 }.flatMap { () -> EventLoopFuture<Void> in


### PR DESCRIPTION
I was trying to load files from a bundle of files passed to a test suite. In my server setup I had this middleware:

```swift
let configuration = HBApplication.Configuration()
let server = HBApplication(configuration: configuration)
server.middleware.add(HBFileMiddleware(Bundle.testData.filePath.absoluteString, application: server))
try server.start()
```

However whenever I requested a file from the `testData` bundle `HBFileMiddleware` failed to find it. 

I debugged through and found that the string based root folder was being set to a `file:///...` path which was not understood by the file code attempting to load the file. 

This PR:

* Converts `rootFolder` to be a file URL instead of a string.
* Updates usage of `rootFolder` based on it now being a URL. ie. `rootFolder.relativePath`.
* Removes checking for a trailing `/` which is no longer needed. 

### Testing

After the code change all Hummingbird test ran green without change.