### PR TITLE
XCTExecute returning values and throwing errors

### DIFF
--- a/Sources/HummingbirdXCT/Application+XCT.swift
+++ b/Sources/HummingbirdXCT/Application+XCT.swift
@@ -100,15 +100,15 @@ extension HBApplication {
     }
 
     /// Send request and call test callback on the response returned
-    public func XCTExecute(
+    @discardableResult public func XCTExecute<Return>(
         uri: String,
         method: HTTPMethod,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        testCallback: @escaping (HBXCTResponse) throws -> Void
-    ) {
-        XCTAssertNoThrow(try self.xct.execute(uri: uri, method: method, headers: headers, body: body).flatMapThrowing { response in
+        testCallback: @escaping (HBXCTResponse) throws -> Return
+    ) throws -> Return {
+        return try self.xct.execute(uri: uri, method: method, headers: headers, body: body).flatMapThrowing { response in
             try testCallback(response)
-        }.wait())
+        }.wait()
     }
 }

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -21,7 +21,7 @@ let hostname = HBEnvironment.shared.get("SERVER_HOSTNAME") ?? "127.0.0.1"
 let port = HBEnvironment.shared.get("SERVER_PORT", as: Int.self) ?? 8080
 
 // create app
-let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+let elg = MultiThreadedEventLoopGroup(numberOfThreads: 2)
 defer { try? elg.syncShutdownGracefully() }
 let app = HBApplication(
     configuration: .init(

--- a/Tests/HummingbirdFoundationTests/CookiesTests.swift
+++ b/Tests/HummingbirdFoundationTests/CookiesTests.swift
@@ -73,7 +73,7 @@ class CookieTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/", method: .POST) { response in
+        try app.XCTExecute(uri: "/", method: .POST) { response in
             XCTAssertEqual(response.headers["Set-Cookie"].first, "test=value; HttpOnly")
         }
     }
@@ -87,7 +87,7 @@ class CookieTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/", method: .POST) { response in
+        try app.XCTExecute(uri: "/", method: .POST) { response in
             XCTAssertEqual(response.headers["Set-Cookie"].first, "test=value; HttpOnly")
         }
     }
@@ -100,7 +100,7 @@ class CookieTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/", method: .POST, headers: ["cookie": "test=value"]) { response in
+        try app.XCTExecute(uri: "/", method: .POST, headers: ["cookie": "test=value"]) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "value")
         }

--- a/Tests/HummingbirdFoundationTests/FileTests+async.swift
+++ b/Tests/HummingbirdFoundationTests/FileTests+async.swift
@@ -48,7 +48,7 @@ class HummingbirdAsyncFilesTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/test.jpg", method: .GET) { response in
+        try app.XCTExecute(uri: "/test.jpg", method: .GET) { response in
             XCTAssertEqual(response.body, buffer)
         }
     }
