### PR TITLE
Fix crash in tracing middleware when streaming body

### DIFF
--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -55,7 +55,7 @@ public struct HBTracingMiddleware: HBMiddleware {
                 attributes["http.flavor"] = "\(request.version.major).\(request.version.minor)"
                 attributes["http.scheme"] = request.uri.scheme?.rawValue
                 attributes["http.user_agent"] = request.headers.first(name: "user-agent")
-                attributes["http.request_content_length"] = request.body.buffer?.readableBytes
+                attributes["http.request_content_length"] = request.headers["content-length"].first.map { Int($0) } ?? nil
 
                 attributes["net.host.name"] = request.application.server.configuration.address.host
                 attributes["net.host.port"] = request.application.server.configuration.address.port
@@ -90,7 +90,9 @@ public struct HBTracingMiddleware: HBMiddleware {
                             switch response.body {
                             case .byteBuffer(let buffer):
                                 attributes["http.response_content_length"] = buffer.readableBytes
-                            case .stream, .empty:
+                            case .stream:
+                                attributes["http.response_content_length"] = response.headers["content-length"].first.map { Int($0) } ?? nil
+                            case .empty:
                                 break
                             }
                         }

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -75,7 +75,7 @@ final class TracingTests: XCTestCase {
         try app.XCTStart()
         defer { app.XCTStop() }
 
-        try app.XCTExecute(uri: "/users", method: .POST, body: ByteBuffer(string: "42")) { response in
+        try app.XCTExecute(uri: "/users", method: .POST, headers: ["content-length": "2"], body: ByteBuffer(string: "42")) { response in
             XCTAssertEqual(response.status, .internalServerError)
         }
 


### PR DESCRIPTION
You can't assume the body is available as a buffer, as it might be a stream