### PR TITLE
Use async version of HBRequestBody.consumeBody, adding tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.45.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "1.0.0-alpha.9"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird-core.git", from: "1.2.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-core.git", from: "1.2.1"),
     ],
     targets: [
         .target(name: "Hummingbird", dependencies: [

--- a/Sources/Hummingbird/AsyncAwaitSupport/Router+async.swift
+++ b/Sources/Hummingbird/AsyncAwaitSupport/Router+async.swift
@@ -80,9 +80,8 @@ extension HBRouterMethods {
             var request = request
             if case .stream = request.body, !options.contains(.streamBody) {
                 let buffer = try await request.body.consumeBody(
-                    maxSize: request.application.configuration.maxUploadSize,
-                    on: request.eventLoop
-                ).get()
+                    maxSize: request.application.configuration.maxUploadSize
+                )
                 request.body = .byteBuffer(buffer)
             }
             if options.contains(.editResponse) {

--- a/Tests/HummingbirdTests/AsyncAwaitTests.swift
+++ b/Tests/HummingbirdTests/AsyncAwaitTests.swift
@@ -104,6 +104,31 @@ final class AsyncAwaitTests: XCTestCase {
         }
     }
 
+    func testCollatingRequestBody() throws {
+        #if os(macOS)
+        // disable macOS tests in CI. GH Actions are currently running this when they shouldn't
+        guard HBEnvironment().get("CI") != "true" else { throw XCTSkip() }
+        #endif
+        let app = HBApplication(testing: .asyncTest)
+        app.router.patch("size") { request -> String in
+            guard let body = request.body.buffer else {
+                throw HBHTTPError(.badRequest)
+            }
+            // force route to be async
+            try await Task.sleep(nanoseconds: 1)
+            return body.readableBytes.description
+        }
+
+        try app.XCTStart()
+        defer { app.XCTStop() }
+
+        let buffer = self.randomBuffer(size: 530_001)
+        try app.XCTExecute(uri: "/size", method: .PATCH, body: buffer) { response in
+            let body = try XCTUnwrap(response.body)
+            XCTAssertEqual(String(buffer: body), "530001")
+        }
+    }
+
     /// Test streaming of requests via AsyncSequence
     func testStreaming() throws {
         #if os(macOS)


### PR DESCRIPTION
Also add tests