@@ -75,7 +75,7 @@ class HummingbirdAsyncFilesTests: XCTestCase {
         defer { app.XCTStop() }
 
         let buffer = ByteBufferAllocator().buffer(string: "This is a test")
-        app.XCTExecute(uri: "/store", method: .PUT, body: buffer) { response in
+        try app.XCTExecute(uri: "/store", method: .PUT, body: buffer) { response in
             XCTAssertEqual(response.status, .ok)
         }
 

--- a/Tests/HummingbirdFoundationTests/FilesTests.swift
+++ b/Tests/HummingbirdFoundationTests/FilesTests.swift
@@ -171,7 +171,7 @@ class HummingbirdFilesTests: XCTestCase {
         let eTag = try app.XCTExecute(uri: "/test.txt", method: .HEAD) { response in
             return try XCTUnwrap(response.headers["eTag"].first)
         }
-        try app.XCTExecute(uri: "/test.txt", method: .GET, headers: ["if-none-match": eTag!]) { response in
+        try app.XCTExecute(uri: "/test.txt", method: .GET, headers: ["if-none-match": eTag]) { response in
             XCTAssertEqual(response.status, .notModified)
         }
         var headers: HTTPHeaders = ["if-none-match": "test"]

--- a/Tests/HummingbirdFoundationTests/HummingBirdJSONTests.swift
+++ b/Tests/HummingbirdFoundationTests/HummingBirdJSONTests.swift
@@ -40,7 +40,7 @@ class HummingbirdJSONTests: XCTestCase {
         defer { app.XCTStop() }
 
         let body = #"{"name": "John Smith", "email": "john.smith@email.com", "age": 25}"#
-        app.XCTExecute(uri: "/user", method: .PUT, body: ByteBufferAllocator().buffer(string: body)) {
+        try app.XCTExecute(uri: "/user", method: .PUT, body: ByteBufferAllocator().buffer(string: body)) {
             XCTAssertEqual($0.status, .ok)
         }
     }
@@ -54,7 +54,7 @@ class HummingbirdJSONTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/user", method: .GET) { response in
+        try app.XCTExecute(uri: "/user", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             let user = try JSONDecoder().decode(User.self, from: body)
             XCTAssertEqual(user.name, "John Smith")
@@ -72,7 +72,7 @@ class HummingbirdJSONTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/json", method: .GET) { response in
+        try app.XCTExecute(uri: "/json", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), #"{"message":"Hello, world!"}"#)
         }

--- a/Tests/HummingbirdFoundationTests/URLEncodedForm/Application+URLEncodedFormTests.swift
+++ b/Tests/HummingbirdFoundationTests/URLEncodedForm/Application+URLEncodedFormTests.swift
@@ -40,7 +40,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
         defer { app.XCTStop() }
 
         let body = "name=John%20Smith&email=john.smith%40email.com&age=25"
-        app.XCTExecute(uri: "/user", method: .PUT, body: ByteBufferAllocator().buffer(string: body)) {
+        try app.XCTExecute(uri: "/user", method: .PUT, body: ByteBufferAllocator().buffer(string: body)) {
             XCTAssertEqual($0.status, .ok)
         }
     }
@@ -54,7 +54,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/user", method: .GET) { response in
+        try app.XCTExecute(uri: "/user", method: .GET) { response in
             var body = try XCTUnwrap(response.body)
             let bodyString = try XCTUnwrap(body.readString(length: body.readableBytes))
             let user = try URLEncodedFormDecoder().decode(User.self, from: bodyString)

--- a/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
+++ b/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
@@ -259,7 +259,7 @@ final class HummingbirdJobsTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/job", method: .GET) { response in
+        try app.XCTExecute(uri: "/job", method: .GET) { response in
             XCTAssertEqual(response.status, .ok)
         }
 

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -33,7 +33,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET) { response in
             var body = try XCTUnwrap(response.body)
             let string = body.readString(length: body.readableBytes)
             XCTAssertEqual(response.status, .ok)
@@ -49,7 +49,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/accepted", method: .GET) { response in
+        try app.XCTExecute(uri: "/accepted", method: .GET) { response in
             XCTAssertEqual(response.status, .accepted)
         }
     }
@@ -62,7 +62,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET) { response in
             XCTAssertEqual(response.headers["connection"].first, "keep-alive")
             XCTAssertEqual(response.headers["content-length"].first, "5")
         }
@@ -76,7 +76,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET) { response in
             XCTAssertEqual(response.headers["server"].first, "TestServer")
         }
     }
@@ -89,7 +89,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .POST) { response in
+        try app.XCTExecute(uri: "/hello", method: .POST) { response in
             var body = try XCTUnwrap(response.body)
             let string = body.readString(length: body.readableBytes)
             XCTAssertEqual(response.status, .ok)
@@ -108,11 +108,11 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "GET")
         }
-        app.XCTExecute(uri: "/hello", method: .POST) { response in
+        try app.XCTExecute(uri: "/hello", method: .POST) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "POST")
         }
@@ -130,11 +130,11 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "GET")
         }
-        app.XCTExecute(uri: "/hello", method: .POST) { response in
+        try app.XCTExecute(uri: "/hello", method: .POST) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "POST")
         }
