### PR TITLE
Fix endpoint path suffix

### DIFF
--- a/Sources/Hummingbird/Router/RouterBuilder.swift
+++ b/Sources/Hummingbird/Router/RouterBuilder.swift
@@ -60,8 +60,8 @@ public final class HBRouterBuilder: HBRouterMethods {
     ///   - method: http method
     ///   - responder: handler to call
     public func add(_ path: String, method: HTTPMethod, responder: HBResponder) {
-        // ensure path starts with a "/"
-        let path = path.starts(with: "/") ? path : "/\(path)"
+        // ensure path starts with a "/" and doesn't end with a "/"
+        let path = "/\(path.dropSuffix("/").dropPrefix("/"))"
         self.trie.addEntry(.init(path), value: HBEndpointResponders(path: path)) { node in
             node.value!.addResponder(for: method, responder: middlewares.constructResponder(finalResponder: responder))
         }

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -89,21 +89,3 @@ public struct HBRouterGroup: HBRouterMethods {
         return "\(path1)/\(path2)"
     }
 }
-
-private extension String {
-    func dropPrefix(_ prefix: String) -> Substring {
-        if hasPrefix(prefix) {
-            return self.dropFirst(prefix.count)
-        } else {
-            return self[...]
-        }
-    }
-
-    func dropSuffix(_ suffix: String) -> Substring {
-        if hasSuffix(suffix) {
-            return self.dropLast(suffix.count)
-        } else {
-            return self[...]
-        }
-    }
-}

--- a/Sources/Hummingbird/Utils/StringProtocol.swift
+++ b/Sources/Hummingbird/Utils/StringProtocol.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension StringProtocol {
+    func dropPrefix(_ prefix: String) -> Self.SubSequence {
+        if hasPrefix(prefix) {
+            return self.dropFirst(prefix.count)
+        } else {
+            return self[...]
+        }
+    }
+
+    func dropSuffix(_ suffix: String) -> Self.SubSequence {
+        if hasSuffix(suffix) {
+            return self.dropLast(suffix.count)
+        } else {
+            return self[...]
+        }
+    }
+}

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -69,6 +69,9 @@ final class RouterTests: XCTestCase {
         app.router.get("test") {
             $0.endpointPath
         }
+        app.router.get {
+            $0.endpointPath
+        }
         app.router.post("/test2") {
             $0.endpointPath
         }
@@ -76,11 +79,14 @@ final class RouterTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
+        try app.XCTExecute(uri: "/", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "/")
+        }
         try app.XCTExecute(uri: "/test/", method: .GET) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "/test")
         }
-
         try app.XCTExecute(uri: "/test2/", method: .POST) { response in
             let body = try XCTUnwrap(response.body)
             XCTAssertEqual(String(buffer: body), "/test2")

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -87,6 +87,57 @@ final class RouterTests: XCTestCase {
         }
     }
 
+    /// Test endpointPath doesn't have "/" at end
+    func testEndpointPathSuffix() throws {
+        struct TestEndpointMiddleware: HBMiddleware {
+            func apply(to request: HBRequest, next: HBResponder) -> EventLoopFuture<HBResponse> {
+                guard let endpointPath = request.endpointPath else { return next.respond(to: request) }
+                return request.success(.init(status: .ok, body: .byteBuffer(ByteBuffer(string: endpointPath))))
+            }
+        }
+
+        let app = HBApplication(testing: .embedded)
+        app.middleware.add(TestEndpointMiddleware())
+        app.router.get("test/") {
+            $0.endpointPath
+        }
+        app.router.post("test2") {
+            $0.endpointPath
+        }
+        app.router
+            .group("testGroup")
+            .get {
+                $0.endpointPath
+            }
+        app.router
+            .group("testGroup2")
+            .get("/") {
+                $0.endpointPath
+            }
+        try app.XCTStart()
+        defer { app.XCTStop() }
+
+        try app.XCTExecute(uri: "/test/", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "/test")
+        }
+
+        try app.XCTExecute(uri: "/test2/", method: .POST) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "/test2")
+        }
+
+        try app.XCTExecute(uri: "/testGroup/", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "/testGroup")
+        }
+
+        try app.XCTExecute(uri: "/testGroup2", method: .GET) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "/testGroup2")
+        }
+    }
+
     /// Test correct endpoints are called from group
     func testMethodEndpoint() throws {
         let app = HBApplication(testing: .embedded)


### PR DESCRIPTION
It should consistently end without a slash