### PR TITLE
Use PartialKeyPath hash value as key in extensions

### DIFF
--- a/Sources/Hummingbird/Extensions/Extensions.swift
+++ b/Sources/Hummingbird/Extensions/Extensions.swift
@@ -42,6 +42,12 @@ public struct HBExtensions<ParentObject> {
         self.items[key.hashValue]?.value as? Type
     }
 
+    /// Get optional extension from a `KeyPath` that returns an optional
+    @inlinable
+    public func get<Type>(_ key: KeyPath<ParentObject, Type?>) -> Type? {
+        self.items[key.hashValue]?.value as? Type
+    }
+
     /// Get extension from a `KeyPath`
     @inlinable
     public func get<Type>(_ key: KeyPath<ParentObject, Type>, error: StaticString? = nil) -> Type {
@@ -119,13 +125,19 @@ public struct HBSendableExtensions<ParentObject>: Sendable {
 
     /// Get optional extension from a `KeyPath`
     @inlinable
-    public func get<Type: HBSendable>(_ key: KeyPath<ParentObject, Type>) -> Type? {
+    public func get<Type: Sendable>(_ key: KeyPath<ParentObject, Type>) -> Type? {
+        self.items[key.hashValue]?.value as? Type
+    }
+
+    /// Get optional extension from a `KeyPath` that returns an optional
+    @inlinable
+    public func get<Type: Sendable>(_ key: KeyPath<ParentObject, Type?>) -> Type? {
         self.items[key.hashValue]?.value as? Type
     }
 
     /// Get extension from a `KeyPath`
     @inlinable
-    public func get<Type: HBSendable>(_ key: KeyPath<ParentObject, Type>, error: StaticString? = nil) -> Type {
+    public func get<Type: Sendable>(_ key: KeyPath<ParentObject, Type>, error: StaticString? = nil) -> Type {
         guard let value = items[key.hashValue]?.value as? Type else {
             preconditionFailure(error?.description ?? "Cannot get extension of type \(Type.self) without having set it")
         }
@@ -134,7 +146,7 @@ public struct HBSendableExtensions<ParentObject>: Sendable {
 
     /// Return if extension has been set
     @inlinable
-    public func exists<Type: HBSendable>(_ key: KeyPath<ParentObject, Type>) -> Bool {
+    public func exists<Type: Sendable>(_ key: KeyPath<ParentObject, Type>) -> Bool {
         self.items[key.hashValue]?.value != nil
     }
 
@@ -144,7 +156,7 @@ public struct HBSendableExtensions<ParentObject>: Sendable {
     ///   - value: value to store in extension
     ///   - shutdownCallback: closure to call when extensions are shutsdown
     @inlinable
-    public mutating func set<Type: HBSendable>(_ key: KeyPath<ParentObject, Type>, value: Type) {
+    public mutating func set<Type: Sendable>(_ key: KeyPath<ParentObject, Type>, value: Type) {
         self.items[key.hashValue] = .init(
             value: value
         )

--- a/Sources/Hummingbird/Extensions/Extensions.swift
+++ b/Sources/Hummingbird/Extensions/Extensions.swift
@@ -37,11 +37,13 @@ public struct HBExtensions<ParentObject> {
     }
 
     /// Get optional extension from a `KeyPath`
+    @inlinable
     public func get<Type>(_ key: KeyPath<ParentObject, Type>) -> Type? {
         self.items[key.hashValue]?.value as? Type
     }
 
     /// Get extension from a `KeyPath`
+    @inlinable
     public func get<Type>(_ key: KeyPath<ParentObject, Type>, error: StaticString? = nil) -> Type {
         guard let value = items[key.hashValue]?.value as? Type else {
             preconditionFailure(error?.description ?? "Cannot get extension of type \(Type.self) without having set it")
@@ -50,6 +52,7 @@ public struct HBExtensions<ParentObject> {
     }
 
     /// Return if extension has been set
+    @inlinable
     public func exists<Type>(_ key: KeyPath<ParentObject, Type>) -> Bool {
         self.items[key.hashValue]?.value != nil
     }
@@ -59,6 +62,7 @@ public struct HBExtensions<ParentObject> {
     ///   - key: KeyPath
     ///   - value: value to store in extension
     ///   - shutdownCallback: closure to call when extensions are shutsdown
+    @inlinable
     public mutating func set<Type>(_ key: KeyPath<ParentObject, Type>, value: Type, shutdownCallback: ((Type) throws -> Void)? = nil) {
         let keyHash = key.hashValue
         if let item = items[keyHash] {
@@ -81,32 +85,46 @@ public struct HBExtensions<ParentObject> {
         self.items = [:]
     }
 
+    @usableFromInline
     struct Item {
+        @usableFromInline
+        init(value: Any, shutdown: ((Any) throws -> Void)? = nil) {
+            self.value = value
+            self.shutdown = shutdown
+        }
+
+        @usableFromInline
         let value: Any
+        @usableFromInline
         let shutdown: ((Any) throws -> Void)?
     }
 
+    @usableFromInline
     var items: [Int: Item]
 }
 
 /// Protocol for extensible classes
 public protocol HBExtensible {
+    @inlinable
     var extensions: HBExtensions<Self> { get set }
 }
 
 /// Version of `HBExtensions` that requires all extensions are sendable
 public struct HBSendableExtensions<ParentObject>: Sendable {
     /// Initialize extensions
+    @inlinable
     public init() {
         self.items = [:]
     }
 
     /// Get optional extension from a `KeyPath`
+    @inlinable
     public func get<Type: HBSendable>(_ key: KeyPath<ParentObject, Type>) -> Type? {
         self.items[key.hashValue]?.value as? Type
     }
 
     /// Get extension from a `KeyPath`
+    @inlinable
     public func get<Type: HBSendable>(_ key: KeyPath<ParentObject, Type>, error: StaticString? = nil) -> Type {
         guard let value = items[key.hashValue]?.value as? Type else {
             preconditionFailure(error?.description ?? "Cannot get extension of type \(Type.self) without having set it")
@@ -115,6 +133,7 @@ public struct HBSendableExtensions<ParentObject>: Sendable {
     }
 
     /// Return if extension has been set
+    @inlinable
     public func exists<Type: HBSendable>(_ key: KeyPath<ParentObject, Type>) -> Bool {
         self.items[key.hashValue]?.value != nil
     }
@@ -124,20 +143,30 @@ public struct HBSendableExtensions<ParentObject>: Sendable {
     ///   - key: KeyPath
     ///   - value: value to store in extension
     ///   - shutdownCallback: closure to call when extensions are shutsdown
+    @inlinable
     public mutating func set<Type: HBSendable>(_ key: KeyPath<ParentObject, Type>, value: Type) {
         self.items[key.hashValue] = .init(
             value: value
         )
     }
 
-    struct Item {
-        let value: Any
+    @usableFromInline
+    struct Item: Sendable {
+        @usableFromInline
+        internal init(value: Sendable) {
+            self.value = value
+        }
+
+        @usableFromInline
+        let value: Sendable
     }
 
+    @usableFromInline
     var items: [Int: Item]
 }
 
 /// Protocol for extensible classes
 public protocol HBSendableExtensible {
+    @inlinable
     var extensions: HBSendableExtensions<Self> { get set }
 }

--- a/Sources/Hummingbird/Router/Parameters.swift
+++ b/Sources/Hummingbird/Router/Parameters.swift
@@ -19,6 +19,7 @@ public struct HBParameters: Sendable {
 
     static let recursiveCaptureKey: Substring = ":**:"
 
+    @usableFromInline
     init() {
         self.parameters = .init()
     }

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -53,10 +53,10 @@ public struct HBRequest: Sendable, HBSendableExtensible {
 
     /// Parameters extracted during processing of request URI. These are available to you inside the route handler
     public var parameters: HBParameters {
-        get {
+        @inlinable get {
             self.extensions.get(\.parameters) ?? .init()
         }
-        set { self.extensions.set(\.parameters, value: newValue) }
+        @inlinable set { self.extensions.set(\.parameters, value: newValue) }
     }
 
     /// endpoint that services this request.

--- a/Tests/HummingbirdTests/ExtensionTests.swift
+++ b/Tests/HummingbirdTests/ExtensionTests.swift
@@ -23,9 +23,19 @@ extension HBApplication {
         }
     }
 
-    var ext: Int? {
+    var ext: Int {
         get { return extensions.get(\.ext) }
         set { extensions.set(\.ext, value: newValue) }
+    }
+
+    var extWithDefault: Int {
+        get { return extensions.get(\.ext) ?? 50 }
+        set { extensions.set(\.ext, value: newValue) }
+    }
+
+    var optionalExt: Int? {
+        get { return extensions.get(\.optionalExt) }
+        set { extensions.set(\.optionalExt, value: newValue) }
     }
 
     var shutdownTest: ActiveTest? {
@@ -38,11 +48,51 @@ extension HBApplication {
     }
 }
 
+extension HBRequest {
+    var ext: Int {
+        get { return extensions.get(\.ext) }
+        set { extensions.set(\.ext, value: newValue) }
+    }
+
+    var extWithDefault: Int {
+        get { return extensions.get(\.ext) ?? 50 }
+        set { extensions.set(\.ext, value: newValue) }
+    }
+
+    var optionalExt: Int? {
+        get { return extensions.get(\.optionalExt) }
+        set { extensions.set(\.optionalExt, value: newValue) }
+    }
+}
+
 class ExtensionTests: XCTestCase {
     func testExtension() {
         let app = HBApplication()
         app.ext = 56
         XCTAssertEqual(app.ext, 56)
+    }
+
+    func testExtensionWithDefault() {
+        let app = HBApplication()
+        XCTAssertEqual(app.extWithDefault, 50)
+        app.ext = 23
+        XCTAssertEqual(app.extWithDefault, 23)
+    }
+
+    func testOptionalExtension() {
+        let app = HBApplication()
+        app.optionalExt = 56
+        XCTAssertEqual(app.optionalExt, 56)
+    }
+
+    func testExists() {
+        let app = HBApplication()
+        XCTAssertEqual(app.extensions.exists(\.ext), false)
+        XCTAssertEqual(app.extensions.exists(\.optionalExt), false)
+        app.optionalExt = 1
+        app.ext = 2
+        XCTAssertEqual(app.extensions.exists(\.ext), true)
+        XCTAssertEqual(app.extensions.exists(\.optionalExt), true)
     }
 
     func testExtensionShutdown() throws {


### PR DESCRIPTION
This allows us to set `HBSendableExtensions` to Sendable without an `@unchecked`

Also add @inlinable markings and fix issue where optional values were not using the correct path when calling get