@@ -149,7 +149,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/query?test=test%20data%C3%A9", method: .POST) { response in
+        try app.XCTExecute(uri: "/query?test=test%20data%C3%A9", method: .POST) { response in
             var body = try XCTUnwrap(response.body)
             let string = body.readString(length: body.readableBytes)
             XCTAssertEqual(response.status, .ok)
@@ -165,7 +165,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/add?value=3&value=45&value=7", method: .POST) { response in
+        try app.XCTExecute(uri: "/add?value=3&value=45&value=7", method: .POST) { response in
             var body = try XCTUnwrap(response.body)
             let string = body.readString(length: body.readableBytes)
             XCTAssertEqual(response.status, .ok)
@@ -181,7 +181,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/array", method: .GET) { response in
+        try app.XCTExecute(uri: "/array", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "[\"yes\", \"no\"]")
         }
@@ -195,7 +195,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/array", method: .PATCH) { response in
+        try app.XCTExecute(uri: "/array", method: .PATCH) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "[\"yes\", \"no\"]")
         }
@@ -213,7 +213,7 @@ final class ApplicationTests: XCTestCase {
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 1_140_000)
-        app.XCTExecute(uri: "/echo-body", method: .POST, body: buffer) { response in
+        try app.XCTExecute(uri: "/echo-body", method: .POST, body: buffer) { response in
             XCTAssertEqual(response.body, buffer)
         }
     }
@@ -255,14 +255,14 @@ final class ApplicationTests: XCTestCase {
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 640_001)
-        app.XCTExecute(uri: "/streaming", method: .POST, body: buffer) { response in
+        try app.XCTExecute(uri: "/streaming", method: .POST, body: buffer) { response in
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.body, buffer)
         }
-        app.XCTExecute(uri: "/streaming", method: .POST) { response in
+        try app.XCTExecute(uri: "/streaming", method: .POST) { response in
             XCTAssertEqual(response.status, .badRequest)
         }
-        app.XCTExecute(uri: "/size", method: .POST, body: buffer) { response in
+        try app.XCTExecute(uri: "/size", method: .POST, body: buffer) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "640001")
         }
@@ -293,11 +293,11 @@ final class ApplicationTests: XCTestCase {
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 64)
-        app.XCTExecute(uri: "/streaming", method: .POST, body: buffer) { response in
+        try app.XCTExecute(uri: "/streaming", method: .POST, body: buffer) { response in
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.body, buffer)
         }
-        app.XCTExecute(uri: "/streaming", method: .POST) { response in
+        try app.XCTExecute(uri: "/streaming", method: .POST) { response in
             XCTAssertEqual(response.status, .badRequest)
         }
     }
@@ -320,7 +320,7 @@ final class ApplicationTests: XCTestCase {
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 512_000)
-        app.XCTExecute(uri: "/hello", method: .PUT, body: buffer) { response in
+        try app.XCTExecute(uri: "/hello", method: .PUT, body: buffer) { response in
             XCTAssertEqual(response.status, .ok)
         }
     }
@@ -336,11 +336,11 @@ final class ApplicationTests: XCTestCase {
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 64)
-        app.XCTExecute(uri: "/echo-body", method: .POST, body: buffer) { response in
+        try app.XCTExecute(uri: "/echo-body", method: .POST, body: buffer) { response in
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.body, buffer)
         }
-        app.XCTExecute(uri: "/echo-body", method: .POST) { response in
+        try app.XCTExecute(uri: "/echo-body", method: .POST) { response in
             XCTAssertEqual(response.status, .notFound)
         }
     }
@@ -356,11 +356,11 @@ final class ApplicationTests: XCTestCase {
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 64)
-        app.XCTExecute(uri: "/echo-body", method: .POST, body: buffer) { response in
+        try app.XCTExecute(uri: "/echo-body", method: .POST, body: buffer) { response in
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.body, buffer)
         }
-        app.XCTExecute(uri: "/echo-body", method: .POST) { response in
+        try app.XCTExecute(uri: "/echo-body", method: .POST) { response in
             XCTAssertEqual(response.status, .notFound)
         }
     }
