### PR TITLE
Add recursive wildcard to trie router

### DIFF
--- a/Sources/Hummingbird/Router/RouterPath.swift
+++ b/Sources/Hummingbird/Router/RouterPath.swift
@@ -18,6 +18,7 @@ struct RouterPath: ExpressibleByStringLiteral {
         case path(Substring)
         case parameter(Substring)
         case wildcard
+        case recursiveWildcard
         case null
 
         static func ~= <S: StringProtocol>(lhs: Element, rhs: S) -> Bool {
@@ -28,7 +29,9 @@ struct RouterPath: ExpressibleByStringLiteral {
                 return true
             case .wildcard:
                 return true
-            default:
+            case .recursiveWildcard:
+                return true
+            case .null:
                 return false
             }
         }
@@ -52,6 +55,8 @@ struct RouterPath: ExpressibleByStringLiteral {
                 return .parameter(component.dropFirst())
             } else if component == "*" {
                 return .wildcard
+            } else if component == "**" {
+                return .recursiveWildcard
             } else {
                 return .path(component)
             }

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -43,6 +43,7 @@ struct RouterPathTrie<Value> {
                 if case .parameter(let key) = node.key {
                     parameters.set(key, value: component)
                 }
+            } else if case .recursiveWildcard = node.key {
             } else {
                 return nil
             }

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -54,10 +54,7 @@ public struct HBRequest: HBSendableExtensible {
     /// Parameters extracted during processing of request URI. These are available to you inside the route handler
     public var parameters: HBParameters {
         get {
-            self.extensions.get(
-                \.parameters,
-                error: "Cannot access HBRequest.parameters on a route not extracting parameters from the URI."
-            )
+            self.extensions.get(\.parameters) ?? .init()
         }
         set { self.extensions.set(\.parameters, value: newValue) }
     }

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -40,6 +40,7 @@ class HummingbirdTrieRouterTests: XCTestCase {
         trie.addEntry("users/*", value: "test1")
         trie.addEntry("users/*/fowler", value: "test2")
         trie.addEntry("users/*/*", value: "test3")
+        XCTAssertNil(trie.getValueAndParameters("/users"))
         XCTAssertEqual(trie.getValueAndParameters("/users/adam")?.value, "test1")
         XCTAssertEqual(trie.getValueAndParameters("/users/adam/fowler")?.value, "test2")
         XCTAssertEqual(trie.getValueAndParameters("/users/adam/1")?.value, "test3")
@@ -53,5 +54,23 @@ class HummingbirdTrieRouterTests: XCTestCase {
         XCTAssertEqual(trie.getValueAndParameters("/users/1234")?.parameters.get("user"), "1234")
         XCTAssertEqual(trie.getValueAndParameters("/users/1234/name")?.parameters.get("user"), "1234")
         XCTAssertEqual(trie.getValueAndParameters("/users/1234/name")?.value, "john smith")
+    }
+
+    func testRecursiveWildcard() {
+        let trie = RouterPathTrie<String>()
+        trie.addEntry("**", value: "**")
+        XCTAssertEqual(trie.getValueAndParameters("/one")?.value, "**")
+        XCTAssertEqual(trie.getValueAndParameters("/one/two")?.value, "**")
+        XCTAssertEqual(trie.getValueAndParameters("/one/two/three")?.value, "**")
+    }
+
+    func testRecursiveWildcardWithPrefix() {
+        let trie = RouterPathTrie<String>()
+        trie.addEntry("Test/**", value: "true")
+        XCTAssertNil(trie.getValueAndParameters("/notTest/hello"))
+        XCTAssertNil(trie.getValueAndParameters("/Test/")?.value, "true")
+        XCTAssertEqual(trie.getValueAndParameters("/Test/one")?.value, "true")
+        XCTAssertEqual(trie.getValueAndParameters("/Test/one/two")?.value, "true")
+        XCTAssertEqual(trie.getValueAndParameters("/Test/one/two/three")?.value, "true")
     }
 }


### PR DESCRIPTION
```swift
router.get("**") { request in
    req.uri.description
}
```
Will work for 
```
GET /one
GET /one/two
GET /one/two/three
```
Also
```swift
router.get("test/**") { request in
    req.uri.description
}
```
Will work for 
```
GET /test
GET /test/two
GET /test/two/three
```
