### PR TITLE
Add new test setup `.asyncTest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
           - 'swift:5.4'
           - 'swift:5.5'
           - 'swift:5.6'
-          - 'swiftlang/swift:nightly-5.7-focal'
+          - 'swift:5.7'
+          - 'swiftlang/swift:nightly-focal'
     
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'swift:5.4'
           - 'swift:5.5'
           - 'swift:5.6'
           - 'swift:5.7'    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,7 @@ jobs:
           - 'swift:5.4'
           - 'swift:5.5'
           - 'swift:5.6'
-          - 'swift:5.7'
-          - 'swiftlang/swift:nightly-focal'
-    
+          - 'swift:5.7'    
     container:
       image: ${{ matrix.image }}
     steps:

--- a/Sources/Hummingbird/Configuration.swift
+++ b/Sources/Hummingbird/Configuration.swift
@@ -56,7 +56,7 @@ extension HBApplication {
         // MARK: Initialization
 
         /// Initialize HBApplication configuration
-        /// 
+        ///
         /// - Parameters:
         ///   - address: Bind address for server
         ///   - serverName: Server name to return in "server" header
@@ -111,7 +111,7 @@ extension HBApplication {
 
         #if canImport(Network)
         /// Initialize HBApplication configuration
-        /// 
+        ///
         /// - Parameters:
         ///   - address: Bind address for server
         ///   - serverName: Server name to return in "server" header

--- a/Sources/HummingbirdXCT/Application+XCT.swift
+++ b/Sources/HummingbirdXCT/Application+XCT.swift
@@ -59,18 +59,18 @@ extension HBApplication {
     /// - Parameters:
     ///   - testing: indicates which type of testing framework we want
     ///   - configuration: configuration of application
-    public convenience init(testing: XCTTestingSetup, configuration: HBApplication.Configuration = .init()) {
+    public convenience init(testing: XCTTestingSetup, configuration: HBApplication.Configuration = .init(), timeout: TimeAmount = .seconds(15)) {
         let xct: HBXCT
         let configuration = configuration.with(address: .hostname("localhost", port: 0))
         switch testing {
         case .embedded:
             xct = HBXCTEmbedded()
         case .live:
-            xct = HBXCTLive(configuration: configuration)
+            xct = HBXCTLive(configuration: configuration, timeout: timeout)
         case .asyncTest:
             #if compiler(>=5.5.2) && canImport(_Concurrency)
             if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
-                xct = HBXCTAsyncTesting()
+                xct = HBXCTAsyncTesting(timeout: timeout)
             } else {
                 fatalError("XCTTestingSetup.asyncTest is not supported on your platform")
             }

--- a/Sources/HummingbirdXCT/Application+XCT.swift
+++ b/Sources/HummingbirdXCT/Application+XCT.swift
@@ -70,7 +70,7 @@ extension HBApplication {
         case .asyncTest:
             #if compiler(>=5.5.2) && canImport(_Concurrency)
             if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
-                xct = HBXCTAsyncEmbedded()
+                xct = HBXCTAsyncTesting()
             } else {
                 fatalError("XCTTestingSetup.asyncTest is not supported on your platform")
             }

--- a/Sources/HummingbirdXCT/Application+XCT.swift
+++ b/Sources/HummingbirdXCT/Application+XCT.swift
@@ -46,6 +46,8 @@ extension HBApplication {
     public enum XCTTestingSetup {
         /// Test using `EmbeddedChannel`. If you have routes that use multi-threading this will probably fail
         case embedded
+        /// Test using `NIOAsyncTestingChannel`.
+        case asyncTest
         /// Test using live server
         case live
     }
@@ -65,6 +67,17 @@ extension HBApplication {
             xct = HBXCTEmbedded()
         case .live:
             xct = HBXCTLive(configuration: configuration)
+        case .asyncTest:
+            #if compiler(>=5.5.2) && canImport(_Concurrency)
+            if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+                xct = HBXCTAsyncEmbedded()
+            } else {
+                fatalError("XCTTestingSetup.asyncTest is not supported on your platform")
+            }
+            #else
+            fatalError("XCTTestingSetup.asyncTest is not supported by version of Swift earlier than 5.5.2")
+            xct = HBXCTEmbedded()
+            #endif
         }
         self.init(configuration: configuration, eventLoopGroupProvider: .shared(xct.eventLoopGroup))
         self.extensions.set(\.xct, value: xct)

--- a/Sources/HummingbirdXCT/HBXCT.swift
+++ b/Sources/HummingbirdXCT/HBXCT.swift
@@ -34,6 +34,7 @@ struct HBXCTError: Error, Equatable {
         case noEnd
         case timeout
     }
+
     private let value: _Internal
     private init(_ value: _Internal) {
         self.value = value

--- a/Sources/HummingbirdXCT/HBXCT.swift
+++ b/Sources/HummingbirdXCT/HBXCT.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Hummingbird
+import NIOCore
 
 /// Response structure returned by XCT testing framework
 public struct HBXCTResponse {
@@ -25,11 +26,24 @@ public struct HBXCTResponse {
 }
 
 /// Errors thrown by XCT framework.
-enum HBXCTError: Error {
-    case notStarted
-    case noHead
-    case illegalBody
-    case noEnd
+struct HBXCTError: Error, Equatable {
+    private enum _Internal {
+        case notStarted
+        case noHead
+        case illegalBody
+        case noEnd
+        case timeout
+    }
+    private let value: _Internal
+    private init(_ value: _Internal) {
+        self.value = value
+    }
+
+    static var notStarted: Self { .init(.notStarted) }
+    static var noHead: Self { .init(.noHead) }
+    static var illegalBody: Self { .init(.illegalBody) }
+    static var noEnd: Self { .init(.noEnd) }
+    static var timeout: Self { .init(.timeout) }
 }
 
 /// Protocol for XCT framework.

--- a/Sources/HummingbirdXCT/HBXCTAsyncEmbedded.swift
+++ b/Sources/HummingbirdXCT/HBXCTAsyncEmbedded.swift
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2021 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+
+import Hummingbird
+import NIOCore
+import NIOEmbedded
+import NIOHTTP1
+import XCTest
+
+/// Test application by running on an EmbeddedChannel
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+struct HBXCTAsyncEmbedded: HBXCT {
+    init() {
+        self.asyncTestingChannel = .init()
+        self.testingEventLoop = self.asyncTestingChannel.testingEventLoop
+    }
+
+    /// Start tests
+    func start(application: HBApplication) {
+        application.server.addChannelHandler(BreakupHTTPBodyChannelHandler())
+        XCTAssertNoThrow(
+            try self.asyncTestingChannel.pipeline.addHandlers(
+                application.server.getChildChannelHandlers(responder: HBApplication.HTTPResponder(application: application))
+            ).wait()
+        )
+    }
+
+    /// EventLoop version of stop
+    func stop(application: HBApplication) {
+        let promise = self.testingEventLoop.makePromise(of: Void.self)
+        promise.completeWithTask {
+            try await self._stop(application: application)
+        }
+        try? promise.futureResult.wait()
+    }
+
+    /// Stop tests
+    func _stop(application: HBApplication) async throws {
+        do {
+            try application.shutdownApplication()
+            _ = try await self.asyncTestingChannel.finish()
+            try self.testingEventLoop.syncShutdownGracefully()
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func execute(
+        uri: String,
+        method: HTTPMethod,
+        headers: HTTPHeaders = [:],
+        body: ByteBuffer? = nil
+    ) -> EventLoopFuture<HBXCTResponse> {
+        let promise = self.testingEventLoop.makePromise(of: HBXCTResponse.self)
+        promise.completeWithTask {
+            try await self._execute(uri: uri, method: method, headers: headers, body: body)
+        }
+        return promise.futureResult
+    }
+
+    /// Send request and call test callback on the response returned
+    func _execute(
+        uri: String,
+        method: HTTPMethod,
+        headers: HTTPHeaders,
+        body: ByteBuffer?
+    ) async throws -> HBXCTResponse {
+        do {
+            // write request
+            let requestHead = HTTPRequestHead(version: .init(major: 1, minor: 1), method: method, uri: uri, headers: headers)
+            try await writeInbound(.head(requestHead))
+            if let body = body {
+                try await self.writeInbound(.body(body))
+            }
+            try await self.writeInbound(.end(nil))
+
+            await self.asyncTestingChannel.testingEventLoop.run()
+
+            // read response
+            guard case .head(let head) = try await readOutbound() else { throw HBXCTError.noHead }
+            var next = try await readOutbound()
+            var buffer = self.asyncTestingChannel.allocator.buffer(capacity: 0)
+            while case .body(let part) = next {
+                guard case .byteBuffer(var b) = part else { throw HBXCTError.illegalBody }
+                buffer.writeBuffer(&b)
+                next = try await readOutbound()
+            }
+            guard case .end = next else { throw HBXCTError.noEnd }
+
+            return .init(status: head.status, headers: head.headers, body: buffer)
+        }
+    }
+
+    var eventLoopGroup: EventLoopGroup { return self.testingEventLoop }
+
+    func writeInbound(_ part: HTTPServerRequestPart) async throws {
+        try await self.asyncTestingChannel.writeInbound(part)
+    }
+
+    func readOutbound() async throws -> HTTPServerResponsePart? {
+        return try await self.asyncTestingChannel.readOutbound(as: HTTPServerResponsePart.self)
+    }
+
+    let asyncTestingChannel: NIOAsyncTestingChannel
+    let testingEventLoop: NIOAsyncTestingEventLoop
+}
+
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/HummingbirdXCT/HBXCTAsyncTesting.swift
+++ b/Sources/HummingbirdXCT/HBXCTAsyncTesting.swift
@@ -129,4 +129,9 @@ struct HBXCTAsyncTesting: HBXCT {
     let timeout: TimeAmount
 }
 
+// to get this to compile with Swift 5.5 we need to conform `IOData`` to `Sendable``
+#if compiler(<5.6)
+extension IOData: @unchecked Sendable {}
+#endif
+
 #endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -22,19 +22,25 @@ import XCTest
 
 /// Test using a live server and AsyncHTTPClient
 class HBXCTLive: HBXCT {
-    init(configuration: HBApplication.Configuration) {
+    init(configuration: HBApplication.Configuration, timeout: TimeAmount) {
         #if os(iOS)
         self.eventLoopGroup = NIOTSEventLoopGroup()
         #else
         self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         #endif
+        self.timeout = timeout
     }
 
     /// Start tests
     func start(application: HBApplication) throws {
         do {
             try application.start()
-            let client = HBXCTClient(host: "localhost", port: application.server.port!, eventLoopGroupProvider: .createNew)
+            let client = HBXCTClient(
+                host: "localhost", 
+                port: application.server.port!, 
+                configuration: .init(timeout: self.timeout), 
+                eventLoopGroupProvider: .createNew
+            )
             client.connect()
             self.client = client
         } catch {
@@ -74,4 +80,5 @@ class HBXCTLive: HBXCT {
 
     let eventLoopGroup: EventLoopGroup
     var client: HBXCTClient?
+    let timeout: TimeAmount
 }

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -36,9 +36,9 @@ class HBXCTLive: HBXCT {
         do {
             try application.start()
             let client = HBXCTClient(
-                host: "localhost", 
-                port: application.server.port!, 
-                configuration: .init(timeout: self.timeout), 
+                host: "localhost",
+                port: application.server.port!,
+                configuration: .init(timeout: self.timeout),
                 eventLoopGroupProvider: .createNew
             )
             client.connect()

--- a/Tests/HummingbirdFoundationTests/FileTests+async.swift
+++ b/Tests/HummingbirdFoundationTests/FileTests+async.swift
@@ -33,7 +33,7 @@ class HummingbirdAsyncFilesTests: XCTestCase {
         // disable macOS tests in CI. GH Actions are currently running this when they shouldn't
         guard HBEnvironment().get("CI") != "true" else { throw XCTSkip() }
         #endif
-        let app = HBApplication(testing: .live)
+        let app = HBApplication(testing: .asyncTest)
         app.router.get("test.jpg") { request -> HBResponse in
             let fileIO = HBFileIO(application: request.application)
             let body = try await fileIO.loadFile(path: "test.jpg", context: request.context, logger: request.logger)
@@ -59,7 +59,7 @@ class HummingbirdAsyncFilesTests: XCTestCase {
         guard HBEnvironment().get("CI") != "true" else { throw XCTSkip() }
         #endif
         let filename = "testWrite.txt"
-        let app = HBApplication(testing: .live)
+        let app = HBApplication(testing: .asyncTest)
         app.router.put("store") { request -> HTTPResponseStatus in
             let fileIO = HBFileIO(application: request.application)
             try await fileIO.writeFile(

--- a/Tests/HummingbirdTests/AsyncAwaitTests.swift
+++ b/Tests/HummingbirdTests/AsyncAwaitTests.swift
@@ -109,7 +109,7 @@ final class AsyncAwaitTests: XCTestCase {
         // disable macOS tests in CI. GH Actions are currently running this when they shouldn't
         guard HBEnvironment().get("CI") != "true" else { throw XCTSkip() }
         #endif
-        let app = HBApplication(testing: .asyncTest)
+        let app = HBApplication(testing: .live)
         app.router.post("size", options: .streamBody) { request -> String in
             guard let stream = request.body.stream else {
                 throw HBHTTPError(.badRequest)

--- a/Tests/HummingbirdTests/AsyncAwaitTests.swift
+++ b/Tests/HummingbirdTests/AsyncAwaitTests.swift
@@ -109,7 +109,7 @@ final class AsyncAwaitTests: XCTestCase {
         // disable macOS tests in CI. GH Actions are currently running this when they shouldn't
         guard HBEnvironment().get("CI") != "true" else { throw XCTSkip() }
         #endif
-        let app = HBApplication(testing: .live)
+        let app = HBApplication(testing: .asyncTest)
         app.router.post("size", options: .streamBody) { request -> String in
             guard let stream = request.body.stream else {
                 throw HBHTTPError(.badRequest)

--- a/Tests/HummingbirdTests/AsyncAwaitTests.swift
+++ b/Tests/HummingbirdTests/AsyncAwaitTests.swift
@@ -36,7 +36,7 @@ final class AsyncAwaitTests: XCTestCase {
         // disable macOS tests in CI. GH Actions are currently running this when they shouldn't
         guard HBEnvironment().get("CI") != "true" else { throw XCTSkip() }
         #endif
-        let app = HBApplication(testing: .live)
+        let app = HBApplication(testing: .asyncTest)
         app.router.get("/hello") { request -> ByteBuffer in
             return await self.getBuffer(request: request)
         }
@@ -63,7 +63,7 @@ final class AsyncAwaitTests: XCTestCase {
                 return response
             }
         }
-        let app = HBApplication(testing: .live)
+        let app = HBApplication(testing: .asyncTest)
         app.middleware.add(AsyncTestMiddleware())
         app.router.get("/hello") { _ -> String in
             "hello"
@@ -91,7 +91,7 @@ final class AsyncAwaitTests: XCTestCase {
                 return try await request.success("Hello \(self.name)").get()
             }
         }
-        let app = HBApplication(testing: .live)
+        let app = HBApplication(testing: .asyncTest)
         app.router.post("/hello/:name", use: AsyncTest.self)
 
         try app.XCTStart()
@@ -109,7 +109,7 @@ final class AsyncAwaitTests: XCTestCase {
         // disable macOS tests in CI. GH Actions are currently running this when they shouldn't
         guard HBEnvironment().get("CI") != "true" else { throw XCTSkip() }
         #endif
-        let app = HBApplication(testing: .live)
+        let app = HBApplication(testing: .asyncTest)
         app.router.post("size", options: .streamBody) { request -> String in
             guard let stream = request.body.stream else {
                 throw HBHTTPError(.badRequest)

--- a/Tests/HummingbirdTests/PersistTests+async.swift
+++ b/Tests/HummingbirdTests/PersistTests+async.swift
@@ -20,7 +20,7 @@ import XCTest
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class AsyncPersistTests: XCTestCase {
     func createApplication() throws -> HBApplication {
-        let app = HBApplication(testing: .asyncTest)
+        let app = HBApplication(testing: .live)
         // add persist
         app.addPersist(using: .memory)
 

--- a/Tests/HummingbirdTests/PersistTests+async.swift
+++ b/Tests/HummingbirdTests/PersistTests+async.swift
@@ -20,7 +20,7 @@ import XCTest
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class AsyncPersistTests: XCTestCase {
     func createApplication() throws -> HBApplication {
-        let app = HBApplication(testing: .live)
+        let app = HBApplication(testing: .asyncTest)
         // add persist
         app.addPersist(using: .memory)
 


### PR DESCRIPTION
Makes use of new `NIOAsyncTestingChannel`.
Fixed issues with `NIOAsyncTestingChannel` by temporarily adding a poll for result with timeout