@@ -379,7 +379,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/name", method: .PATCH) { response in
+        try app.XCTExecute(uri: "/name", method: .PATCH) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), #"Name(first: "john", last: "smith")"#)
         }
@@ -396,7 +396,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .DELETE) { response in
+        try app.XCTExecute(uri: "/hello", method: .DELETE) { response in
             var body = try XCTUnwrap(response.body)
             let string = body.readString(length: body.readableBytes)
             XCTAssertEqual(response.status, .imATeapot)
@@ -418,7 +418,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .DELETE) { response in
+        try app.XCTExecute(uri: "/hello", method: .DELETE) { response in
             var body = try XCTUnwrap(response.body)
             let string = body.readString(length: body.readableBytes)
             XCTAssertEqual(response.status, .imATeapot)
@@ -444,7 +444,7 @@ final class ApplicationTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/", method: .GET) { response in
+        try app.XCTExecute(uri: "/", method: .GET) { response in
             XCTAssertEqual(response.status, .ok)
             let body = try XCTUnwrap(response.body)
             let address = String(buffer: body)

--- a/Tests/HummingbirdTests/AsyncAwaitTests.swift
+++ b/Tests/HummingbirdTests/AsyncAwaitTests.swift
@@ -43,7 +43,7 @@ final class AsyncAwaitTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET) { response in
             var body = try XCTUnwrap(response.body)
             let string = body.readString(length: body.readableBytes)
             XCTAssertEqual(response.status, .ok)
@@ -71,7 +71,7 @@ final class AsyncAwaitTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET) { response in
             XCTAssertEqual(response.headers["async"].first, "true")
         }
     }
@@ -97,7 +97,7 @@ final class AsyncAwaitTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello/Adam", method: .POST) { response in
+        try app.XCTExecute(uri: "/hello/Adam", method: .POST) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "Hello Adam")
         }
@@ -125,7 +125,7 @@ final class AsyncAwaitTests: XCTestCase {
         defer { app.XCTStop() }
 
         let buffer = self.randomBuffer(size: 530_001)
-        app.XCTExecute(uri: "/size", method: .POST, body: buffer) { response in
+        try app.XCTExecute(uri: "/size", method: .POST, body: buffer) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "530001")
         }

--- a/Tests/HummingbirdTests/DateCacheTests.swift
+++ b/Tests/HummingbirdTests/DateCacheTests.swift
@@ -39,10 +39,10 @@ class HummingbirdDateTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/date", method: .GET) { response in
+        try app.XCTExecute(uri: "/date", method: .GET) { response in
             XCTAssertNotNil(response.headers["date"].first)
         }
-        app.XCTExecute(uri: "/date", method: .GET) { response in
+        try app.XCTExecute(uri: "/date", method: .GET) { response in
             XCTAssertNotNil(response.headers["date"].first)
         }
     }

