### PR TITLE
Add AsyncSequenceResponseBodyStreamer

### DIFF
--- a/Sources/Hummingbird/AsyncAwaitSupport/ResponseGenerator+async.swift
+++ b/Sources/Hummingbird/AsyncAwaitSupport/ResponseGenerator+async.swift
@@ -14,6 +14,7 @@
 #if compiler(>=5.5.2) && canImport(_Concurrency)
 import HummingbirdCore
 
+/// Response body streamer which uses an AsyncSequence as its input.
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class AsyncSequenceResponseBodyStreamer<ByteBufferSequence: AsyncSequence>: HBResponseBodyStreamer where ByteBufferSequence.Element == ByteBuffer {
     var iterator: ByteBufferSequence.AsyncIterator
@@ -56,6 +57,9 @@ extension AsyncStream: HBResponseGenerator where Element == ByteBuffer {
 }
 
 /// Wrapper object for AsyncSequence that conforms to `HBResponseGenerator`
+///
+/// This can be returned from a route to generate a response that includes the
+/// sequence of ByteBuffers as its payload.
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct AsyncSequenceResponseGenerator<ByteBufferSequence: AsyncSequence>: HBResponseGenerator where ByteBufferSequence.Element == ByteBuffer {
     let asyncSequence: ByteBufferSequence

--- a/Sources/Hummingbird/AsyncAwaitSupport/ResponseGenerator+async.swift
+++ b/Sources/Hummingbird/AsyncAwaitSupport/ResponseGenerator+async.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2021 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+import HummingbirdCore
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+final class AsyncSequenceResponseBodyStreamer<ByteBufferSequence: AsyncSequence>: HBResponseBodyStreamer where ByteBufferSequence.Element == ByteBuffer {
+    var iterator: ByteBufferSequence.AsyncIterator
+
+    init(_ asyncSequence: ByteBufferSequence) {
+        self.iterator = asyncSequence.makeAsyncIterator()
+    }
+
+    func read(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
+        let promise = eventLoop.makePromise(of: HBStreamerOutput.self)
+        promise.completeWithTask {
+            if let buffer = try await self.iterator.next() {
+                return .byteBuffer(buffer)
+            } else {
+                return .end
+            }
+        }
+        return promise.futureResult
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension AsyncThrowingStream: HBResponseGenerator where Element == ByteBuffer {
+    /// Return self as the response
+    public func response(from request: HBRequest) -> HBResponse {
+        return .init(status: .ok, body: .stream(AsyncSequenceResponseBodyStreamer(self)))
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension AsyncStream: HBResponseGenerator where Element == ByteBuffer {
+    /// Return self as the response
+    public func response(from request: HBRequest) -> HBResponse {
+        return .init(status: .ok, body: .stream(AsyncSequenceResponseBodyStreamer(self)))
+    }
+}
+
+#if compiler(>=5.6)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+// can guarantee Sendable because the read function is only ever called on the same EventLoop
+extension AsyncSequenceResponseBodyStreamer: @unchecked Sendable {}
+#endif // compiler(>=5.6)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/Hummingbird/AsyncAwaitSupport/ResponseGenerator+async.swift
+++ b/Sources/Hummingbird/AsyncAwaitSupport/ResponseGenerator+async.swift
@@ -68,12 +68,13 @@ public struct AsyncSequenceResponseGenerator<ByteBufferSequence: AsyncSequence>:
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension AsyncSequence where Element == ByteBuffer {
+    public typealias ResponseGenerator = AsyncSequenceResponseGenerator<Self>
     /// Return type that conforms to `HBResponseGenerator` that will serialize contents of sequence
     ///
     /// Preferably I would like to conform `AsyncSequence` to `HBResponseGenerator` but it is not
     /// possible to add conformances to protocols in extensions. So the solution is to return
     /// another object which wraps the `AsyncSequence`
-    public var responseGenerator: AsyncSequenceResponseGenerator<Self> { .init(asyncSequence: self) }
+    public var responseGenerator: ResponseGenerator { .init(asyncSequence: self) }
 }
 
 #if compiler(>=5.6)

--- a/Tests/HummingbirdTests/AsyncAwaitTests.swift
+++ b/Tests/HummingbirdTests/AsyncAwaitTests.swift
@@ -15,6 +15,7 @@
 #if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import Hummingbird
+import HummingbirdCore
 import HummingbirdXCT
 import NIOHTTP1
 import XCTest
@@ -138,7 +139,7 @@ final class AsyncAwaitTests: XCTestCase {
         guard HBEnvironment().get("CI") != "true" else { throw XCTSkip() }
         #endif
         let app = HBApplication(testing: .asyncTest)
-        app.router.get("buffer", options: .streamBody) { request in
+        app.router.get("buffer", options: .streamBody) { request -> HBRequestBodyStreamerSequence.ResponseGenerator in
             guard let stream = request.body.stream else { throw HBHTTPError(.badRequest) }
             return stream.sequence.responseGenerator
         }

--- a/Tests/HummingbirdTests/AsyncAwaitTests.swift
+++ b/Tests/HummingbirdTests/AsyncAwaitTests.swift
@@ -161,7 +161,7 @@ final class AsyncAwaitTests: XCTestCase {
         #endif
         let app = HBApplication(testing: .asyncTest)
         app.router.get("alphabet") { _ in
-            let stream = AsyncStream<ByteBuffer> { cont in
+            AsyncStream<ByteBuffer> { cont in
                 let alphabet = "abcdefghijklmnopqrstuvwxyz"
                 var index = alphabet.startIndex
                 while index != alphabet.endIndex {
@@ -172,7 +172,6 @@ final class AsyncAwaitTests: XCTestCase {
                 }
                 cont.finish()
             }
-            return stream
         }
 
         try app.XCTStart()


### PR DESCRIPTION
- Using `AsyncSequenceResponseBodyStreamer`  conform `AsyncThrowingStream` and `AsyncStream` to `HBResponseGenerator`
- Also added `AsyncSequence.responseGenerator` that returns a type that wraps the `AsyncSequence` and conforms to `HBResponseGenerator`. Had to do this as I cannot conform a protocol to a new type outside of the protocol definition.