### PR TITLE
Update CORSMiddleware.swift

### DIFF
--- a/Sources/Hummingbird/Middleware/CORSMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/CORSMiddleware.swift
@@ -113,6 +113,9 @@ public struct HBCORSMiddleware: HBMiddleware {
             return next.respond(to: request).map { response in
                 var response = response
                 response.headers.add(name: "access-control-allow-origin", value: self.allowOrigin.value(for: request) ?? "")
+                if self.allowCredentials {
+                    response.headers.add(name: "access-control-allow-credentials", value: "true")
+                }
                 if case .originBased = self.allowOrigin {
                     response.headers.add(name: "vary", value: "Origin")
                 }


### PR DESCRIPTION
As mentioned in this [issue](https://github.com/hummingbird-project/hummingbird/issues/236) the Access-Control-Allow-Credentials header is missing in the actual response but send in the preflight.

Access-Control-Allow-Credentials is only set as response header when _allowCredentials_ is set to true

Changes are working on my environment and the browser are happy :)