### PR TITLE
Use ComponentLifecycle in HBApplication

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -39,7 +39,7 @@ public final class HBApplication: HBExtensible {
     // MARK: Member variables
 
     /// server lifecycle, controls initialization and shutdown of application
-    public let lifecycle: ServiceLifecycle
+    public let lifecycle: ComponentLifecycle
     /// event loop group used by application
     public let eventLoopGroup: EventLoopGroup
     /// thread pool used by application
@@ -75,7 +75,7 @@ public final class HBApplication: HBExtensible {
         logger.logLevel = configuration.logLevel
         self.logger = logger
 
-        self.lifecycle = ServiceLifecycle(configuration: .init(logger: self.logger))
+        self.lifecycle = ComponentLifecycle(label: logger.label, logger: logger)
         self.middleware = HBMiddlewareGroup()
         self.router = TrieRouter()
         self.configuration = configuration

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -39,7 +39,7 @@ public final class HBApplication: HBExtensible {
     // MARK: Member variables
 
     /// server lifecycle, controls initialization and shutdown of application
-    public let lifecycle: ComponentLifecycle
+    public let lifecycle: ServiceLifecycle
     /// event loop group used by application
     public let eventLoopGroup: EventLoopGroup
     /// thread pool used by application
@@ -69,13 +69,13 @@ public final class HBApplication: HBExtensible {
     /// Initialize new Application
     public init(
         configuration: HBApplication.Configuration = HBApplication.Configuration(),
-        eventLoopGroupProvider: NIOEventLoopGroupProvider = .createNew
+        eventLoopGroupProvider: NIOEventLoopGroupProvider = .createNew,
+        serviceLifecycleProvider: ServiceLifecycleProvider = .createNew
     ) {
         var logger = Logger(label: configuration.serverName ?? "HummingBird")
         logger.logLevel = configuration.logLevel
         self.logger = logger
 
-        self.lifecycle = ComponentLifecycle(label: logger.label, logger: logger)
         self.middleware = HBMiddlewareGroup()
         self.router = TrieRouter()
         self.configuration = configuration
@@ -95,6 +95,22 @@ public final class HBApplication: HBExtensible {
         case .shared(let elg):
             self.eventLoopGroup = elg
         }
+
+        // create lifecycle
+        let lifecycle: LifecycleTasksContainer
+
+        switch serviceLifecycleProvider {
+        case .shared(let parentLifecycle):
+            self.lifecycle = parentLifecycle
+            let componentLifecycle = ComponentLifecycle(label: self.logger.label, logger: self.logger)
+            lifecycle = componentLifecycle
+            self.lifecycle.register(componentLifecycle)
+        case .createNew:
+            let serviceLifecycle = ServiceLifecycle(configuration: .init(logger: self.logger))
+            lifecycle = serviceLifecycle
+            self.lifecycle = serviceLifecycle
+        }
+
         self.threadPool = NIOThreadPool(numberOfThreads: configuration.threadPoolSize)
         self.threadPool.start()
 
@@ -103,17 +119,17 @@ public final class HBApplication: HBExtensible {
         self.addEventLoopStorage()
 
         // register application shutdown with lifecycle
-        self.lifecycle.registerShutdown(
+        lifecycle.registerShutdown(
             label: "Application", .sync(self.shutdownApplication)
         )
 
-        self.lifecycle.registerShutdown(
+        lifecycle.registerShutdown(
             label: "DateCache", .eventLoopFuture { HBDateCache.shutdownDateCaches(eventLoopGroup: self.eventLoopGroup) }
         )
 
         // register server startup and shutdown with lifecycle
         if !configuration.noHTTPServer {
-            self.lifecycle.register(
+            lifecycle.register(
                 label: "HTTP Server",
                 start: .eventLoopFuture { self.server.start(responder: HTTPResponder(application: self)) },
                 shutdown: .eventLoopFuture(self.server.stop)

--- a/Sources/Hummingbird/Lifecycle/ServiceLifecycleProvider.swift
+++ b/Sources/Hummingbird/Lifecycle/ServiceLifecycleProvider.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2021 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Lifecycle
+
+public enum ServiceLifecycleProvider {
+    /// Use a `ServiceLifecycle` provided by the user
+    /// and run `HBApplication` tasks in a `ComponentLifecycle`.
+    case shared(ServiceLifecycle)
+
+    /// Create a new `ServiceLifecycle`.
+    case createNew
+}

--- a/Sources/Hummingbird/Lifecycle/ServiceLifecycleProvider.swift
+++ b/Sources/Hummingbird/Lifecycle/ServiceLifecycleProvider.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2022 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information


### PR DESCRIPTION
In my server applications I usually have two servers running, one for the public API of a service and one for the admin API (e.g. to expose a `/metrics` route), but I still want them to run in the same process/container. I'd like to be able to use `ServiceLifecycle` to pull them all together but that's currently not possible since `HBApplication` creates its own top-level lifecycle. If we were to use `ComponentLifecycle` instead, an `HBApplication` and all its lifecycle tasks could be registered as a subcomponent of a larger lifecycle, which could look like this:

```swift
let lifecycle = ServiceLifecycle()

let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
lifecycle.registerShutdown(label: "event-loop-group", .async(eventLoopGroup.shutdownGracefully))

let publicApp = HBApplication(
    configuration: .init(
        address: .hostname(options.host, port: Int(options.publicPort)),
        serverName: "Example API",
        logLevel: options.logLevel
    ),
    eventLoopGroupProvider: .shared(eventLoopGroup)
)
lifecycle.register(publicApp.lifecycle)

let adminApp = HBApplication(
    configuration: .init(
        address: .hostname(options.host, port: Int(options.adminPort)),
        serverName: "Example API [Admin]",
        logLevel: options.logLevel
    ),
    eventLoopGroupProvider: .shared(eventLoopGroup)
)
lifecycle.register(adminApp.lifecycle)

try lifecycle.startAndWait()
```