### PR TITLE
Add async version of wait, add run and asyncRun

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -186,7 +186,7 @@ public final class HBApplication: HBExtensible {
 
     /// Start application and wait for it to stop
     ///
-    /// Version of `run`` that can be called from asynchronous context
+    /// Version of `run` that can be called from asynchronous context
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     public func asyncRun() async throws {
         try await self.onExecutionQueue { app in

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -212,7 +212,7 @@ public final class HBApplication: HBExtensible {
     ///
     /// This function can only be called from a non async context as it stalls
     /// the current thread waiting for the application to finish
-    @available(*, noasync, message: "Use HBApplication.asyncRun instead.")
+    @available(*, noasync, message: "Use HBApplication.asyncWait instead.")
     public func wait() {
         self.lifecycle.wait()
     }

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -18,7 +18,7 @@ import NIOPosix
 
 // get environment
 let hostname = HBEnvironment.shared.get("SERVER_HOSTNAME") ?? "127.0.0.1"
-let port = HBEnvironment.shared.get("SERVER_PORT", as: Int.self) ?? 8080
+let port = HBEnvironment.shared.get("SERVER_PORT", as: Int.self) ?? 8081
 
 // create app
 let elg = MultiThreadedEventLoopGroup(numberOfThreads: 2)
@@ -54,6 +54,4 @@ app.router.get("json") { _ in
 }
 
 // run app
-if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
-    try await app.asyncRun()
-}
+try app.run()

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -54,5 +54,6 @@ app.router.get("json") { _ in
 }
 
 // run app
-try app.start()
-app.wait()
+if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+    try await app.asyncRun()
+}


### PR DESCRIPTION
`HBApplication.wait` stalls the thread it is running on. If that thread is used by the task executor it will mean running Tasks could stall. This PR adds `asyncWait` to run application on a separate DispatchQueue.

Also added a `run` and `asyncRun` which are combinations of `start` and `wait`/`asyncWait`