### PR TITLE
Extend Substring to conform to HBResponseGenerator

### DIFF
--- a/Sources/Hummingbird/Router/ResponseGenerator.swift
+++ b/Sources/Hummingbird/Router/ResponseGenerator.swift
@@ -45,6 +45,15 @@ extension String: HBResponseGenerator {
     }
 }
 
+/// Extend String to conform to ResponseGenerator
+extension Substring: HBResponseGenerator {
+    /// Generate response holding string
+    public func response(from request: HBRequest) -> HBResponse {
+        let buffer = request.allocator.buffer(substring: self)
+        return HBResponse(status: .ok, headers: ["content-type": "text/plain; charset=utf-8"], body: .byteBuffer(buffer))
+    }
+}
+
 /// Extend ByteBuffer to conform to ResponseGenerator
 extension ByteBuffer: HBResponseGenerator {
     /// Generate response holding bytebuffer

--- a/Sources/Hummingbird/Router/ResponseGenerator.swift
+++ b/Sources/Hummingbird/Router/ResponseGenerator.swift
@@ -77,7 +77,7 @@ extension Optional: HBResponseGenerator where Wrapped: HBResponseGenerator {
         case .some(let wrapped):
             return try wrapped.response(from: request)
         case .none:
-            throw HBHTTPError(.notFound)
+            return HBResponse(status: .noContent, headers: [:], body: .empty)
         }
     }
 }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -341,7 +341,7 @@ final class ApplicationTests: XCTestCase {
             XCTAssertEqual(response.body, buffer)
         }
         try app.XCTExecute(uri: "/echo-body", method: .POST) { response in
-            XCTAssertEqual(response.status, .notFound)
+            XCTAssertEqual(response.status, .noContent)
         }
     }
 
@@ -361,7 +361,7 @@ final class ApplicationTests: XCTestCase {
             XCTAssertEqual(response.body, buffer)
         }
         try app.XCTExecute(uri: "/echo-body", method: .POST) { response in
-            XCTAssertEqual(response.status, .notFound)
+            XCTAssertEqual(response.status, .noContent)
         }
     }
 

--- a/Tests/HummingbirdTests/PersistTests+async.swift
+++ b/Tests/HummingbirdTests/PersistTests+async.swift
@@ -150,7 +150,7 @@ final class AsyncPersistTests: XCTestCase {
         try app.XCTExecute(uri: "/persist/\(tag2)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest2")) { _ in }
         Thread.sleep(forTimeInterval: 1)
         try app.XCTExecute(uri: "/persist/\(tag1)", method: .GET) { response in
-            XCTAssertEqual(response.status, .notFound)
+            XCTAssertEqual(response.status, .noContent)
         }
         try app.XCTExecute(uri: "/persist/\(tag2)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
@@ -202,7 +202,7 @@ final class AsyncPersistTests: XCTestCase {
         try app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
         try app.XCTExecute(uri: "/persist/\(tag)", method: .DELETE) { _ in }
         try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
-            XCTAssertEqual(response.status, .notFound)
+            XCTAssertEqual(response.status, .noContent)
         }
     }
 
@@ -219,7 +219,7 @@ final class AsyncPersistTests: XCTestCase {
         try app.XCTExecute(uri: "/persist/\(tag)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
         Thread.sleep(forTimeInterval: 1)
         try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
-            XCTAssertEqual(response.status, .notFound)
+            XCTAssertEqual(response.status, .noContent)
         }
         try app.XCTExecute(uri: "/persist/\(tag)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { response in
             XCTAssertEqual(response.status, .ok)

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -129,7 +129,7 @@ final class PersistTests: XCTestCase {
         try app.XCTExecute(uri: "/persist/\(tag2)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest2")) { _ in }
         Thread.sleep(forTimeInterval: 1)
         try app.XCTExecute(uri: "/persist/\(tag1)", method: .GET) { response in
-            XCTAssertEqual(response.status, .notFound)
+            XCTAssertEqual(response.status, .noContent)
         }
         try app.XCTExecute(uri: "/persist/\(tag2)", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
@@ -173,7 +173,7 @@ final class PersistTests: XCTestCase {
         try app.XCTExecute(uri: "/persist/\(tag)", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
         try app.XCTExecute(uri: "/persist/\(tag)", method: .DELETE) { _ in }
         try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
-            XCTAssertEqual(response.status, .notFound)
+            XCTAssertEqual(response.status, .noContent)
         }
     }
 
@@ -186,7 +186,7 @@ final class PersistTests: XCTestCase {
         try app.XCTExecute(uri: "/persist/\(tag)/0", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
         Thread.sleep(forTimeInterval: 1)
         try app.XCTExecute(uri: "/persist/\(tag)", method: .GET) { response in
-            XCTAssertEqual(response.status, .notFound)
+            XCTAssertEqual(response.status, .noContent)
         }
         try app.XCTExecute(uri: "/persist/\(tag)/10", method: .PUT, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { response in
             XCTAssertEqual(response.status, .ok)


### PR DESCRIPTION
Also return .noContent when Optional returns nil