### PR TITLE
Add HBTracingMiddleware

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", .upToNextMinor(from: "0.3.1")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.45.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "1.0.0-alpha.9"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-core.git", from: "1.0.0-rc"),
@@ -27,6 +28,7 @@ let package = Package(
             .product(name: "LifecycleNIOCompat", package: "swift-service-lifecycle"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Metrics", package: "swift-metrics"),
+            .product(name: "Tracing", package: "swift-distributed-tracing"),
             .product(name: "NIOCore", package: "swift-nio"),
             .product(name: "NIOPosix", package: "swift-nio"),
             .product(name: "NIOHTTP1", package: "swift-nio"),

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -1,0 +1,151 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Tracing
+
+/// Middleware creating Distributed Tracing spans for each request.
+///
+/// Creates a span for each request, including attributes such as the HTTP method.
+///
+/// You may opt in to recording a specific subset of HTTP request header values by passing
+/// a set of header names to ``init(recordingHeaders:)``.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public struct HBTracingMiddleware: HBMiddleware {
+    private let headerNamesToRecord: Set<RecordingHeader>
+
+    /// Intialize a new HBTracingMiddleware.
+    ///
+    /// - Parameter recordingHeaders: A list of HTTP header names to be recorded as span attributes. By default, no headers
+    /// are being recorded.
+    public init<C: Collection>(recordingHeaders headerNamesToRecord: C) where C.Element == String {
+        self.headerNamesToRecord = Set(headerNamesToRecord.map(RecordingHeader.init))
+    }
+
+    /// Intialize a new HBTracingMiddleware.
+    public init() {
+        self.init(recordingHeaders: [])
+    }
+
+    public func apply(to request: HBRequest, next: HBResponder) -> EventLoopFuture<HBResponse> {
+        var baggage = Baggage.topLevel
+        InstrumentationSystem.instrument.extract(request.headers, into: &baggage, using: HTTPHeadersExtractor())
+
+        let operationName: String = {
+            guard let endpointPath = request.endpointPath else {
+                return "HTTP \(request.method.rawValue) route not found"
+            }
+            return endpointPath.starts(with: "/") ? endpointPath : "/\(endpointPath)"
+        }()
+        let span = InstrumentationSystem.tracer.startSpan(operationName, baggage: baggage, ofKind: .server)
+
+        span.attributes["http.method"] = request.method.rawValue
+        span.attributes["http.target"] = request.uri.path
+        span.attributes["http.flavor"] = "\(request.version.major).\(request.version.minor)"
+        span.attributes["http.scheme"] = request.uri.scheme?.rawValue
+        span.attributes["http.user_agent"] = request.headers.first(name: "user-agent")
+        span.attributes["http.request_content_length"] = request.body.buffer?.readableBytes
+
+        span.attributes["net.host.name"] = request.application.server.configuration.address.host
+        span.attributes["net.host.port"] = request.application.server.configuration.address.port
+
+        if let remoteAddress = request.remoteAddress {
+            span.attributes["net.sock.peer.port"] = remoteAddress.port
+
+            switch remoteAddress.protocol {
+            case .inet:
+                span.attributes["net.sock.peer.addr"] = remoteAddress.ipAddress
+            case .inet6:
+                span.attributes["net.sock.family"] = "inet6"
+                span.attributes["net.sock.peer.addr"] = remoteAddress.ipAddress
+            case .unix:
+                span.attributes["net.sock.family"] = "unix"
+                span.attributes["net.sock.peer.addr"] = remoteAddress.pathname
+            default:
+                break
+            }
+        }
+
+        if !self.headerNamesToRecord.isEmpty {
+            for header in self.headerNamesToRecord {
+                let values = request.headers[header.name]
+                guard !values.isEmpty else { continue }
+                let attribute = "http.request.header.\(header.attributeName)"
+
+                if values.count == 1 {
+                    span.attributes[attribute] = values[0]
+                } else {
+                    span.attributes[attribute] = values
+                }
+            }
+        }
+
+        return Baggage.$current.withValue(span.baggage) {
+            return next
+                .respond(to: request)
+                .always { result in
+                    defer { span.end() }
+
+                    switch result {
+                    case .success(let response):
+                        if !headerNamesToRecord.isEmpty {
+                            for header in headerNamesToRecord {
+                                let values = response.headers[header.name]
+                                guard !values.isEmpty else { continue }
+                                let attribute = "http.response.header.\(header.attributeName)"
+
+                                if values.count == 1 {
+                                    span.attributes[attribute] = values[0]
+                                } else {
+                                    span.attributes[attribute] = values
+                                }
+                            }
+                        }
+
+                        span.attributes["http.status_code"] = Int(response.status.code)
+                        switch response.body {
+                        case .byteBuffer(let buffer):
+                            span.attributes["http.response_content_length"] = buffer.readableBytes
+                        case .stream, .empty:
+                            break
+                        }
+                    case .failure(let error):
+                        if let httpError = error as? HBHTTPError {
+                            span.attributes["http.status_code"] = Int(httpError.status.code)
+
+                            if 500..<600 ~= httpError.status.code {
+                                span.setStatus(.init(code: .error))
+                            }
+                        }
+                        span.recordError(error)
+                    }
+                }
+        }
+    }
+}
+
+struct RecordingHeader: Hashable {
+    let name: String
+    let attributeName: String
+
+    init(name: String) {
+        self.name = name
+        self.attributeName = name.lowercased().replacingOccurrences(of: "-", with: "_")
+    }
+}
+
+private struct HTTPHeadersExtractor: Extractor {
+    func extract(key name: String, from headers: HTTPHeaders) -> String? {
+        headers.first(name: name)
+    }
+}

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,6 +14,8 @@
 
 @testable import Hummingbird
 import HummingbirdXCT
+@testable import Instrumentation
+import Tracing
 import XCTest
 
 final class MiddlewareTests: XCTestCase {
@@ -203,5 +205,303 @@ final class MiddlewareTests: XCTestCase {
 
         try app.XCTExecute(uri: "/hello", method: .PUT) { _ in
         }
+    }
+
+    func testTracingMiddleware() throws {
+        let expectation = expectation(description: "Expected span to be ended.")
+
+        let tracer = TestTracer()
+        tracer.onEndSpan = { _ in expectation.fulfill() }
+        InstrumentationSystem.bootstrapInternal(tracer)
+
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(HBTracingMiddleware())
+        app.router.get("users/:id") { _ -> String in
+            return "42"
+        }
+        try app.XCTStart()
+        defer { app.XCTStop() }
+
+        try app.XCTExecute(uri: "/users/42", method: .GET) { response in
+            XCTAssertEqual(response.status, .ok)
+            var responseBody = try XCTUnwrap(response.body)
+            XCTAssertEqual(responseBody.readString(length: responseBody.readableBytes), "42")
+        }
+
+        waitForExpectations(timeout: 1)
+
+        let span = try XCTUnwrap(tracer.spans.first)
+
+        XCTAssertEqual(span.operationName, "/users/:id")
+        XCTAssertEqual(span.kind, .server)
+        XCTAssertNil(span.status)
+        XCTAssertTrue(span.errors.isEmpty)
+
+        XCTAssertEqual(span.attributes.count, 7)
+        XCTAssertEqual(span.attributes["http.method"]?.toSpanAttribute(), "GET")
+        XCTAssertEqual(span.attributes["http.target"]?.toSpanAttribute(), "/users/42")
+        XCTAssertEqual(span.attributes["http.status_code"]?.toSpanAttribute(), 200)
+        XCTAssertEqual(span.attributes["http.response_content_length"]?.toSpanAttribute(), 2)
+        XCTAssertEqual(span.attributes["net.host.name"]?.toSpanAttribute(), "localhost")
+        XCTAssertEqual(span.attributes["net.host.port"]?.toSpanAttribute(), 0)
+        XCTAssertEqual(span.attributes["http.flavor"]?.toSpanAttribute(), "1.1")
+
+        XCTAssertSpanAttributesEqual(span.attributes, [
+            "http.method": "GET",
+            "http.target": "/users/42",
+            "http.status_code": 200,
+            "http.response_content_length": 2,
+            "net.host.name": "localhost",
+            "net.host.port": 0,
+            "http.flavor": "1.1",
+        ])
+    }
+
+    func testTracingMiddlewareServerError() throws {
+        let expectation = expectation(description: "Expected span to be ended.")
+
+        let tracer = TestTracer()
+        tracer.onEndSpan = { _ in expectation.fulfill() }
+        InstrumentationSystem.bootstrapInternal(tracer)
+
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(HBTracingMiddleware())
+        app.router.post("users") { _ -> String in
+            throw HBHTTPError(.internalServerError)
+        }
+        try app.XCTStart()
+        defer { app.XCTStop() }
+
+        try app.XCTExecute(uri: "/users", method: .POST, body: ByteBuffer(string: "42")) { response in
+            XCTAssertEqual(response.status, .internalServerError)
+        }
+
+        waitForExpectations(timeout: 1)
+
+        let span = try XCTUnwrap(tracer.spans.first)
+
+        XCTAssertEqual(span.operationName, "/users")
+        XCTAssertEqual(span.kind, .server)
+        XCTAssertEqual(span.status, .init(code: .error))
+
+        XCTAssertEqual(span.errors.count, 1)
+        let error = try XCTUnwrap(span.errors.first as? HBHTTPError, "Recorded unexpected errors: \(span.errors)")
+        XCTAssertEqual(error.status, .internalServerError)
+
+        XCTAssertSpanAttributesEqual(span.attributes, [
+            "http.method": "POST",
+            "http.target": "/users",
+            "http.status_code": 500,
+            "http.request_content_length": 2,
+            "net.host.name": "localhost",
+            "net.host.port": 0,
+            "http.flavor": "1.1",
+        ])
+    }
+
+    func testTracingMiddlewareIncludingHeaders() throws {
+        let expectation = expectation(description: "Expected span to be ended.")
+
+        let tracer = TestTracer()
+        tracer.onEndSpan = { _ in expectation.fulfill() }
+        InstrumentationSystem.bootstrapInternal(tracer)
+
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(HBTracingMiddleware(recordingHeaders: [
+            "accept", "content-type", "cache-control", "does-not-exist",
+        ]))
+        app.router.get("users/:id") { _ -> HBResponse in
+            var headers = HTTPHeaders()
+            headers.add(name: "cache-control", value: "86400")
+            headers.add(name: "cache-control", value: "public")
+            headers.add(name: "content-type", value: "text/plain")
+            return HBResponse(
+                status: .ok,
+                headers: headers,
+                body: .byteBuffer(ByteBuffer(string: "42"))
+            )
+        }
+        try app.XCTStart()
+        defer { app.XCTStop() }
+
+        var requestHeaders = HTTPHeaders()
+        requestHeaders.add(name: "Accept", value: "text/plain")
+        requestHeaders.add(name: "Accept", value: "application/json")
+        requestHeaders.add(name: "Cache-Control", value: "no-cache")
+        try app.XCTExecute(uri: "/users/42", method: .GET, headers: requestHeaders) { response in
+            XCTAssertEqual(response.status, .ok)
+            var responseBody = try XCTUnwrap(response.body)
+            XCTAssertEqual(responseBody.readString(length: responseBody.readableBytes), "42")
+        }
+
+        waitForExpectations(timeout: 1)
+
+        let span = try XCTUnwrap(tracer.spans.first)
+
+        XCTAssertEqual(span.operationName, "/users/:id")
+        XCTAssertEqual(span.kind, .server)
+        XCTAssertNil(span.status)
+        XCTAssertTrue(span.errors.isEmpty)
+
+        XCTAssertEqual(span.attributes.count, 11)
+
+        XCTAssertSpanAttributesEqual(span.attributes, [
+            "http.method": "GET",
+            "http.target": "/users/42",
+            "http.status_code": 200,
+            "http.response_content_length": 2,
+            "net.host.name": "localhost",
+            "net.host.port": 0,
+            "http.flavor": "1.1",
+            "http.request.header.accept": .stringArray(["text/plain", "application/json"]),
+            "http.request.header.cache_control": "no-cache",
+            "http.response.header.content_type": "text/plain",
+            "http.response.header.cache_control": .stringArray(["86400", "public"]),
+        ])
+    }
+
+    func testTracingMiddlewareEmptyResponse() throws {
+        let expectation = expectation(description: "Expected span to be ended.")
+
+        let tracer = TestTracer()
+        tracer.onEndSpan = { _ in expectation.fulfill() }
+        InstrumentationSystem.bootstrapInternal(tracer)
+
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(HBTracingMiddleware())
+        app.router.post("/users") { _ -> HTTPResponseStatus in
+            return .noContent
+        }
+        try app.XCTStart()
+        defer { app.XCTStop() }
+
+        try app.XCTExecute(uri: "/users", method: .POST) { response in
+            XCTAssertEqual(response.status, .noContent)
+        }
+
+        waitForExpectations(timeout: 1)
+
+        let span = try XCTUnwrap(tracer.spans.first)
+
+        XCTAssertEqual(span.operationName, "/users")
+        XCTAssertEqual(span.kind, .server)
+        XCTAssertNil(span.status)
+        XCTAssertTrue(span.errors.isEmpty)
+
+        XCTAssertSpanAttributesEqual(span.attributes, [
+            "http.method": "POST",
+            "http.target": "/users",
+            "http.status_code": 204,
+            "net.host.name": "localhost",
+            "net.host.port": 0,
+            "http.flavor": "1.1",
+        ])
+    }
+
+    func testTracingMiddlewareIndexRoute() throws {
+        let expectation = expectation(description: "Expected span to be ended.")
+
+        let tracer = TestTracer()
+        tracer.onEndSpan = { _ in expectation.fulfill() }
+        InstrumentationSystem.bootstrapInternal(tracer)
+
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(HBTracingMiddleware())
+        app.router.get("/") { _ -> HTTPResponseStatus in
+            return .ok
+        }
+        try app.XCTStart()
+        defer { app.XCTStop() }
+
+        try app.XCTExecute(uri: "/", method: .GET) { response in
+            XCTAssertEqual(response.status, .ok)
+        }
+
+        waitForExpectations(timeout: 1)
+
+        let span = try XCTUnwrap(tracer.spans.first)
+
+        XCTAssertEqual(span.operationName, "/")
+        XCTAssertEqual(span.kind, .server)
+        XCTAssertNil(span.status)
+        XCTAssertTrue(span.errors.isEmpty)
+
+        XCTAssertSpanAttributesEqual(span.attributes, [
+            "http.method": "GET",
+            "http.target": "/",
+            "http.status_code": 200,
+            "net.host.name": "localhost",
+            "net.host.port": 0,
+            "http.flavor": "1.1",
+        ])
+    }
+
+    func testTracingMiddlewareRouteNotFound() throws {
+        let expectation = expectation(description: "Expected span to be ended.")
+
+        let tracer = TestTracer()
+        tracer.onEndSpan = { _ in expectation.fulfill() }
+        InstrumentationSystem.bootstrapInternal(tracer)
+
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(HBTracingMiddleware())
+        try app.XCTStart()
+        defer { app.XCTStop() }
+
+        try app.XCTExecute(uri: "/", method: .GET) { response in
+            XCTAssertEqual(response.status, .notFound)
+        }
+
+        waitForExpectations(timeout: 1)
+
+        let span = try XCTUnwrap(tracer.spans.first)
+
+        XCTAssertEqual(span.operationName, "HTTP GET route not found")
+        XCTAssertEqual(span.kind, .server)
+        XCTAssertNil(span.status)
+
+        XCTAssertEqual(span.errors.count, 1)
+        let error = try XCTUnwrap(span.errors.first as? HBHTTPError, "Recorded unexpected errors: \(span.errors)")
+        XCTAssertEqual(error.status, .notFound)
+
+        XCTAssertSpanAttributesEqual(span.attributes, [
+            "http.method": "GET",
+            "http.target": "/",
+            "http.status_code": 404,
+            "net.host.name": "localhost",
+            "net.host.port": 0,
+            "http.flavor": "1.1",
+        ])
+    }
+}
+
+private func XCTAssertSpanAttributesEqual(
+    _ lhs: @autoclosure () -> SpanAttributes,
+    _ rhs: @autoclosure () -> [String: SpanAttribute],
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    var rhs = rhs()
+
+    lhs().forEach { key, attribute in
+        if let rhsValue = rhs.removeValue(forKey: key) {
+            if rhsValue != attribute {
+                XCTFail(
+                    #""\#(key)" was expected to be "\#(rhsValue)" but is actually "\#(attribute)"."#,
+                    file: file,
+                    line: line
+                )
+            }
+        } else {
+            XCTFail(
+                #"Did not specify expected value for "\#(key)", actual value is "\#(attribute)"."#,
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    if !rhs.isEmpty {
+        XCTFail(#"Expected attributes "\#(rhs.keys)" are not present in actual attributes."#, file: file, line: line)
     }
 }

--- a/Tests/HummingbirdTests/TestTracer.swift
+++ b/Tests/HummingbirdTests/TestTracer.swift
@@ -1,0 +1,158 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2020-2021 Apple Inc. and the Swift Distributed Tracing project
+// authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import Foundation
+import Instrumentation
+import InstrumentationBaggage
+import Tracing
+
+final class TestTracer: Tracer {
+    private(set) var spans = [TestSpan]()
+    var onEndSpan: (Span) -> Void = { _ in }
+
+    func startSpan(
+        _ operationName: String,
+        baggage: Baggage,
+        ofKind kind: SpanKind,
+        at time: DispatchWallTime
+    ) -> Span {
+        let span = TestSpan(
+            operationName: operationName,
+            startTime: time,
+            baggage: baggage,
+            kind: kind,
+            onEnd: onEndSpan
+        )
+        self.spans.append(span)
+        return span
+    }
+
+    public func forceFlush() {}
+
+    func extract<Carrier, Extract>(_ carrier: Carrier, into baggage: inout Baggage, using extractor: Extract)
+        where
+        Extract: Extractor,
+        Carrier == Extract.Carrier
+    {
+        let traceID = extractor.extract(key: "trace-id", from: carrier) ?? UUID().uuidString
+        baggage.traceID = traceID
+    }
+
+    func inject<Carrier, Inject>(_ baggage: Baggage, into carrier: inout Carrier, using injector: Inject)
+        where
+        Inject: Injector,
+        Carrier == Inject.Carrier
+    {
+        guard let traceID = baggage.traceID else { return }
+        injector.inject(traceID, forKey: "trace-id", into: &carrier)
+    }
+}
+
+extension TestTracer {
+    enum TraceIDKey: BaggageKey {
+        typealias Value = String
+    }
+}
+
+extension Baggage {
+    var traceID: String? {
+        get {
+            self[TestTracer.TraceIDKey.self]
+        }
+        set {
+            self[TestTracer.TraceIDKey.self] = newValue
+        }
+    }
+}
+
+final class TestSpan: Span {
+    let operationName: String
+    let kind: SpanKind
+
+    private(set) var status: SpanStatus?
+
+    private let startTime: DispatchWallTime
+    private(set) var endTime: DispatchWallTime?
+    private(set) var errors = [Error]()
+
+    let baggage: Baggage
+
+    private(set) var events = [SpanEvent]() {
+        didSet {
+            self.isRecording = !self.events.isEmpty
+        }
+    }
+
+    private(set) var links = [SpanLink]()
+
+    var attributes: SpanAttributes = [:] {
+        didSet {
+            self.isRecording = !self.attributes.isEmpty
+        }
+    }
+
+    private(set) var isRecording = false
+
+    let onEnd: (Span) -> Void
+
+    init(
+        operationName: String,
+        startTime: DispatchWallTime,
+        baggage: Baggage,
+        kind: SpanKind,
+        onEnd: @escaping (Span) -> Void
+    ) {
+        self.operationName = operationName
+        self.startTime = startTime
+        self.baggage = baggage
+        self.onEnd = onEnd
+        self.kind = kind
+    }
+
+    func setStatus(_ status: SpanStatus) {
+        self.status = status
+        self.isRecording = true
+    }
+
+    func addLink(_ link: SpanLink) {
+        self.links.append(link)
+    }
+
+    func addEvent(_ event: SpanEvent) {
+        self.events.append(event)
+    }
+
+    func recordError(_ error: Error) {
+        self.errors.append(error)
+    }
+
+    func end(at time: DispatchWallTime) {
+        self.endTime = time
+        self.onEnd(self)
+    }
+}


### PR DESCRIPTION
This PR adds a middleware to automatically creates server spans for incoming requests, based on the semantic conventions defined in the OpenTelemetry specification.

[📖 OTel Spec: Semantic Conventions for HTTP spans](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.17.0/specification/trace/semantic_conventions/http.md)