### PR TITLE
Add support for writing informational headers

### DIFF
--- a/Sources/Hummingbird/Server/Application+HTTPResponder.swift
+++ b/Sources/Hummingbird/Server/Application+HTTPResponder.swift
@@ -73,5 +73,10 @@ extension HBApplication {
         var eventLoop: EventLoop { return self.channel.eventLoop }
         var allocator: ByteBufferAllocator { return self.channel.allocator }
         var remoteAddress: SocketAddress? { return self.channel.remoteAddress }
+
+        /// Used by HBRequest to write informational headers
+        func writeInformationalResponse(head: HTTPResponseHead) {
+            self.channel.writeAndFlush(HTTPPart<HTTPResponseHead, IOData>.head(head), promise: nil)
+        }
     }
 }

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -187,6 +187,36 @@ public struct HBRequest: Sendable, HBSendableExtensible {
     private static let globalRequestID = ManagedAtomic(0)
 }
 
+extension HBRequest {
+    public enum InformationalResponseStatus {
+        case `continue`
+        case switchingProtocols
+        case processing
+        case earlyHints
+
+        var httpResponseStatus: HTTPResponseStatus {
+            switch self {
+            case .continue: return .continue
+            case .switchingProtocols: return .switchingProtocols
+            case .processing: return .processing
+            case .earlyHints: return .custom(code: 103, reasonPhrase: "Early Hints")
+            }
+        }
+    }
+
+    /// Write informantional response back before finishing processing request
+    ///
+    /// An informational response indicates that the request was received and understood. It is issued on a
+    /// provisional basis while request processing continues. It alerts the client to wait for a final response.
+    /// The message consists only of the status line and optional header fields
+    /// - Parameters:
+    ///   - status: information response status
+    ///   - headers: headers to include in information response
+    public func writeInformationalResponse(status: InformationalResponseStatus, headers: HTTPHeaders = [:]) {
+        self.context.writeInformationalResponse(head: .init(version: self.version, status: status.httpResponseStatus, headers: headers))
+    }
+}
+
 extension Logger {
     /// Create new Logger with additional metadata value
     /// - Parameters:

--- a/Sources/Hummingbird/Server/RequestContext.swift
+++ b/Sources/Hummingbird/Server/RequestContext.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOHTTP1
+
 /// Context that created HBRequest.
 public protocol HBRequestContext: Sendable {
     /// EventLoop request is running on
@@ -20,4 +22,8 @@ public protocol HBRequestContext: Sendable {
     var allocator: ByteBufferAllocator { get }
     /// Connected host address
     var remoteAddress: SocketAddress? { get }
+
+    ///  Write informational response back to server before completing the request
+    /// - Parameter head: response head
+    func writeInformationalResponse(head: HTTPResponseHead)
 }


### PR DESCRIPTION
Added `HBRequest.writeInformationalResponse`. 
Used for writing 1xx status codes