### PR TITLE
Fix SVGs in Safari

### DIFF
--- a/Sources/Hummingbird/HTTP/MediaType.swift
+++ b/Sources/Hummingbird/HTTP/MediaType.swift
@@ -288,7 +288,7 @@ extension HBMediaType {
     /// Portable Network Graphics
     public static var imagePng: Self { .init(type: .image, subType: "png") }
     /// Scalable Vector Graphics (SVG)
-    public static var imageSvg: Self { .init(type: .image, subType: "svg") }
+    public static var imageSvg: Self { .init(type: .image, subType: "svg+xml") }
     /// Tagged Image File Format (TIFF)
     public static var imageTiff: Self { .init(type: .image, subType: "tiff") }
     /// WEBP image


### PR DESCRIPTION
SVG images weren't being displayed correctly in Safari when using `HBFileMiddleware`. Following a little investigation, it looks like Safari will only treat SVGs as images if they have the 'image/svg+xml' MIME type, whereas both Firefox and Chrome are more than happy to display them with the 'image/svg' MIME type, perhaps explaining why this wasn't seen earlier. Nginx reports SVG images as 'image/svg+xml'.

This change updates the mapping from the '.svg' extension to the 'image/svg+xml' MIME type to bring it in-line with Nginx behaviour (and presumably that of other servers).

I have verified that Safari displays SVG images correctly with this change, and Chrome and Firefox also continue to behave correctly.