### PR TITLE
Swapping out event loop group for OS X

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -86,11 +86,11 @@ public final class HBApplication: HBExtensible {
         self.eventLoopGroupProvider = eventLoopGroupProvider
         switch eventLoopGroupProvider {
         case .createNew:
-            #if os(iOS)
-            self.eventLoopGroup = NIOTSEventLoopGroup()
-            #else
-            self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-            #endif
+            if #available(macOS 10.14, iOS 12.0, *) {
+                self.eventLoopGroup = NIOTSEventLoopGroup()
+            } else {
+                self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            }
         case .shared(let elg):
             self.eventLoopGroup = elg
         }


### PR DESCRIPTION
This is an alternative I just figured out. It replaces the `MultiThreadedEventLoopGroup` with a `NIOTSEventLoopGroup` for OSX >= 10.14. 

A lingering thought though is will this bug still be present on Linux? Because I have someone who wants to use this on a linux machine.