### PR TITLE
Allow matching HBMediaType in switch statements

### DIFF
--- a/Sources/Hummingbird/HTTP/MediaType.swift
+++ b/Sources/Hummingbird/HTTP/MediaType.swift
@@ -125,12 +125,15 @@ public struct HBMediaType: Sendable, CustomStringConvertible {
     /// Return if media type matches the input
     public func isType(_ type: HBMediaType) -> Bool {
         guard self.type == type.type,
-              self.subType == type.subType || type.subType == "*",
-              type.parameter == nil || (self.parameter?.name == type.parameter?.name && self.parameter?.value == type.parameter?.value)
+              self.subType == type.subType || type.subType == "*"
         else {
             return false
         }
-        return true
+        if let parameter = type.parameter {
+            return parameter.name == self.parameter?.name && parameter.value == self.parameter?.value
+        } else {
+            return true
+        }
     }
 
     /// Get media type from a file extension
@@ -421,4 +424,11 @@ extension HBMediaType {
         "3g2": .video3g2,
         "7z": .application7z,
     ]
+}
+
+extension HBMediaType {
+    // Allow matching media types in switch statements
+    public static func ~= (_ lhs: Self, _ rhs: Self) -> Bool {
+        rhs.isType(lhs)
+    }
 }

--- a/Tests/HummingbirdTests/HTTPTests.swift
+++ b/Tests/HummingbirdTests/HTTPTests.swift
@@ -89,6 +89,19 @@ class HTTPTests: XCTestCase {
         XCTAssert(HBMediaType(from: "audio/ogg")?.isType(.audioOgg) == true)
     }
 
+    func testMediaTypeMatching() {
+        switch HBMediaType(from: "application/json; charset=utf8") {
+        case .some(.application), .some(.applicationJson):
+            break
+        default: XCTFail()
+        }
+        switch HBMediaType(from: "application/json") {
+        case .some(.application), .some(.applicationJson):
+            break
+        default: XCTFail()
+        }
+    }
+
     func testMediaTypeParameters() {
         let mediaType = HBMediaType(from: "application/json; charset=utf8")
         XCTAssertEqual(mediaType?.parameter?.name, "charset")

--- a/Tests/HummingbirdTests/HTTPTests.swift
+++ b/Tests/HummingbirdTests/HTTPTests.swift
@@ -102,6 +102,19 @@ class HTTPTests: XCTestCase {
         }
     }
 
+    func testMediaTypeMisMatching() {
+        switch HBMediaType.applicationJson {
+        case HBMediaType(from: "application/json; charset=utf8")!:
+            XCTFail()
+        default: break
+        }
+        switch HBMediaType.application {
+        case .applicationJson:
+            XCTFail()
+        default: break
+        }
+    }
+
     func testMediaTypeParameters() {
         let mediaType = HBMediaType(from: "application/json; charset=utf8")
         XCTAssertEqual(mediaType?.parameter?.name, "charset")


### PR DESCRIPTION
Allows

```swift
switch mediaType {
// will match "application/json" and "application/json; charset=utf8"
case .applicationJson:
    break
default:
    break
}