### PR TITLE
Use a semaphore instead of an EventLoopPromise in start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           - 'swift:5.4'
           - 'swift:5.5'
           - 'swift:5.6'
+          - 'swiftlang/swift:nightly-5.7-focal'
     
     container:
       image: ${{ matrix.image }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-/.build
+.build/
 /.swiftpm
 /.vscode
 /.devcontainer

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Dispatch
 import HummingbirdCore
 import Lifecycle
 import LifecycleNIOCompat
@@ -124,17 +125,15 @@ public final class HBApplication: HBExtensible {
 
     /// Run application
     public func start() throws {
-        let promise = self.eventLoopGroup.next().makePromise(of: Void.self)
+    var startError: Error?
+        let startSemaphore = DispatchSemaphore(value: 0)
+
         self.lifecycle.start { error in
-            if let error = error {
-                self.logger.error("Failed starting HummingBird: \(error)")
-                promise.fail(error)
-            } else {
-                self.logger.info("HummingBird started successfully")
-                promise.succeed(())
-            }
+            startError = error
+            startSemaphore.signal()
         }
-        try promise.futureResult.wait()
+        startSemaphore.wait()
+        try startError.map { throw $0 }
     }
 
     /// wait while server is running

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -125,7 +125,7 @@ public final class HBApplication: HBExtensible {
 
     /// Run application
     public func start() throws {
-    var startError: Error?
+        var startError: Error?
         let startSemaphore = DispatchSemaphore(value: 0)
 
         self.lifecycle.start { error in


### PR DESCRIPTION
This fixes a hang, where if start fails and the lifecycle is shutdown. The eventloopgroup is shutdown while we are waiting on result from one of the eventloops in the group