### PR TITLE
Fix appending connections to available queue when closing connection

### DIFF
--- a/Sources/Hummingbird/ConnectionPool/ConnectionPool.swift
+++ b/Sources/Hummingbird/ConnectionPool/ConnectionPool.swift
@@ -170,8 +170,9 @@ public final class HBConnectionPool<Source: HBConnectionSource> {
         case .open:
             if let waitingPromise = self.waitingQueue.popFirst() {
                 waitingPromise.succeed(connection)
+            } else {
+                self.availableQueue.append(connection)
             }
-            self.availableQueue.append(connection)
 
         case .closed, .closing:
             _ = connection.close(on: self.eventLoop)


### PR DESCRIPTION
If a connection was immediately used by a request on the waiting queue, it was still being added to the available queue