--- a/Tests/HummingbirdTests/HandlerTests.swift
+++ b/Tests/HummingbirdTests/HandlerTests.swift
@@ -33,7 +33,7 @@ final class HandlerTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .POST, body: ByteBufferAllocator().buffer(string: #"{"name": "Adam"}"#)) { response in
+        try app.XCTExecute(uri: "/hello", method: .POST, body: ByteBufferAllocator().buffer(string: #"{"name": "Adam"}"#)) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "Hello Adam")
         }
@@ -53,7 +53,7 @@ final class HandlerTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .PUT, body: ByteBufferAllocator().buffer(string: #"{"name": "Adam"}"#)) { response in
+        try app.XCTExecute(uri: "/hello", method: .PUT, body: ByteBufferAllocator().buffer(string: #"{"name": "Adam"}"#)) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "Hello Adam")
         }
@@ -73,7 +73,7 @@ final class HandlerTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET, body: ByteBufferAllocator().buffer(string: #"{"name2": "Adam"}"#)) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET, body: ByteBufferAllocator().buffer(string: #"{"name2": "Adam"}"#)) { response in
             XCTAssertEqual(response.status, .badRequest)
         }
     }
@@ -96,7 +96,7 @@ final class HandlerTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/23", method: .PUT) { response in
+        try app.XCTExecute(uri: "/23", method: .PUT) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "23")
         }

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -191,7 +191,7 @@ final class MetricsTests: XCTestCase {
         }
         try app.XCTStart()
         defer { app.XCTStop() }
-        app.XCTExecute(uri: "/hello", method: .GET) { _ in }
+        try app.XCTExecute(uri: "/hello", method: .GET) { _ in }
 
         let counter = try XCTUnwrap(Self.testMetrics.counters["hb_requests"] as? TestCounter)
         XCTAssertEqual(counter.values[0].1, 1)
@@ -209,7 +209,7 @@ final class MetricsTests: XCTestCase {
         }
         try app.XCTStart()
         defer { app.XCTStop() }
-        app.XCTExecute(uri: "/hello", method: .GET) { _ in }
+        try app.XCTExecute(uri: "/hello", method: .GET) { _ in }
 
         let counter = try XCTUnwrap(Self.testMetrics.counters["hb_errors"] as? TestCounter)
         XCTAssertEqual(counter.values.count, 1)
@@ -228,7 +228,7 @@ final class MetricsTests: XCTestCase {
         }
         try app.XCTStart()
         defer { app.XCTStop() }
-        app.XCTExecute(uri: "/hello2", method: .GET) { _ in }
+        try app.XCTExecute(uri: "/hello2", method: .GET) { _ in }
 
         let counter = try XCTUnwrap(Self.testMetrics.counters["hb_errors"] as? TestCounter)
         XCTAssertEqual(counter.values.count, 1)
@@ -246,7 +246,7 @@ final class MetricsTests: XCTestCase {
         }
         try app.XCTStart()
         defer { app.XCTStop() }
-        app.XCTExecute(uri: "/user/765", method: .GET) { _ in }
+        try app.XCTExecute(uri: "/user/765", method: .GET) { _ in }
 
         let counter = try XCTUnwrap(Self.testMetrics.counters["hb_errors"] as? TestCounter)
         XCTAssertEqual(counter.values.count, 1)

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -107,7 +107,7 @@ final class MiddlewareTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "Edited error")
             XCTAssertEqual(response.status, .notFound)

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -35,7 +35,7 @@ final class MiddlewareTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET) { response in
             XCTAssertEqual(response.headers["middleware"].first, "TestMiddleware")
         }
     }
@@ -60,7 +60,7 @@ final class MiddlewareTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET) { response in
             // headers come back in opposite order as middleware is applied to responses in that order
             XCTAssertEqual(response.headers["middleware"].first, "second")
             XCTAssertEqual(response.headers["middleware"].last, "first")
@@ -86,7 +86,7 @@ final class MiddlewareTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET) { _ in
+        try app.XCTExecute(uri: "/hello", method: .GET) { _ in
         }
     }
 
@@ -129,7 +129,7 @@ final class MiddlewareTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/test", method: .GET) { _ in }
+        try app.XCTExecute(uri: "/test", method: .GET) { _ in }
     }
 
     func testCORSUseOrigin() throws {
@@ -141,7 +141,7 @@ final class MiddlewareTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET, headers: ["origin": "foo.com"]) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET, headers: ["origin": "foo.com"]) { response in
             // headers come back in opposite order as middleware is applied to responses in that order
             XCTAssertEqual(response.headers["Access-Control-Allow-Origin"].first, "foo.com")
         }
@@ -156,7 +156,7 @@ final class MiddlewareTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .GET, headers: ["origin": "foo.com"]) { response in
+        try app.XCTExecute(uri: "/hello", method: .GET, headers: ["origin": "foo.com"]) { response in
             // headers come back in opposite order as middleware is applied to responses in that order
             XCTAssertEqual(response.headers["Access-Control-Allow-Origin"].first, "*")
         }
@@ -178,7 +178,7 @@ final class MiddlewareTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .OPTIONS, headers: ["origin": "foo.com"]) { response in
+        try app.XCTExecute(uri: "/hello", method: .OPTIONS, headers: ["origin": "foo.com"]) { response in
             // headers come back in opposite order as middleware is applied to responses in that order
             XCTAssertEqual(response.headers["Access-Control-Allow-Origin"].first, "*")
             let headers = response.headers[canonicalForm: "Access-Control-Allow-Headers"].joined(separator: ", ")
@@ -201,7 +201,7 @@ final class MiddlewareTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/hello", method: .PUT) { _ in
+        try app.XCTExecute(uri: "/hello", method: .PUT) { _ in
         }
     }
 }

