### PR TITLE
Add support for loading `.env` files

### DIFF
--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -97,7 +97,7 @@ public struct HBEnvironment: Decodable, ExpressibleByDictionaryLiteral {
     /// If an environment variable exists in both sets it will choose the version from the second
     /// set of environment variables
     /// - Parameter env: environemnt variables to merge into this environment variable set
-    public func merging(_ env: HBEnvironment) -> HBEnvironment {
+    public func merging(with env: HBEnvironment) -> HBEnvironment {
         .init(rawValues: self.values.merging(env.values) { $1 })
     }
 

--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -17,11 +17,27 @@ import Glibc
 #else
 import Darwin.C
 #endif
+import NIO
 
 /// Access environment variables
 public struct HBEnvironment: Decodable, ExpressibleByDictionaryLiteral {
+    struct Error: Swift.Error, Equatable {
+        enum Value {
+            case dotEnvParseError
+        }
+
+        private let value: Value
+        private init(_ value: Value) {
+            self.value = value
+        }
+
+        public static var dotEnvParseError: Self { .init(.dotEnvParseError) }
+    }
+
     // shared environment
     public static let shared: HBEnvironment = .init()
+
+    var values: [String: String]
 
     /// initialize from environment variables
     public init() {
@@ -76,6 +92,15 @@ public struct HBEnvironment: Decodable, ExpressibleByDictionaryLiteral {
         self.values[s.lowercased()] = value
     }
 
+    /// Merge two environment variable sets together and return result
+    ///
+    /// If an environment variable exists in both sets it will choose the version from the second
+    /// set of environment variables
+    /// - Parameter env: environemnt variables to merge into this environment variable set
+    public func merging(_ env: HBEnvironment) -> HBEnvironment {
+        .init(rawValues: self.values.merging(env.values) { $1 })
+    }
+
     /// Construct environment variable map
     static func getEnvironment() -> [String: String] {
         var values: [String: String] = [:]
@@ -95,7 +120,91 @@ public struct HBEnvironment: Decodable, ExpressibleByDictionaryLiteral {
         return values
     }
 
-    var values: [String: String]
+    /// Create HBEnvironment initialised from the `.env` file
+    public static func dotEnv() throws -> Self {
+        guard let dotEnv = loadDotEnv() else { return [:] }
+        return try .init(rawValues: self.parseDotEnv(dotEnv))
+    }
+
+    /// Load `.env` file into string
+    internal static func loadDotEnv() -> String? {
+        do {
+            let fileHandle = try NIOFileHandle(path: ".env")
+            defer {
+                try? fileHandle.close()
+            }
+            let fileRegion = try FileRegion(fileHandle: fileHandle)
+            let contents = try fileHandle.withUnsafeFileDescriptor { descriptor in
+                return Array<UInt8>.init(unsafeUninitializedCapacity: fileRegion.readableBytes) { bytes, size in
+                    size = fileRegion.readableBytes
+                    read(descriptor, .init(bytes.baseAddress), size)
+                }
+            }
+            return String(bytes: contents, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Parse a `.env` file
+    internal static func parseDotEnv(_ dotEnv: String) throws -> [String: String] {
+        enum DotEnvParserState {
+            case readingKey
+            case skippingEquals(key: String)
+            case readingValue(key: String)
+        }
+        var dotEnvDictionary: [String: String] = [:]
+        var parser = HBParser(dotEnv)
+        var state: DotEnvParserState = .readingKey
+        do {
+            parser.read(while: \.isWhitespace)
+            while !parser.reachedEnd() {
+                switch state {
+                case .readingKey:
+                    // check for comment
+                    let c = parser.current()
+                    if c == "#" {
+                        do {
+                            _ = try parser.read(until: \.isNewline)
+                            parser.unsafeAdvance()
+                        } catch HBParser.Error.overflow {
+                            parser.moveToEnd()
+                            break
+                        }
+                    }
+                    let key = try parser.read(until: { $0.isWhitespace || $0 == "=" }).string
+                    state = .skippingEquals(key: key)
+
+                case .skippingEquals(let key):
+                    let c = try parser.character()
+                    // we are expecting an equals
+                    guard c == "=" else { throw Error.dotEnvParseError }
+                    state = .readingValue(key: key)
+
+                case .readingValue(let key):
+                    let value: String
+                    if try parser.read("\"") {
+                        value = try parser.read(until: { $0 == "\"" }).string
+                        parser.unsafeAdvance()
+                    } else {
+                        value = try parser.read(until: \.isWhitespace, throwOnOverflow: false).string
+                    }
+                    dotEnvDictionary[key.lowercased()] = value
+                    state = .readingKey
+                }
+                parser.read(while: \.isWhitespace)
+            }
+            guard case .readingKey = state else { throw Error.dotEnvParseError }
+        } catch {
+            throw Error.dotEnvParseError
+        }
+        return dotEnvDictionary
+    }
+
+    /// initialize from an already processed dictionary
+    private init(rawValues: [String: String]) {
+        self.values = rawValues
+    }
 }
 
 extension HBEnvironment: CustomStringConvertible {

--- a/Sources/Hummingbird/Utils/HBParser.swift
+++ b/Sources/Hummingbird/Utils/HBParser.swift
@@ -394,6 +394,16 @@ public extension HBParser {
         }
     }
 
+    /// Move parser to beginning of string
+    mutating func moveToStart() {
+        self.index = self.range.startIndex
+    }
+
+    /// Move parser to end of string
+    mutating func moveToEnd() {
+        self.index = self.range.endIndex
+    }
+
     mutating func unsafeAdvance() {
         self.index = skipUTF8Character(at: self.index)
     }

--- a/Tests/HummingbirdTests/EnvironmentTests.swift
+++ b/Tests/HummingbirdTests/EnvironmentTests.swift
@@ -116,7 +116,7 @@ final class EnvironmentTests: XCTestCase {
         }
         XCTAssertEqual(setenv("TEST_VAR", "testSetFromEnvironment", 1), 0)
         XCTAssertEqual(setenv("TEST_VAR2", "testSetFromEnvironment2", 1), 0)
-        let env = try HBEnvironment.shared.merging(.dotEnv())
+        let env = try HBEnvironment.shared.merging(with: .dotEnv())
         XCTAssertEqual(env.get("TEST_VAR"), "testDotEnvOverridingEnvironment")
         XCTAssertEqual(env.get("TEST_VAR2"), "testSetFromEnvironment2")
     }

--- a/Tests/HummingbirdTests/EnvironmentTests.swift
+++ b/Tests/HummingbirdTests/EnvironmentTests.swift
@@ -71,6 +71,16 @@ final class EnvironmentTests: XCTestCase {
         XCTAssertEqual(result.get("credentials"), "sdkfjh")
     }
 
+    func testDotEnvParsingError() throws {
+        let dotenv = """
+        TEST #thse
+        """
+        do {
+            let result = try HBEnvironment.parseDotEnv(dotenv)
+            XCTFail("Should fail")
+        } catch let error as HBEnvironment.Error where error == .dotEnvParseError {}
+    }
+
     func testDotEnvSpeechMarks() throws {
         let dotenv = """
         TEST="test this"

--- a/Tests/HummingbirdTests/EnvironmentTests.swift
+++ b/Tests/HummingbirdTests/EnvironmentTests.swift
@@ -76,7 +76,7 @@ final class EnvironmentTests: XCTestCase {
         TEST #thse
         """
         do {
-            let result = try HBEnvironment.parseDotEnv(dotenv)
+            _ = try HBEnvironment.parseDotEnv(dotenv)
             XCTFail("Should fail")
         } catch let error as HBEnvironment.Error where error == .dotEnvParseError {}
     }

--- a/Tests/HummingbirdTests/EnvironmentTests.swift
+++ b/Tests/HummingbirdTests/EnvironmentTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import Hummingbird
+@testable import Hummingbird
 import XCTest
 
 final class EnvironmentTests: XCTestCase {
@@ -45,5 +45,79 @@ final class EnvironmentTests: XCTestCase {
         setenv("LOG_LEVEL", "trace", 1)
         let app = HBApplication()
         XCTAssertEqual(app.logger.logLevel, .trace)
+    }
+
+    func testCaseInsensitive() {
+        XCTAssertEqual(setenv("test_VAR", "testSetFromEnvironment", 1), 0)
+        let env = HBEnvironment()
+        XCTAssertEqual(env.get("TEST_VAR"), "testSetFromEnvironment")
+        XCTAssertEqual(env.get("test_var"), "testSetFromEnvironment")
+    }
+
+    func testDotEnvLoading() throws {
+        let dotenv = """
+        TEST=this
+        CREDENTIALS=sdkfjh
+        """
+        let data = dotenv.data(using: .utf8)
+        let envURL = URL(fileURLWithPath: ".env")
+        try data?.write(to: envURL)
+        defer {
+            try? FileManager.default.removeItem(at: envURL)
+        }
+
+        let result = try HBEnvironment.dotEnv()
+        XCTAssertEqual(result.get("test"), "this")
+        XCTAssertEqual(result.get("credentials"), "sdkfjh")
+    }
+
+    func testDotEnvSpeechMarks() throws {
+        let dotenv = """
+        TEST="test this"
+        CREDENTIALS=sdkfjh
+        """
+        let result = try HBEnvironment.parseDotEnv(dotenv)
+        XCTAssertEqual(result["test"], "test this")
+        XCTAssertEqual(result["credentials"], "sdkfjh")
+    }
+
+    func testDotEnvMultilineValue() throws {
+        let dotenv = """
+        TEST="test
+        this"
+        CREDENTIALS=sdkfjh
+        """
+        let result = try HBEnvironment.parseDotEnv(dotenv)
+        XCTAssertEqual(result["test"], "test\nthis")
+        XCTAssertEqual(result["credentials"], "sdkfjh")
+    }
+
+    func testDotEnvComments() throws {
+        let dotenv = """
+        # Comment 
+        TEST=this # Comment at end of line
+        CREDENTIALS=sdkfjh
+        # Comment at end
+        """
+        let result = try HBEnvironment.parseDotEnv(dotenv)
+        XCTAssertEqual(result["test"], "this")
+        XCTAssertEqual(result["credentials"], "sdkfjh")
+    }
+
+    func testDotEnvOverridingEnvironment() throws {
+        let dotenv = """
+        TEST_VAR=testDotEnvOverridingEnvironment
+        """
+        let data = dotenv.data(using: .utf8)
+        let envURL = URL(fileURLWithPath: ".env")
+        try data?.write(to: envURL)
+        defer {
+            try? FileManager.default.removeItem(at: envURL)
+        }
+        XCTAssertEqual(setenv("TEST_VAR", "testSetFromEnvironment", 1), 0)
+        XCTAssertEqual(setenv("TEST_VAR2", "testSetFromEnvironment2", 1), 0)
+        let env = try HBEnvironment.shared.merging(.dotEnv())
+        XCTAssertEqual(env.get("TEST_VAR"), "testDotEnvOverridingEnvironment")
+        XCTAssertEqual(env.get("TEST_VAR2"), "testSetFromEnvironment2")
     }
 }


### PR DESCRIPTION
Add static function `HBEnvironment.dotEnv()` that loads a `.env` file and creates an `HBEnvironment` from it
Add function `merging` which merges two `HBEnvironments` together.

So to get the full set of environment variables you can do the following
```swift
let env = try HBEnvironment.shared.merging(with: .dotEnv())
```