### PR TITLE
Run router before any middleware

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -44,10 +44,8 @@ public final class HBApplication: HBExtensible {
     public let eventLoopGroup: EventLoopGroup
     /// thread pool used by application
     public let threadPool: NIOThreadPool
-    /// middleware applied to requests
-    public let middleware: HBMiddlewareGroup
     /// routes requests to requestResponders based on URI
-    public var router: HBRouter
+    public var router: HBRouterBuilder
     /// http server
     public var server: HBHTTPServer
     /// Configuration
@@ -76,8 +74,7 @@ public final class HBApplication: HBExtensible {
         logger.logLevel = configuration.logLevel
         self.logger = logger
 
-        self.router = TrieRouter()
-        self.middleware = HBMiddlewareGroup()
+        self.router = HBRouterBuilder()
         self.configuration = configuration
         self.extensions = HBExtensions()
         self.encoder = NullEncoder()
@@ -160,9 +157,12 @@ public final class HBApplication: HBExtensible {
         self.lifecycle.shutdown()
     }
 
+    /// middleware applied to requests
+    public var middleware: HBMiddlewareGroup { return self.router.middlewares }
+
     /// Construct the RequestResponder from the middleware group and router
     public func constructResponder() -> HBResponder {
-        return self.middleware.constructResponder(finalResponder: self.router)
+        return self.router.buildRouter()
     }
 
     /// shutdown eventloop, threadpool and any extensions attached to the Application

--- a/Sources/Hummingbird/AsyncAwaitSupport/Router+async.swift
+++ b/Sources/Hummingbird/AsyncAwaitSupport/Router+async.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -93,7 +93,7 @@ extension HBRouterMethods {
 }
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension HBRouter {
+extension HBRouterBuilder {
     /// Add path for closure returning type conforming to ResponseFutureEncodable
     @discardableResult public func on<Output: HBResponseGenerator>(
         _ path: String,

--- a/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
@@ -17,7 +17,7 @@ public final class HBMiddlewareGroup {
     var middlewares: [HBMiddleware]
 
     /// Initialize `HBMiddlewareGroup`
-    /// 
+    ///
     /// Set middleware array to be empty
     public init() {
         // this is set by WebSocketRouterGroup so this needs to be kept public

--- a/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
@@ -16,7 +16,11 @@
 public final class HBMiddlewareGroup {
     var middlewares: [HBMiddleware]
 
-    init() {
+    /// Initialize `HBMiddlewareGroup`
+    /// 
+    /// Set middleware array to be empty
+    public init() {
+        // this is set by WebSocketRouterGroup so this needs to be kept public
         self.middlewares = []
     }
 
@@ -32,7 +36,7 @@ public final class HBMiddlewareGroup {
     /// Construct responder chain from this middleware group
     /// - Parameter finalResponder: The responder the last middleware calls
     /// - Returns: Responder chain
-    func constructResponder(finalResponder: HBResponder) -> HBResponder {
+    public func constructResponder(finalResponder: HBResponder) -> HBResponder {
         var currentResponser = finalResponder
         for i in (0..<self.middlewares.count).reversed() {
             let responder = MiddlewareResponder(middleware: middlewares[i], next: currentResponser)

--- a/Sources/Hummingbird/Router/EndpointResponder.swift
+++ b/Sources/Hummingbird/Router/EndpointResponder.swift
@@ -23,7 +23,7 @@ final class HBEndpointResponders {
     }
 
     public func getResponder(for method: HTTPMethod) -> HBResponder? {
-        return methods[method.rawValue]
+        return self.methods[method.rawValue]
     }
 
     func addResponder(for method: HTTPMethod, responder: HBResponder) {

--- a/Sources/Hummingbird/Router/EndpointResponder.swift
+++ b/Sources/Hummingbird/Router/EndpointResponder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -15,18 +15,15 @@
 import NIOCore
 import NIOHTTP1
 
-/// Responder that chooses the next responder to call based on the request method
-final class HBEndpointResponder: HBResponder {
+/// Stores endpoint responders for each HTTP method
+final class HBEndpointResponders {
     init(path: String) {
         self.path = path
         self.methods = [:]
     }
 
-    public func respond(to request: HBRequest) -> EventLoopFuture<HBResponse> {
-        guard let responder = methods[request.method.rawValue] else {
-            return request.failure(HBHTTPError(.notFound))
-        }
-        return responder.respond(to: request)
+    public func getResponder(for method: HTTPMethod) -> HBResponder? {
+        return methods[method.rawValue]
     }
 
     func addResponder(for method: HTTPMethod, responder: HBResponder) {

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,75 +12,31 @@
 //
 //===----------------------------------------------------------------------===//
 
-import HummingbirdCore
-import NIOCore
-import NIOHTTP1
-
-/// Directs Requests to handlers based on the request uri.
+/// Directs requests to handlers based on the request uri and method.
 ///
 /// Conforms to `HBResponder` so need to provide its own implementation of
 /// `func apply(to request: Request) -> EventLoopFuture<Response>`.
 ///
-/// `HBRouter` requires an implementation of  the `on(path:method:use)` functions but because it
-/// also conforms to `HBRouterMethods` it is also possible to call the method specific functions `get`, `put`,
-/// `head`, `post` and `patch`.  The route handler closures all return objects conforming to
-/// `HBResponseGenerator`.  This allows us to support routes which return a multitude of types eg
-/// ```
-/// app.router.get("string") { _ -> String in
-///     return "string"
-/// }
-/// app.router.post("status") { _ -> HTTPResponseStatus in
-///     return .ok
-/// }
-/// app.router.data("data") { request -> ByteBuffer in
-///     return request.allocator.buffer(string: "buffer")
-/// }
-/// ```
-/// Routes can also return `EventLoopFuture`'s. So you can support returning values from
-/// asynchronous processes.
-///
-/// The default `Router` setup in `HBApplication` is the `TrieRouter` . This uses a
-/// trie to partition all the routes for faster access. It also supports wildcards and parameter extraction
-/// ```
-/// app.router.get("user/*", use: anyUser)
-/// app.router.get("user/:id", use: userWithId)
-/// ```
-/// Both of these match routes which start with "/user" and the next path segment being anything.
-/// The second version extracts the path segment out and adds it to `HBRequest.parameters` with the
-/// key "id".
-public protocol HBRouter: HBRouterMethods, HBResponder {
-    /// Add router entry
-    func add(_ path: String, method: HTTPMethod, responder: HBResponder)
-}
+struct HBRouter: HBResponder {
+    let trie: RouterPathTrie<HBEndpointResponders>
+    let notFoundResponder: HBResponder
 
-extension HBRouter {
-    /// Add path for closure returning type conforming to ResponseFutureEncodable
-    @discardableResult public func on<Output: HBResponseGenerator>(
-        _ path: String,
-        method: HTTPMethod,
-        options: HBRouterMethodOptions = [],
-        use closure: @escaping (HBRequest) throws -> Output
-    ) -> Self {
-        let responder = constructResponder(options: options, use: closure)
-        add(path, method: method, responder: responder)
-        return self
-    }
-
-    /// Add path for closure returning type conforming to ResponseFutureEncodable
-    @discardableResult public func on<Output: HBResponseGenerator>(
-        _ path: String,
-        method: HTTPMethod,
-        options: HBRouterMethodOptions = [],
-        use closure: @escaping (HBRequest) -> EventLoopFuture<Output>
-    ) -> Self {
-        let responder = constructResponder(options: options, use: closure)
-        add(path, method: method, responder: responder)
-        return self
-    }
-
-    /// return new `RouterGroup`
-    /// - Parameter path: prefix to add to paths inside the group
-    public func group(_ path: String = "") -> HBRouterGroup {
-        return .init(path: path, router: self)
+    /// Respond to request by calling correct handler
+    /// - Parameter request: HTTP request
+    /// - Returns: EventLoopFuture that will be fulfilled with the Response
+    public func respond(to request: HBRequest) -> EventLoopFuture<HBResponse> {
+        let path = request.uri.path
+        guard let result = trie.getValueAndParameters(path),
+            let responder = result.value.getResponder(for: request.method) else {
+                return notFoundResponder.respond(to: request)
+        }
+        var request = request
+        if result.parameters.count > 0 {
+            request.parameters = result.parameters
+        }
+        // store endpoint path in request (mainly for metrics)
+        request.endpointPath = result.value.path
+        return responder.respond(to: request)
     }
 }
+

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -27,8 +27,9 @@ struct HBRouter: HBResponder {
     public func respond(to request: HBRequest) -> EventLoopFuture<HBResponse> {
         let path = request.uri.path
         guard let result = trie.getValueAndParameters(path),
-            let responder = result.value.getResponder(for: request.method) else {
-                return notFoundResponder.respond(to: request)
+              let responder = result.value.getResponder(for: request.method)
+        else {
+            return self.notFoundResponder.respond(to: request)
         }
         var request = request
         if result.parameters.count > 0 {
@@ -39,4 +40,3 @@ struct HBRouter: HBResponder {
         return responder.respond(to: request)
     }
 }
-

--- a/Sources/Hummingbird/Router/RouterBuilder.swift
+++ b/Sources/Hummingbird/Router/RouterBuilder.swift
@@ -43,7 +43,7 @@ import NIOHTTP1
 /// Both of these match routes which start with "/user" and the next path segment being anything.
 /// The second version extracts the path segment out and adds it to `HBRequest.parameters` with the
 /// key "id".
-public struct HBRouterBuilder: HBRouterMethods {
+public final class HBRouterBuilder: HBRouterMethods {
     var trie: RouterPathTrie<HBEndpointResponders>
     public let middlewares: HBMiddlewareGroup
 
@@ -68,7 +68,7 @@ public struct HBRouterBuilder: HBRouterMethods {
     }
 
     /// build router
-    func buildRouter() -> HBRouter {
+    public func buildRouter() -> HBRouter {
         .init(trie: self.trie, notFoundResponder: self.middlewares.constructResponder(finalResponder: NotFoundResponder()))
     }
 

--- a/Sources/Hummingbird/Router/RouterBuilder.swift
+++ b/Sources/Hummingbird/Router/RouterBuilder.swift
@@ -67,9 +67,9 @@ public struct HBRouterBuilder: HBRouterMethods {
         self.trie.getValueAndParameters(path)?.value
     }
 
-    /// build router 
+    /// build router
     func buildRouter() -> HBRouter {
-        .init(trie: trie, notFoundResponder: middlewares.constructResponder(finalResponder: NotFoundResponder()))
+        .init(trie: self.trie, notFoundResponder: self.middlewares.constructResponder(finalResponder: NotFoundResponder()))
     }
 
     /// Add path for closure returning type conforming to ResponseFutureEncodable
@@ -80,7 +80,7 @@ public struct HBRouterBuilder: HBRouterMethods {
         use closure: @escaping (HBRequest) throws -> Output
     ) -> Self {
         let responder = constructResponder(options: options, use: closure)
-        add(path, method: method, responder: responder)
+        self.add(path, method: method, responder: responder)
         return self
     }
 
@@ -92,10 +92,10 @@ public struct HBRouterBuilder: HBRouterMethods {
         use closure: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
         let responder = constructResponder(options: options, use: closure)
-        add(path, method: method, responder: responder)
+        self.add(path, method: method, responder: responder)
         return self
     }
-    
+
     /// return new `RouterGroup`
     /// - Parameter path: prefix to add to paths inside the group
     public func group(_ path: String = "") -> HBRouterGroup {
@@ -109,4 +109,3 @@ struct NotFoundResponder: HBResponder {
         return request.eventLoop.makeFailedFuture(HBHTTPError(.notFound))
     }
 }
-

--- a/Sources/Hummingbird/Router/RouterBuilder.swift
+++ b/Sources/Hummingbird/Router/RouterBuilder.swift
@@ -68,8 +68,8 @@ public final class HBRouterBuilder: HBRouterMethods {
     }
 
     /// build router
-    public func buildRouter() -> HBRouter {
-        .init(trie: self.trie, notFoundResponder: self.middlewares.constructResponder(finalResponder: NotFoundResponder()))
+    public func buildRouter() -> HBResponder {
+        HBRouter(trie: self.trie, notFoundResponder: self.middlewares.constructResponder(finalResponder: NotFoundResponder()))
     }
 
     /// Add path for closure returning type conforming to ResponseFutureEncodable

--- a/Sources/Hummingbird/Router/RouterBuilder.swift
+++ b/Sources/Hummingbird/Router/RouterBuilder.swift
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HummingbirdCore
+import NIOCore
+import NIOHTTP1
+
+/// `HBRouterBuilder` requires an implementation of  the `on(path:method:use)` functions but because it
+/// also conforms to `HBRouterMethods` it is also possible to call the method specific functions `get`, `put`,
+/// `head`, `post` and `patch`.  The route handler closures all return objects conforming to
+/// `HBResponseGenerator`.  This allows us to support routes which return a multitude of types eg
+/// ```
+/// app.router.get("string") { _ -> String in
+///     return "string"
+/// }
+/// app.router.post("status") { _ -> HTTPResponseStatus in
+///     return .ok
+/// }
+/// app.router.data("data") { request -> ByteBuffer in
+///     return request.allocator.buffer(string: "buffer")
+/// }
+/// ```
+/// Routes can also return `EventLoopFuture`'s. So you can support returning values from
+/// asynchronous processes.
+///
+/// The default `Router` setup in `HBApplication` is the `TrieRouter` . This uses a
+/// trie to partition all the routes for faster access. It also supports wildcards and parameter extraction
+/// ```
+/// app.router.get("user/*", use: anyUser)
+/// app.router.get("user/:id", use: userWithId)
+/// ```
+/// Both of these match routes which start with "/user" and the next path segment being anything.
+/// The second version extracts the path segment out and adds it to `HBRequest.parameters` with the
+/// key "id".
+public struct HBRouterBuilder: HBRouterMethods {
+    var trie: RouterPathTrie<HBEndpointResponders>
+    public let middlewares: HBMiddlewareGroup
+
+    public init() {
+        self.trie = RouterPathTrie()
+        self.middlewares = .init()
+    }
+
+    /// Add route to router
+    /// - Parameters:
+    ///   - path: URI path
+    ///   - method: http method
+    ///   - responder: handler to call
+    public func add(_ path: String, method: HTTPMethod, responder: HBResponder) {
+        self.trie.addEntry(.init(path), value: HBEndpointResponders(path: path)) { node in
+            node.value!.addResponder(for: method, responder: middlewares.constructResponder(finalResponder: responder))
+        }
+    }
+
+    func endpoint(_ path: String) -> HBEndpointResponders? {
+        self.trie.getValueAndParameters(path)?.value
+    }
+
+    /// build router 
+    func buildRouter() -> HBRouter {
+        .init(trie: trie, notFoundResponder: middlewares.constructResponder(finalResponder: NotFoundResponder()))
+    }
+
+    /// Add path for closure returning type conforming to ResponseFutureEncodable
+    @discardableResult public func on<Output: HBResponseGenerator>(
+        _ path: String,
+        method: HTTPMethod,
+        options: HBRouterMethodOptions = [],
+        use closure: @escaping (HBRequest) throws -> Output
+    ) -> Self {
+        let responder = constructResponder(options: options, use: closure)
+        add(path, method: method, responder: responder)
+        return self
+    }
+
+    /// Add path for closure returning type conforming to ResponseFutureEncodable
+    @discardableResult public func on<Output: HBResponseGenerator>(
+        _ path: String,
+        method: HTTPMethod,
+        options: HBRouterMethodOptions = [],
+        use closure: @escaping (HBRequest) -> EventLoopFuture<Output>
+    ) -> Self {
+        let responder = constructResponder(options: options, use: closure)
+        add(path, method: method, responder: responder)
+        return self
+    }
+    
+    /// return new `RouterGroup`
+    /// - Parameter path: prefix to add to paths inside the group
+    public func group(_ path: String = "") -> HBRouterGroup {
+        return .init(path: path, router: self)
+    }
+}
+
+/// Responder that return a not found error
+struct NotFoundResponder: HBResponder {
+    func respond(to request: HBRequest) -> NIOCore.EventLoopFuture<HBResponse> {
+        return request.eventLoop.makeFailedFuture(HBHTTPError(.notFound))
+    }
+}
+

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -32,10 +32,10 @@ import NIOHTTP1
 /// ```
 public struct HBRouterGroup: HBRouterMethods {
     let path: String
-    let router: HBRouter
+    let router: HBRouterBuilder
     let middlewares: HBMiddlewareGroup
 
-    init(path: String = "", middlewares: HBMiddlewareGroup = .init(), router: HBRouter) {
+    init(path: String = "", middlewares: HBMiddlewareGroup = .init(), router: HBRouterBuilder) {
         self.path = path
         self.router = router
         self.middlewares = middlewares

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,49 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-
-import HummingbirdCore
-
-/// Route requests to handlers based on request URI. Uses a Trie to select handler
-struct TrieRouter: HBRouter {
-    var trie: RouterPathTrie<HBEndpointResponder>
-
-    public init() {
-        self.trie = RouterPathTrie()
-    }
-
-    /// Add route to router
-    /// - Parameters:
-    ///   - path: URI path
-    ///   - method: http method
-    ///   - responder: handler to call
-    public func add(_ path: String, method: HTTPMethod, responder: HBResponder) {
-        self.trie.addEntry(.init(path), value: HBEndpointResponder(path: path)) { node in
-            node.value!.addResponder(for: method, responder: responder)
-        }
-    }
-
-    func endpoint(_ path: String) -> HBEndpointResponder? {
-        self.trie.getValueAndParameters(path)?.value
-    }
-
-    /// Respond to request by calling correct handler
-    /// - Parameter request: HTTP request
-    /// - Returns: EventLoopFuture that will be fulfilled with the Response
-    public func respond(to request: HBRequest) -> EventLoopFuture<HBResponse> {
-        let path = request.uri.path
-        guard let result = trie.getValueAndParameters(path) else {
-            return request.eventLoop.makeFailedFuture(HBHTTPError(.notFound))
-        }
-        var request = request
-        if result.parameters.count > 0 {
-            request.parameters = result.parameters
-        }
-        // store endpoint path in request (mainly for metrics)
-        request.endpointPath = result.value.path
-        return result.value.respond(to: request)
-    }
-}
 
 /// URI Path Trie
 struct RouterPathTrie<Value> {

--- a/Tests/HummingbirdFoundationTests/FilesTests.swift
+++ b/Tests/HummingbirdFoundationTests/FilesTests.swift
@@ -168,15 +168,16 @@ class HummingbirdFilesTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        var eTag: String?
+        var eTagOptional: String?
         app.XCTExecute(uri: "/test.txt", method: .HEAD) { response in
-            eTag = try XCTUnwrap(response.headers["eTag"].first)
+            eTagOptional = try XCTUnwrap(response.headers["eTag"].first)
         }
-        app.XCTExecute(uri: "/test.txt", method: .GET, headers: ["if-none-match": eTag!]) { response in
+        let eTag = try XCTUnwrap(eTagOptional)
+        app.XCTExecute(uri: "/test.txt", method: .GET, headers: ["if-none-match": eTag]) { response in
             XCTAssertEqual(response.status, .notModified)
         }
         var headers: HTTPHeaders = ["if-none-match": "test"]
-        headers.add(name: "if-none-match", value: "\(eTag!)")
+        headers.add(name: "if-none-match", value: "\(eTag)")
         app.XCTExecute(uri: "/test.txt", method: .GET, headers: headers) { response in
             XCTAssertEqual(response.status, .notModified)
         }
@@ -198,11 +199,12 @@ class HummingbirdFilesTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        var modifiedDate: String?
+        var modifiedDateOptional: String?
         app.XCTExecute(uri: "/test.txt", method: .HEAD) { response in
-            modifiedDate = try XCTUnwrap(response.headers["modified-date"].first)
+            modifiedDateOptional = try XCTUnwrap(response.headers["modified-date"].first)
         }
-        app.XCTExecute(uri: "/test.txt", method: .GET, headers: ["if-modified-since": modifiedDate!]) { response in
+        let modifiedDate = try XCTUnwrap(modifiedDateOptional)
+        app.XCTExecute(uri: "/test.txt", method: .GET, headers: ["if-modified-since": modifiedDate]) { response in
             XCTAssertEqual(response.status, .notModified)
         }
         // one minute before current date

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -38,8 +38,11 @@ class HummingbirdTrieRouterTests: XCTestCase {
     func testWildcard() {
         let trie = RouterPathTrie<String>()
         trie.addEntry("users/*", value: "test1")
+        trie.addEntry("users/*/fowler", value: "test2")
+        trie.addEntry("users/*/*", value: "test3")
         XCTAssertEqual(trie.getValueAndParameters("/users/adam")?.value, "test1")
-        XCTAssertNil(trie.getValueAndParameters("/users/adam/1")?.value)
+        XCTAssertEqual(trie.getValueAndParameters("/users/adam/fowler")?.value, "test2")
+        XCTAssertEqual(trie.getValueAndParameters("/users/adam/1")?.value, "test3")
     }
 
     func testGetParameters() {


### PR DESCRIPTION
- When adding routes it constructs the middleware chain for the router at that point
- Add `NotFoundResponder` which is called along with middleware chain when no route is found
- Split TrieRouter into two, the builder and the responder 
- EndpointResponder returns the responder for a method, instead of calling the responder 
- Collapsed the builder part of TrieRouter into HBRouterBuilder