--- a/Tests/HummingbirdTests/PersistTests+async.swift
+++ b/Tests/HummingbirdTests/PersistTests+async.swift
@@ -58,8 +58,8 @@ final class AsyncPersistTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "Persist")
         }
@@ -80,8 +80,8 @@ final class AsyncPersistTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "Persist")
         }
@@ -106,10 +106,10 @@ final class AsyncPersistTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { response in
+        try app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { response in
             XCTAssertEqual(response.status, .ok)
         }
-        app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { response in
+        try app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { response in
             XCTAssertEqual(response.status, .conflict)
         }
     }
@@ -124,11 +124,11 @@ final class AsyncPersistTests: XCTestCase {
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "test1")) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "test2")) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "test1")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "test2")) { response in
             XCTAssertEqual(response.status, .ok)
         }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "test2")
         }
@@ -146,13 +146,13 @@ final class AsyncPersistTests: XCTestCase {
         let tag1 = UUID().uuidString
         let tag2 = UUID().uuidString
 
-        app.XCTExecute(uri: "/persist/\(tag1)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag2)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest2")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag1)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag2)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest2")) { _ in }
         Thread.sleep(forTimeInterval: 1)
-        app.XCTExecute(uri: "/persist/\(tag1)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag1)", method: .GET) { response in
             XCTAssertEqual(response.status, .notFound)
         }
-        app.XCTExecute(uri: "/persist/\(tag2)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag2)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "ThisIsTest2")
         }
@@ -182,8 +182,8 @@ final class AsyncPersistTests: XCTestCase {
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/codable/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
-        app.XCTExecute(uri: "/codable/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/codable/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
+        try app.XCTExecute(uri: "/codable/\(tag)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "Persist")
         }
@@ -199,9 +199,9 @@ final class AsyncPersistTests: XCTestCase {
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .DELETE) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .DELETE) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             XCTAssertEqual(response.status, .notFound)
         }
     }
@@ -216,15 +216,15 @@ final class AsyncPersistTests: XCTestCase {
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/persist/\(tag)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
         Thread.sleep(forTimeInterval: 1)
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             XCTAssertEqual(response.status, .notFound)
         }
-        app.XCTExecute(uri: "/persist/\(tag)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { response in
             XCTAssertEqual(response.status, .ok)
         }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             XCTAssertEqual(response.status, .ok)
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "ThisIsTest1")

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -53,8 +53,8 @@ final class PersistTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "Persist")
         }
@@ -71,8 +71,8 @@ final class PersistTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "Persist")
         }
@@ -93,10 +93,10 @@ final class PersistTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { response in
+        try app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { response in
             XCTAssertEqual(response.status, .ok)
         }
-        app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { response in
+        try app.XCTExecute(uri: "/create/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { response in
             XCTAssertEqual(response.status, .conflict)
         }
     }
@@ -107,11 +107,11 @@ final class PersistTests: XCTestCase {
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "test1")) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "test2")) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "test1")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "test2")) { response in
             XCTAssertEqual(response.status, .ok)
         }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "test2")
         }
@@ -125,13 +125,13 @@ final class PersistTests: XCTestCase {
         let tag1 = UUID().uuidString
         let tag2 = UUID().uuidString
 
-        app.XCTExecute(uri: "/persist/\(tag1)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag2)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest2")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag1)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag2)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest2")) { _ in }
         Thread.sleep(forTimeInterval: 1)
-        app.XCTExecute(uri: "/persist/\(tag1)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag1)", method: .GET) { response in
             XCTAssertEqual(response.status, .notFound)
         }
-        app.XCTExecute(uri: "/persist/\(tag2)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag2)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "ThisIsTest2")
         }
