### PR TITLE
Replacing future wait with run loop

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -134,7 +134,7 @@ public final class HBApplication: HBExtensible {
         }
 
         let loop = RunLoop.current
-        while shouldKeepRunning && loop.run(mode: .default, before: Date()) {}
+        while shouldKeepRunning, loop.run(mode: .default, before: Date()) {}
 
         if let error = startError {
             self.logger.error("Failed starting HummingBird: \(error)")

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import HummingbirdCore
 import Lifecycle
 import LifecycleNIOCompat
@@ -19,7 +20,6 @@ import Logging
 import NIOCore
 import NIOPosix
 import NIOTransportServices
-import Foundation
 
 /// Application class. Brings together all the components of Hummingbird together
 ///
@@ -125,7 +125,6 @@ public final class HBApplication: HBExtensible {
 
     /// Run application
     public func start() throws {
-
         var shouldKeepRunning = true
         var startError: Error?
         self.lifecycle.start { error in


### PR DESCRIPTION
Pursuant to the discussion in https://github.com/hummingbird-project/hummingbird/issues/132 I messed about to see if I could come up with something that would allow the future to resolve and the current thread to release. 

The NIO API doco actually suggests that using `.wait()` might not be a good idea so I decided to try replacing the promise/future with run loop execution. It worked, allowing the `.start()` function to throw an error if the port was not available both iOS and OSX.

However, I'm not an expert in the the NIO code or all the depths of multithreading at that level so whilst this solutions works, it may not be the best one.

All tests were run and green with this code.