### PR TITLE
Support multiple query values with same key

### DIFF
--- a/Sources/Hummingbird/HTTP/URL.swift
+++ b/Sources/Hummingbird/HTTP/URL.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2022 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -139,7 +139,7 @@ extension HBParameters {
     /// - Parameter query: parser holding query strings
     init(fromQuery query: HBParser?) {
         guard var query = query else {
-            self.parameters = [:]
+            self.parameters = .init()
             return
         }
         let queries: [HBParser] = query.split(separator: "&")
@@ -158,7 +158,7 @@ extension HBParameters {
                 return (key: query.string[...], value: "")
             }
         }
-        self.parameters = [Substring: Substring].init(queryKeyValues) { lhs, _ in lhs }
+        self.parameters = .init(queryKeyValues)
     }
 }
 

--- a/Sources/Hummingbird/Router/Parameters.swift
+++ b/Sources/Hummingbird/Router/Parameters.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2022 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,10 +14,11 @@
 
 /// Store for parameters key, value pairs extracted from URI
 public struct HBParameters {
-    internal var parameters: [Substring: Substring]
+    public typealias Collection = FlatDictionary<Substring, Substring>
+    internal var parameters: Collection
 
     init() {
-        self.parameters = [:]
+        self.parameters = .init()
     }
 
     /// Return parameter with specified id
@@ -56,6 +57,33 @@ public struct HBParameters {
         return result
     }
 
+    /// Return parameter with specified id
+    /// - Parameter s: parameter id
+    public func getAll(_ s: String) -> [String] {
+        return self.parameters.getAll(for: s[...]).map { String($0) }
+    }
+
+    /// Return parameter with specified id as a certain type
+    /// - Parameters:
+    ///   - s: parameter id
+    ///   - as: type we want returned
+    public func getAll<T: LosslessStringConvertible>(_ s: String, as: T.Type) -> [T] {
+        return self.parameters.getAll(for: s[...]).compactMap { T(String($0)) }
+    }
+
+    /// Return parameter with specified id as a certain type
+    /// - Parameters:
+    ///   - s: parameter id
+    ///   - as: type we want returned
+    public func requireAll<T: LosslessStringConvertible>(_ s: String, as: T.Type) throws -> [T] {
+        return try self.parameters.getAll(for: s[...]).compactMap {
+            guard let result = T(String($0)) else {
+                throw HBHTTPError(.badRequest)
+            }
+            return result
+        }
+    }
+
     /// Set parameter
     /// - Parameters:
     ///   - s: parameter id
@@ -74,10 +102,10 @@ public struct HBParameters {
 }
 
 extension HBParameters: Collection {
-    public typealias Index = Dictionary<Substring, Substring>.Index
+    public typealias Index = Collection.Index
     public var startIndex: Index { self.parameters.startIndex }
     public var endIndex: Index { self.parameters.endIndex }
-    public subscript(_ index: Index) -> Dictionary<Substring, Substring>.Element { return self.parameters[index] }
+    public subscript(_ index: Index) -> Collection.Element { return self.parameters[index] }
     public func index(after index: Index) -> Index { self.parameters.index(after: index) }
 }
 

--- a/Sources/Hummingbird/Utils/FlatDictionary.swift
+++ b/Sources/Hummingbird/Utils/FlatDictionary.swift
@@ -1,0 +1,118 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2022 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Provides Dictionary like indexing, but uses a flat array of key
+/// value pairs, plus an array of hash keys for lookup for storage.
+/// Useful for dictionary lookup on small collection that don't need
+/// a tree lookup to optimise indexing.
+///
+/// The FlatDictionary also allows for key clashes. Standard lookup
+/// functions will always return the first key found, but it you
+/// iterate through the key,value pairs you can access all values
+/// for a key
+public struct FlatDictionary<Key: Hashable, Value>: Collection {
+    public typealias Element = (key: Key, value: Value)
+    public typealias Index = Array<Element>.Index
+
+    // MARK: Collection requirements
+
+    /// The position of the first element
+    public var startIndex: Index { self.elements.startIndex }
+    /// The position of the element just after the last element
+    public var endIndex: Index { self.elements.endIndex }
+    /// Access element at specific position
+    public subscript(_ index: Index) -> Element { return self.elements[index] }
+    /// Returns the index immediately after the given index
+    public func index(after index: Index) -> Index { self.elements.index(after: index) }
+
+    /// Create a new FlatDictionary
+    public init() {
+        self.elements = []
+        self.hashKeys = []
+    }
+
+    /// Create a new FlatDictionary initialized with a dictionary literal
+    public init(dictionaryLiteral elements: (Key, Value)...) {
+        self.elements = elements.map { (key: $0.0, value: $0.1) }
+        self.hashKeys = elements.map {
+            Self.hashKey($0.0)
+        }
+    }
+
+    /// Create a new FlatDictionary from an array of key value pairs
+    public init(_ values: [(key: Key, value: Value)]) {
+        self.elements = values
+        self.hashKeys = values.map {
+            Self.hashKey($0.key)
+        }
+    }
+
+    /// Access the value associated with a given key for reading and writing
+    ///
+    /// Because FlatDictionary allows for key clashes this function will
+    /// return the first entry in the array with the associated key
+    public subscript(_ key: Key) -> Value? {
+        get {
+            let hashKey = Self.hashKey(key)
+            if let index = hashKeys.firstIndex(of: hashKey) {
+                return self.elements[index].value
+            } else {
+                return nil
+            }
+        }
+        set {
+            let hashKey = Self.hashKey(key)
+            if let index = hashKeys.firstIndex(of: hashKey) {
+                if let newValue = newValue {
+                    self.elements[index].value = newValue
+                } else {
+                    self.elements.remove(at: index)
+                    self.hashKeys.remove(at: index)
+                }
+            } else if let newValue = newValue {
+                self.elements.append((key: key, value: newValue))
+                self.hashKeys.append(hashKey)
+            }
+        }
+    }
+
+    /// Return all the values, associated with a given key
+    public func getAll(for key: Key) -> [Value] {
+        var values: [Value] = []
+        let hashKey = Self.hashKey(key)
+
+        for hashIndex in 0..<self.hashKeys.count {
+            if self.hashKeys[hashIndex] == hashKey {
+                values.append(self.elements[hashIndex].value)
+            }
+        }
+        return values
+    }
+
+    /// Append a new key value pair to the list of key value pairs
+    public mutating func append(key: Key, value: Value) {
+        let hashKey = Self.hashKey(key)
+        self.elements.append((key: key, value: value))
+        self.hashKeys.append(hashKey)
+    }
+
+    private static func hashKey(_ key: Key) -> Int {
+        var hasher = Hasher()
+        hasher.combine(key)
+        return hasher.finalize()
+    }
+
+    private var elements: [Element]
+    private var hashKeys: [Int]
+}

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -157,6 +157,22 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
+    func testMultipleQueriesRoute() throws {
+        let app = HBApplication(testing: .embedded)
+        app.router.post("/add") { request -> String in
+            return request.uri.queryParameters.getAll("value", as: Int.self).reduce(0,+).description
+        }
+        try app.XCTStart()
+        defer { app.XCTStop() }
+
+        app.XCTExecute(uri: "/add?value=3&value=45&value=7", method: .POST) { response in
+            var body = try XCTUnwrap(response.body)
+            let string = body.readString(length: body.readableBytes)
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(string, "55")
+        }
+    }
+
     func testArray() throws {
         let app = HBApplication(testing: .embedded)
         app.router.get("array") { _ -> [String] in


### PR DESCRIPTION
Add FlatDictionary to store query values, which supports storing multiple values for the same key. Use this in HBParameters.