@@ -157,8 +157,8 @@ final class PersistTests: XCTestCase {
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/codable/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
-        app.XCTExecute(uri: "/codable/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/codable/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
+        try app.XCTExecute(uri: "/codable/\(tag)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "Persist")
         }
@@ -170,9 +170,9 @@ final class PersistTests: XCTestCase {
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .DELETE) { _ in }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .DELETE) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             XCTAssertEqual(response.status, .notFound)
         }
     }
@@ -183,15 +183,15 @@ final class PersistTests: XCTestCase {
         defer { app.XCTStop() }
 
         let tag = UUID().uuidString
-        app.XCTExecute(uri: "/persist/\(tag)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+        try app.XCTExecute(uri: "/persist/\(tag)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
         Thread.sleep(forTimeInterval: 1)
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             XCTAssertEqual(response.status, .notFound)
         }
-        app.XCTExecute(uri: "/persist/\(tag)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { response in
             XCTAssertEqual(response.status, .ok)
         }
-        app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
+        try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
             XCTAssertEqual(response.status, .ok)
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "ThisIsTest1")

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -69,12 +69,12 @@ final class RouterTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/endpoint", method: .GET) { response in
+        try app.XCTExecute(uri: "/endpoint", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "GET")
         }
 
-        app.XCTExecute(uri: "/endpoint", method: .PUT) { response in
+        try app.XCTExecute(uri: "/endpoint", method: .PUT) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "PUT")
         }
@@ -96,11 +96,11 @@ final class RouterTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/group", method: .GET) { response in
+        try app.XCTExecute(uri: "/group", method: .GET) { response in
             XCTAssertEqual(response.headers["middleware"].first, "TestMiddleware")
         }
 
-        app.XCTExecute(uri: "/not-group", method: .GET) { response in
+        try app.XCTExecute(uri: "/not-group", method: .GET) { response in
             XCTAssertEqual(response.headers["middleware"].first, nil)
         }
     }
@@ -116,7 +116,7 @@ final class RouterTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/group", method: .HEAD) { response in
+        try app.XCTExecute(uri: "/group", method: .HEAD) { response in
             XCTAssertEqual(response.headers["middleware"].first, "TestMiddleware")
         }
     }
@@ -134,7 +134,7 @@ final class RouterTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/test/group", method: .GET) { response in
+        try app.XCTExecute(uri: "/test/group", method: .GET) { response in
             XCTAssertEqual(response.headers["middleware"].first, "TestMiddleware")
         }
     }
@@ -166,11 +166,11 @@ final class RouterTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/test/group", method: .GET) { response in
+        try app.XCTExecute(uri: "/test/group", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "route2")
         }
-        app.XCTExecute(uri: "/test", method: .GET) { response in
+        try app.XCTExecute(uri: "/test", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "route1")
         }
@@ -185,7 +185,7 @@ final class RouterTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/user/1234", method: .DELETE) { response in
+        try app.XCTExecute(uri: "/user/1234", method: .DELETE) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "1234")
         }
@@ -201,7 +201,7 @@ final class RouterTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/user/john/1234", method: .DELETE) { response in
+        try app.XCTExecute(uri: "/user/john/1234", method: .DELETE) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "1234")
         }

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -49,7 +49,7 @@ final class RouterTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        app.XCTExecute(uri: "/test/1", method: .GET) { response in
+        try app.XCTExecute(uri: "/test/1", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "/test/:number")
         }


### PR DESCRIPTION
This is a breaking change:
`HBApplication.XCTExecute` will now return the value the supplied closure returns. This simplifies testing code where you need a value from one response to use in the next.
```swift
var optionalHeader: String?
app.XCTExecute(uri: "/", method: .GET) { response in
    optionalHeader = response.header["my-header"].first
}
let header = try XCTUnwrap(optionalHeader)
```
now becomes 
```swift
let header = try app.XCTExecute(uri: "/", method: .GET) { response in
    return response.header["my-header"].first
}
```
which is much cleaner.

To get this to work though requires `XCTExecute` to throw errors