### PR TITLE
Router improvements

### DIFF
--- a/Benchmarks/Sources/HBPerformance/Router.swift
+++ b/Benchmarks/Sources/HBPerformance/Router.swift
@@ -27,8 +27,8 @@ public class TrieRouterBenchmark: BenchmarkWrapper {
         self.trie.addEntry("/test/", value: "/test/")
         self.trie.addEntry("/test/one", value: "/test/one")
         self.trie.addEntry("/test/one/two", value: "/test/one/two")
-        self.trie.addEntry("/test/:value:", value: "/test/:value:")
-        self.trie.addEntry("/test/:value:/:value2:", value: "/test/:value:/:value2:")
+        self.trie.addEntry("/test/:value", value: "/test/:value")
+        self.trie.addEntry("/test/:value/:value2", value: "/test/:value:/:value2")
         self.trie.addEntry("/test2/*/*", value: "/test2/*/*")
 
         // warmup

--- a/Sources/Hummingbird/Router/Parameters.swift
+++ b/Sources/Hummingbird/Router/Parameters.swift
@@ -17,8 +17,20 @@ public struct HBParameters {
     public typealias Collection = FlatDictionary<Substring, Substring>
     internal var parameters: Collection
 
+    static let recursiveCaptureKey: Substring = ":**:"
+
     init() {
         self.parameters = .init()
+    }
+
+    init(_ values: Collection) {
+        self.parameters = values
+    }
+
+    /// Return if parameter exists
+    /// - Parameter s: parameter id
+    public func has(_ s: Substring) -> Bool {
+        return self.parameters.has(s)
     }
 
     /// Return parameter with specified id
@@ -33,6 +45,11 @@ public struct HBParameters {
     ///   - as: type we want returned
     public func get<T: LosslessStringConvertible>(_ s: String, as: T.Type) -> T? {
         return self.parameters[s[...]].map { T(String($0)) } ?? nil
+    }
+
+    ///  Return path elements caught by recursive capture
+    public func getRecursiveCapture() -> String? {
+        return self.parameters[Self.recursiveCaptureKey].map { String($0) }
     }
 
     /// Return parameter with specified id
@@ -90,6 +107,14 @@ public struct HBParameters {
     ///   - value: parameter value
     mutating func set(_ s: Substring, value: Substring) {
         self.parameters[s] = value
+    }
+
+    /// Set path components caught by recursive capture
+    /// - Parameters:
+    ///   - value: parameter value
+    mutating func setRecursiveCapture(_ value: Substring) {
+        guard !self.parameters.has(Self.recursiveCaptureKey) else { return }
+        self.parameters[Self.recursiveCaptureKey] = value
     }
 
     public subscript(_ s: String) -> String? {

--- a/Sources/Hummingbird/Router/Parameters.swift
+++ b/Sources/Hummingbird/Router/Parameters.swift
@@ -48,8 +48,8 @@ public struct HBParameters {
     }
 
     ///  Return path elements caught by recursive capture
-    public func getCatchAll() -> String? {
-        return self.parameters[Self.recursiveCaptureKey].map { String($0) }
+    public func getCatchAll() -> [Substring] {
+        return self.parameters[Self.recursiveCaptureKey].map { $0.split(separator: "/", omittingEmptySubsequences: true) } ?? []
     }
 
     /// Return parameter with specified id

--- a/Sources/Hummingbird/Router/Parameters.swift
+++ b/Sources/Hummingbird/Router/Parameters.swift
@@ -48,7 +48,7 @@ public struct HBParameters {
     }
 
     ///  Return path elements caught by recursive capture
-    public func getRecursiveCapture() -> String? {
+    public func getCatchAll() -> String? {
         return self.parameters[Self.recursiveCaptureKey].map { String($0) }
     }
 
@@ -112,7 +112,7 @@ public struct HBParameters {
     /// Set path components caught by recursive capture
     /// - Parameters:
     ///   - value: parameter value
-    mutating func setRecursiveCapture(_ value: Substring) {
+    mutating func setCatchAll(_ value: Substring) {
         guard !self.parameters.has(Self.recursiveCaptureKey) else { return }
         self.parameters[Self.recursiveCaptureKey] = value
     }

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -32,8 +32,8 @@ struct HBRouter: HBResponder {
             return self.notFoundResponder.respond(to: request)
         }
         var request = request
-        if result.parameters.count > 0 {
-            request.parameters = result.parameters
+        if let parameters = result.parameters {
+            request.parameters = parameters
         }
         // store endpoint path in request (mainly for metrics)
         request.endpointPath = result.value.path

--- a/Sources/Hummingbird/Router/RouterPath.swift
+++ b/Sources/Hummingbird/Router/RouterPath.swift
@@ -18,6 +18,8 @@ struct RouterPath: ExpressibleByStringLiteral {
         case path(Substring)
         case parameter(Substring)
         case wildcard
+        case prefixWildcard(Substring) // *.jpg
+        case suffixWildcard(Substring) // file.*
         case recursiveWildcard
         case null
 
@@ -29,6 +31,10 @@ struct RouterPath: ExpressibleByStringLiteral {
                 return true
             case .wildcard:
                 return true
+            case .prefixWildcard(let suffix):
+                return rhs.hasSuffix(suffix)
+            case .suffixWildcard(let prefix):
+                return rhs.hasPrefix(prefix)
             case .recursiveWildcard:
                 return true
             case .null:
@@ -57,6 +63,10 @@ struct RouterPath: ExpressibleByStringLiteral {
                 return .wildcard
             } else if component == "**" {
                 return .recursiveWildcard
+            } else if component.first == "*" {
+                return .prefixWildcard(component.dropFirst())
+            } else if component.last == "*" {
+                return .suffixWildcard(component.dropLast())
             } else {
                 return .path(component)
             }

--- a/Sources/Hummingbird/Router/RouterPath.swift
+++ b/Sources/Hummingbird/Router/RouterPath.swift
@@ -70,7 +70,7 @@ struct RouterPath: ExpressibleByStringLiteral {
                     if charAfterColon != parameter.endIndex {
                         return .prefixCapture(parameter[charAfterColon...], parameter[..<secondColon])
                     } else {
-                        return .capture(parameter)
+                        return .capture(parameter.dropLast())
                     }
                 }
                 return .capture(component.dropFirst())

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -48,7 +48,7 @@ struct RouterPathTrie<Value> {
                 case .suffixCapture(let prefix, let key):
                     parameters.set(key, value: component.dropFirst(prefix.count))
                 case .recursiveWildcard:
-                    parameters.setRecursiveCapture(path[component.startIndex..<path.endIndex])
+                    parameters.setCatchAll(path[component.startIndex..<path.endIndex])
                 default:
                     break
                 }
@@ -108,10 +108,10 @@ extension Optional where Wrapped == HBParameters {
         }
     }
 
-    mutating func setRecursiveCapture(_ value: Substring) {
+    mutating func setCatchAll(_ value: Substring) {
         switch self {
         case .some(var parameters):
-            parameters.setRecursiveCapture(value)
+            parameters.setCatchAll(value)
             self = .some(parameters)
         case .none:
             self = .some(.init(.init([(HBParameters.recursiveCaptureKey, value)])))

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -40,10 +40,17 @@ struct RouterPathTrie<Value> {
         for component in pathComponents {
             if let childNode = node.getChild(component) {
                 node = childNode
-                if case .parameter(let key) = node.key {
+                switch node.key {
+                case .capture(let key):
                     parameters.set(key, value: component)
-                } else if case .recursiveWildcard = node.key {
+                case .prefixCapture(let suffix, let key):
+                    parameters.set(key, value: component.dropLast(suffix.count))
+                case .suffixCapture(let prefix, let key):
+                    parameters.set(key, value: component.dropFirst(prefix.count))
+                case .recursiveWildcard:
                     parameters.setRecursiveCapture(path[component.startIndex..<path.endIndex])
+                default:
+                    break
                 }
             } else if case .recursiveWildcard = node.key {
             } else {

--- a/Sources/Hummingbird/Utils/FlatDictionary.swift
+++ b/Sources/Hummingbird/Utils/FlatDictionary.swift
@@ -52,7 +52,7 @@ public struct FlatDictionary<Key: Hashable, Value>: Collection {
     }
 
     /// Create a new FlatDictionary from an array of key value pairs
-    public init(_ values: [(key: Key, value: Value)]) {
+    public init(_ values: [Element]) {
         self.elements = values
         self.hashKeys = values.map {
             Self.hashKey($0.key)
@@ -86,6 +86,13 @@ public struct FlatDictionary<Key: Hashable, Value>: Collection {
                 self.hashKeys.append(hashKey)
             }
         }
+    }
+
+    ///  Return if dictionary has this value
+    /// - Parameter key:
+    public func has(_ key: Key) -> Bool {
+        let hashKey = Self.hashKey(key)
+        return self.hashKeys.firstIndex(of: hashKey) != nil
     }
 
     /// Return all the values, associated with a given key

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -299,7 +299,7 @@ final class RouterTests: XCTestCase {
     func testPartialCapture() throws {
         let app = HBApplication(testing: .embedded)
         app.router
-            .get("/files/file.:ext:/:name:.jpg") { request -> String in
+            .get("/files/file.${ext}/${name}.jpg") { request -> String in
                 XCTAssertEqual(request.parameters.count, 2)
                 let ext = try request.parameters.require("ext")
                 let name = try request.parameters.require("name")

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -120,4 +120,17 @@ class TrieRouterTests: XCTestCase {
         XCTAssertEqual(trie.getValueAndParameters("/test/file.jpg")?.parameters?.get("ext"), "jpg")
         XCTAssertEqual(trie.getValueAndParameters("/file.png/test")?.parameters?.get("ext"), "png")
     }
+
+    func testPrefixFullComponentCapture() {
+        let trie = RouterPathTrie<String>()
+        trie.addEntry(":text:", value: "test")
+        XCTAssertEqual(trie.getValueAndParameters("/file.jpg")?.parameters?.get("text"), "file.jpg")
+    }
+
+    func testIncompletSuffixCapture() {
+        let trie = RouterPathTrie<String>()
+        trie.addEntry("text:", value: "test")
+        XCTAssertEqual(trie.getValueAndParameters("/text:")?.value, "test")
+        XCTAssertNil(trie.getValueAndParameters("/text"))
+    }
 }

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -98,4 +98,26 @@ class TrieRouterTests: XCTestCase {
         XCTAssertEqual(trie.getValueAndParameters("/test/file.jpg")?.value, "testfile")
         XCTAssertEqual(trie.getValueAndParameters("/file.png/test")?.value, "filetest")
     }
+
+    func testPrefixCapture() {
+        let trie = RouterPathTrie<String>()
+        trie.addEntry(":file:.jpg", value: "jpg")
+        trie.addEntry("test/:file:.jpg", value: "testjpg")
+        trie.addEntry(":app:.app/config.json", value: "app")
+        XCTAssertNil(trie.getValueAndParameters("/hello.png"))
+        XCTAssertEqual(trie.getValueAndParameters("/hello.jpg")?.parameters?.get("file"), "hello")
+        XCTAssertEqual(trie.getValueAndParameters("/test/hello.jpg")?.parameters?.get("file"), "hello")
+        XCTAssertEqual(trie.getValueAndParameters("/hello.app/config.json")?.parameters?.get("app"), "hello")
+    }
+
+    func testSuffixCapture() {
+        let trie = RouterPathTrie<String>()
+        trie.addEntry("file.:ext:", value: "file")
+        trie.addEntry("test/file.:ext:", value: "testfile")
+        trie.addEntry("file.:ext:/test", value: "filetest")
+        XCTAssertNil(trie.getValueAndParameters("/file2.png"))
+        XCTAssertEqual(trie.getValueAndParameters("/file.jpg")?.parameters?.get("ext"), "jpg")
+        XCTAssertEqual(trie.getValueAndParameters("/test/file.jpg")?.parameters?.get("ext"), "jpg")
+        XCTAssertEqual(trie.getValueAndParameters("/file.png/test")?.parameters?.get("ext"), "png")
+    }
 }

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -68,6 +68,7 @@ class TrieRouterTests: XCTestCase {
     func testRecursiveWildcardWithPrefix() {
         let trie = RouterPathTrie<String>()
         trie.addEntry("Test/**", value: "true")
+        trie.addEntry("Test2/:test/**", value: "true")
         XCTAssertNil(trie.getValueAndParameters("/notTest/hello"))
         XCTAssertNil(trie.getValueAndParameters("/Test/")?.value, "true")
         XCTAssertEqual(trie.getValueAndParameters("/Test/one")?.value, "true")
@@ -75,6 +76,7 @@ class TrieRouterTests: XCTestCase {
         XCTAssertEqual(trie.getValueAndParameters("/Test/one/two/three")?.value, "true")
         XCTAssertEqual(trie.getValueAndParameters("/Test/")?.parameters?.getCatchAll(), nil)
         XCTAssertEqual(trie.getValueAndParameters("/Test/one/two")?.parameters?.getCatchAll(), "one/two")
+        XCTAssertEqual(trie.getValueAndParameters("/Test2/one/two")?.parameters?.getCatchAll(), "two")
     }
 
     func testPrefixWildcard() {

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -103,9 +103,9 @@ class TrieRouterTests: XCTestCase {
 
     func testPrefixCapture() {
         let trie = RouterPathTrie<String>()
-        trie.addEntry(":file:.jpg", value: "jpg")
-        trie.addEntry("test/:file:.jpg", value: "testjpg")
-        trie.addEntry(":app:.app/config.json", value: "app")
+        trie.addEntry("${file}.jpg", value: "jpg")
+        trie.addEntry("test/${file}.jpg", value: "testjpg")
+        trie.addEntry("${app}.app/config.json", value: "app")
         XCTAssertNil(trie.getValueAndParameters("/hello.png"))
         XCTAssertEqual(trie.getValueAndParameters("/hello.jpg")?.parameters?.get("file"), "hello")
         XCTAssertEqual(trie.getValueAndParameters("/test/hello.jpg")?.parameters?.get("file"), "hello")
@@ -114,9 +114,9 @@ class TrieRouterTests: XCTestCase {
 
     func testSuffixCapture() {
         let trie = RouterPathTrie<String>()
-        trie.addEntry("file.:ext:", value: "file")
-        trie.addEntry("test/file.:ext:", value: "testfile")
-        trie.addEntry("file.:ext:/test", value: "filetest")
+        trie.addEntry("file.${ext}", value: "file")
+        trie.addEntry("test/file.${ext}", value: "testfile")
+        trie.addEntry("file.${ext}/test", value: "filetest")
         XCTAssertNil(trie.getValueAndParameters("/file2.png"))
         XCTAssertEqual(trie.getValueAndParameters("/file.jpg")?.parameters?.get("ext"), "jpg")
         XCTAssertEqual(trie.getValueAndParameters("/test/file.jpg")?.parameters?.get("ext"), "jpg")
@@ -125,14 +125,14 @@ class TrieRouterTests: XCTestCase {
 
     func testPrefixFullComponentCapture() {
         let trie = RouterPathTrie<String>()
-        trie.addEntry(":text:", value: "test")
+        trie.addEntry("${text}", value: "test")
         XCTAssertEqual(trie.getValueAndParameters("/file.jpg")?.parameters?.get("text"), "file.jpg")
     }
 
     func testIncompletSuffixCapture() {
         let trie = RouterPathTrie<String>()
-        trie.addEntry("text:", value: "test")
-        XCTAssertEqual(trie.getValueAndParameters("/text:")?.value, "test")
+        trie.addEntry("text}", value: "test")
+        XCTAssertEqual(trie.getValueAndParameters("/text}")?.value, "test")
         XCTAssertNil(trie.getValueAndParameters("/text"))
     }
 }

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -62,7 +62,7 @@ class TrieRouterTests: XCTestCase {
         XCTAssertEqual(trie.getValueAndParameters("/one")?.value, "**")
         XCTAssertEqual(trie.getValueAndParameters("/one/two")?.value, "**")
         XCTAssertEqual(trie.getValueAndParameters("/one/two/three")?.value, "**")
-        XCTAssertEqual(trie.getValueAndParameters("/one/two/three")?.parameters?.getCatchAll(), "one/two/three")
+        XCTAssertEqual(trie.getValueAndParameters("/one/two/three")?.parameters?.getCatchAll(), ["one", "two", "three"])
     }
 
     func testRecursiveWildcardWithPrefix() {
@@ -75,8 +75,9 @@ class TrieRouterTests: XCTestCase {
         XCTAssertEqual(trie.getValueAndParameters("/Test/one/two")?.value, "true")
         XCTAssertEqual(trie.getValueAndParameters("/Test/one/two/three")?.value, "true")
         XCTAssertEqual(trie.getValueAndParameters("/Test/")?.parameters?.getCatchAll(), nil)
-        XCTAssertEqual(trie.getValueAndParameters("/Test/one/two")?.parameters?.getCatchAll(), "one/two")
-        XCTAssertEqual(trie.getValueAndParameters("/Test2/one/two")?.parameters?.getCatchAll(), "two")
+        XCTAssertEqual(trie.getValueAndParameters("/Test/one/two")?.parameters?.getCatchAll(), ["one", "two"])
+        XCTAssertEqual(trie.getValueAndParameters("/Test2/one/two")?.parameters?.getCatchAll(), ["two"])
+        XCTAssertEqual(HBParameters().getCatchAll(), [])
     }
 
     func testPrefixWildcard() {

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -62,7 +62,7 @@ class TrieRouterTests: XCTestCase {
         XCTAssertEqual(trie.getValueAndParameters("/one")?.value, "**")
         XCTAssertEqual(trie.getValueAndParameters("/one/two")?.value, "**")
         XCTAssertEqual(trie.getValueAndParameters("/one/two/three")?.value, "**")
-        XCTAssertEqual(trie.getValueAndParameters("/one/two/three")?.parameters?.getRecursiveCapture(), "one/two/three")
+        XCTAssertEqual(trie.getValueAndParameters("/one/two/three")?.parameters?.getCatchAll(), "one/two/three")
     }
 
     func testRecursiveWildcardWithPrefix() {
@@ -73,8 +73,8 @@ class TrieRouterTests: XCTestCase {
         XCTAssertEqual(trie.getValueAndParameters("/Test/one")?.value, "true")
         XCTAssertEqual(trie.getValueAndParameters("/Test/one/two")?.value, "true")
         XCTAssertEqual(trie.getValueAndParameters("/Test/one/two/three")?.value, "true")
-        XCTAssertEqual(trie.getValueAndParameters("/Test/")?.parameters?.getRecursiveCapture(), nil)
-        XCTAssertEqual(trie.getValueAndParameters("/Test/one/two")?.parameters?.getRecursiveCapture(), "one/two")
+        XCTAssertEqual(trie.getValueAndParameters("/Test/")?.parameters?.getCatchAll(), nil)
+        XCTAssertEqual(trie.getValueAndParameters("/Test/one/two")?.parameters?.getCatchAll(), "one/two")
     }
 
     func testPrefixWildcard() {


### PR DESCRIPTION
Capture paths caught by recursive wildcard
```swift
router.get("**") { request in
    request.parameters.getCatchAll()
}
```
`GET /test/this` will return `test/this`

Wildcards with both prefix and suffix
```swift
router.get("*.jpg") { request in
}
router.get("file.*") { request in
}
```
Capture with both prefix and suffix. The parameter name is surrounded by ":" instead of just being prefixed with a ":"
```swift
router.get(":image:.jpg") { request in
    request.parameters.get("image")
}
router.get("file.:ext:") { request in
    request.parameters.get("ext")
}
```
