### PR TITLE
HBResponder conforming to Sendable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: SPM tests
-      run: swift test --enable-code-coverage
+      run: swift test
     - name: Convert coverage files
       run: |
         xcrun llvm-cov export -format "lcov" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   macOS:
-    runs-on: macOS-latest
+    runs-on: macOS-13
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: SPM tests
-      run: swift test
+      run: swift test --enable-code-coverage
     - name: Convert coverage files
       run: |
         xcrun llvm-cov export -format "lcov" \

--- a/Sources/Hummingbird/ApplicationBuilder.swift
+++ b/Sources/Hummingbird/ApplicationBuilder.swift
@@ -134,7 +134,7 @@ public final class HBApplicationBuilder<RequestContext: HBRequestContext> {
 
     /// Construct the RequestResponder from the middleware group and router
     func constructResponder() -> any HBResponder<RequestContext> {
-        return self.router.buildRouter()
+        return self.router.buildResponder()
     }
 
     public func addChannelHandler(_ handler: @autoclosure @escaping @Sendable () -> any RemovableChannelHandler) {

--- a/Sources/Hummingbird/Middleware/CORSMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/CORSMiddleware.swift
@@ -22,7 +22,7 @@ import NIOCore
 /// "access-control-allow-origin" header
 public struct HBCORSMiddleware<Context: HBRequestContext>: HBMiddleware {
     /// Defines what origins are allowed
-    public enum AllowOrigin {
+    public enum AllowOrigin: Sendable {
         case none
         case all
         case originBased

--- a/Sources/Hummingbird/Middleware/Middleware.swift
+++ b/Sources/Hummingbird/Middleware/Middleware.swift
@@ -40,7 +40,7 @@ import NIOCore
 ///     }
 /// }
 /// ```
-public protocol HBMiddleware<Context> {
+public protocol HBMiddleware<Context>: Sendable {
     associatedtype Context: HBRequestContext
     func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) -> EventLoopFuture<HBResponse>
 }

--- a/Sources/Hummingbird/Router/EndpointResponder.swift
+++ b/Sources/Hummingbird/Router/EndpointResponder.swift
@@ -16,7 +16,7 @@ import NIOCore
 import NIOHTTP1
 
 /// Stores endpoint responders for each HTTP method
-final class HBEndpointResponders<Context: HBRequestContext> {
+struct HBEndpointResponders<Context: HBRequestContext>: Sendable {
     init(path: String) {
         self.path = path
         self.methods = [:]
@@ -26,7 +26,7 @@ final class HBEndpointResponders<Context: HBRequestContext> {
         return self.methods[method.rawValue]
     }
 
-    func addResponder(for method: HTTPMethod, responder: any HBResponder<Context>) {
+    mutating func addResponder(for method: HTTPMethod, responder: any HBResponder<Context>) {
         guard self.methods[method.rawValue] == nil else {
             preconditionFailure("\(method.rawValue) already has a handler")
         }

--- a/Sources/Hummingbird/Router/RouterBuilder.swift
+++ b/Sources/Hummingbird/Router/RouterBuilder.swift
@@ -46,11 +46,11 @@ import NIOHTTP1
 /// The second version extracts the path segment out and adds it to `HBRequest.parameters` with the
 /// key "id".
 public final class HBRouterBuilder<Context: HBRequestContext>: HBRouterMethods {
-    var trie: RouterPathTrie<HBEndpointResponders<Context>>
+    var trie: RouterPathTrieBuilder<HBEndpointResponders<Context>>
     public let middlewares: HBMiddlewareGroup<Context>
 
-    public init(context: Context.Type) {
-        self.trie = RouterPathTrie()
+    public init(context: Context.Type = HBBasicRequestContext.self) {
+        self.trie = RouterPathTrieBuilder()
         self.middlewares = .init()
     }
 
@@ -67,13 +67,9 @@ public final class HBRouterBuilder<Context: HBRequestContext>: HBRouterMethods {
         }
     }
 
-    func endpoint(_ path: String) -> HBEndpointResponders<Context>? {
-        self.trie.getValueAndParameters(path)?.value
-    }
-
     /// build router
-    public func buildRouter() -> any HBResponder<Context> {
-        HBRouter(context: Context.self, trie: self.trie, notFoundResponder: self.middlewares.constructResponder(finalResponder: NotFoundResponder<Context>()))
+    public func buildResponder() -> any HBResponder<Context> {
+        HBRouter(context: Context.self, trie: self.trie.build(), notFoundResponder: self.middlewares.constructResponder(finalResponder: NotFoundResponder<Context>()))
     }
 
     /// Add path for closure returning type conforming to ResponseFutureEncodable

--- a/Sources/Hummingbird/Router/RouterBuilder.swift
+++ b/Sources/Hummingbird/Router/RouterBuilder.swift
@@ -23,13 +23,13 @@ import NIOHTTP1
 /// `head`, `post` and `patch`.  The route handler closures all return objects conforming to
 /// `HBResponseGenerator`.  This allows us to support routes which return a multitude of types eg
 /// ```
-/// app.router.get("string") { _ -> String in
+/// router.get("string") { _ -> String in
 ///     return "string"
 /// }
-/// app.router.post("status") { _ -> HTTPResponseStatus in
+/// router.post("status") { _ -> HTTPResponseStatus in
 ///     return .ok
 /// }
-/// app.router.data("data") { request -> ByteBuffer in
+/// router.data("data") { request -> ByteBuffer in
 ///     return context.allocator.buffer(string: "buffer")
 /// }
 /// ```
@@ -39,8 +39,8 @@ import NIOHTTP1
 /// The default `Router` setup in `HBApplication` is the `TrieRouter` . This uses a
 /// trie to partition all the routes for faster access. It also supports wildcards and parameter extraction
 /// ```
-/// app.router.get("user/*", use: anyUser)
-/// app.router.get("user/:id", use: userWithId)
+/// router.get("user/*", use: anyUser)
+/// router.get("user/:id", use: userWithId)
 /// ```
 /// Both of these match routes which start with "/user" and the next path segment being anything.
 /// The second version extracts the path segment out and adds it to `HBRequest.parameters` with the
@@ -68,7 +68,7 @@ public final class HBRouterBuilder<Context: HBRequestContext>: HBRouterMethods {
     }
 
     /// build router
-    public func buildResponder() -> any HBResponder<Context> {
+    public func buildResponder() -> some HBResponder<Context> {
         HBRouter(context: Context.self, trie: self.trie.build(), notFoundResponder: self.middlewares.constructResponder(finalResponder: NotFoundResponder<Context>()))
     }
 

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// URI Path Trie
+/// URI Path Trie Builder
 struct RouterPathTrieBuilder<Value: Sendable> {
     var root: Node
 
@@ -20,6 +20,11 @@ struct RouterPathTrieBuilder<Value: Sendable> {
         self.root = Node(key: .null, output: nil)
     }
 
+    /// Add Entry to Trie
+    /// - Parameters:
+    ///   - entry: Path for entry
+    ///   - value: Value to add to this path if one does not exist already
+    ///   - onAdd: How to edit the value at this path
     func addEntry(_ entry: RouterPath, value: @autoclosure () -> Value, onAdd: (Node) -> Void = { _ in }) {
         var node = self.root
         for key in entry {
@@ -75,13 +80,19 @@ struct RouterPathTrieBuilder<Value: Sendable> {
     }
 }
 
+/// Trie used by HBRouter responder
 struct RouterPathTrie<Value: Sendable>: Sendable {
     let root: Node
 
+    /// Initialise RouterPathTrie
+    /// - Parameter root: Root node of trie
     init(root: Node) {
         self.root = root
     }
 
+    /// Get value from trie and any parameters from capture nodes
+    /// - Parameter path: Path to process
+    /// - Returns: value and parameters
     func getValueAndParameters(_ path: String) -> (value: Value, parameters: HBParameters?)? {
         let pathComponents = path.split(separator: "/", omittingEmptySubsequences: true)
         var parameters: HBParameters?
@@ -112,6 +123,7 @@ struct RouterPathTrie<Value: Sendable>: Sendable {
         return nil
     }
 
+    /// Internally used Node to describe static trie
     struct Node: Sendable {
         let key: RouterPath.Element
         let children: [Node]
@@ -137,7 +149,7 @@ struct RouterPathTrie<Value: Sendable>: Sendable {
 }
 
 extension Optional where Wrapped == HBParameters {
-    mutating func set(_ s: Substring, value: Substring) {
+    fileprivate mutating func set(_ s: Substring, value: Substring) {
         switch self {
         case .some(var parameters):
             parameters.set(s, value: value)
@@ -147,7 +159,7 @@ extension Optional where Wrapped == HBParameters {
         }
     }
 
-    mutating func setCatchAll(_ value: Substring) {
+    fileprivate mutating func setCatchAll(_ value: Substring) {
         switch self {
         case .some(var parameters):
             parameters.setCatchAll(value)

--- a/Sources/Hummingbird/Server/Responder.swift
+++ b/Sources/Hummingbird/Server/Responder.swift
@@ -17,7 +17,7 @@ import NIOCore
 /// Protocol for object that produces a response given a request
 ///
 /// This is the core protocol for Hummingbird. It defines an object that can respond to a request.
-public protocol HBResponder<Context> {
+public protocol HBResponder<Context>: Sendable {
     associatedtype Context: HBRequestContext
     /// Return EventLoopFuture that will be fulfilled with response to the request supplied
     func respond(to request: HBRequest, context: Context) -> EventLoopFuture<HBResponse>
@@ -25,9 +25,9 @@ public protocol HBResponder<Context> {
 
 /// Responder that calls supplied closure
 public struct HBCallbackResponder<Context: HBRequestContext>: HBResponder {
-    let callback: (HBRequest, Context) -> EventLoopFuture<HBResponse>
+    let callback: @Sendable (HBRequest, Context) -> EventLoopFuture<HBResponse>
 
-    public init(callback: @escaping (HBRequest, Context) -> EventLoopFuture<HBResponse>) {
+    public init(callback: @escaping @Sendable (HBRequest, Context) -> EventLoopFuture<HBResponse>) {
         self.callback = callback
     }
 

--- a/Sources/HummingbirdFoundation/Files/CacheControl.swift
+++ b/Sources/HummingbirdFoundation/Files/CacheControl.swift
@@ -15,8 +15,8 @@
 import Hummingbird
 
 /// Associates cache control values with filename
-public struct HBCacheControl {
-    public enum Value: CustomStringConvertible {
+public struct HBCacheControl: Sendable {
+    public enum Value: CustomStringConvertible, Sendable {
         case noStore
         case noCache
         case `private`
@@ -62,7 +62,7 @@ public struct HBCacheControl {
             .joined(separator: ", ")
     }
 
-    private struct Entry {
+    private struct Entry: Sendable {
         let mediaType: HBMediaType
         let cacheControl: [Value]
     }

--- a/Sources/HummingbirdFoundation/Files/FileIO.swift
+++ b/Sources/HummingbirdFoundation/Files/FileIO.swift
@@ -19,7 +19,7 @@ import NIOCore
 import NIOPosix
 
 /// Manages File reading and writing.
-public struct HBFileIO {
+public struct HBFileIO: Sendable {
     let fileIO: NonBlockingFileIO
     let chunkSize: Int
 

--- a/Sources/HummingbirdXCT/HBXCTRouter.swift
+++ b/Sources/HummingbirdXCT/HBXCTRouter.swift
@@ -66,7 +66,7 @@ struct HBXCTRouter<RequestContext: HBTestRouterContextProtocol>: HBXCTApplicatio
             encoder: builder.encoder,
             decoder: builder.decoder
         )
-        self.responder = builder.router.buildRouter()
+        self.responder = builder.router.buildResponder()
     }
 
     func shutdown() async throws {

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -17,10 +17,11 @@ import XCTest
 
 class TrieRouterTests: XCTestCase {
     func testPathComponentsTrie() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("/usr/local/bin", value: "test1")
-        trie.addEntry("/usr/bin", value: "test2")
-        trie.addEntry("/Users/*/bin", value: "test3")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("/usr/local/bin", value: "test1")
+        trieBuilder.addEntry("/usr/bin", value: "test2")
+        trieBuilder.addEntry("/Users/*/bin", value: "test3")
+        let trie = trieBuilder.build()
 
         XCTAssertEqual(trie.getValueAndParameters("/usr/local/bin")?.value, "test1")
         XCTAssertEqual(trie.getValueAndParameters("/usr/bin")?.value, "test2")
@@ -29,17 +30,19 @@ class TrieRouterTests: XCTestCase {
     }
 
     func testRootNode() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("", value: "test1")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("", value: "test1")
+        let trie = trieBuilder.build()
         XCTAssertEqual(trie.getValueAndParameters("/")?.value, "test1")
         XCTAssertEqual(trie.getValueAndParameters("")?.value, "test1")
     }
 
     func testWildcard() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("users/*", value: "test1")
-        trie.addEntry("users/*/fowler", value: "test2")
-        trie.addEntry("users/*/*", value: "test3")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("users/*", value: "test1")
+        trieBuilder.addEntry("users/*/fowler", value: "test2")
+        trieBuilder.addEntry("users/*/*", value: "test3")
+        let trie = trieBuilder.build()
         XCTAssertNil(trie.getValueAndParameters("/users"))
         XCTAssertEqual(trie.getValueAndParameters("/users/adam")?.value, "test1")
         XCTAssertEqual(trie.getValueAndParameters("/users/adam/fowler")?.value, "test2")
@@ -47,9 +50,10 @@ class TrieRouterTests: XCTestCase {
     }
 
     func testGetParameters() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("users/:user", value: "test1")
-        trie.addEntry("users/:user/name", value: "john smith")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("users/:user", value: "test1")
+        trieBuilder.addEntry("users/:user/name", value: "john smith")
+        let trie = trieBuilder.build()
         XCTAssertNil(trie.getValueAndParameters("/user/"))
         XCTAssertEqual(trie.getValueAndParameters("/users/1234")?.parameters?.get("user"), "1234")
         XCTAssertEqual(trie.getValueAndParameters("/users/1234/name")?.parameters?.get("user"), "1234")
@@ -57,8 +61,9 @@ class TrieRouterTests: XCTestCase {
     }
 
     func testRecursiveWildcard() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("**", value: "**")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("**", value: "**")
+        let trie = trieBuilder.build()
         XCTAssertEqual(trie.getValueAndParameters("/one")?.value, "**")
         XCTAssertEqual(trie.getValueAndParameters("/one/two")?.value, "**")
         XCTAssertEqual(trie.getValueAndParameters("/one/two/three")?.value, "**")
@@ -66,9 +71,10 @@ class TrieRouterTests: XCTestCase {
     }
 
     func testRecursiveWildcardWithPrefix() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("Test/**", value: "true")
-        trie.addEntry("Test2/:test/**", value: "true")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("Test/**", value: "true")
+        trieBuilder.addEntry("Test2/:test/**", value: "true")
+        let trie = trieBuilder.build()
         XCTAssertNil(trie.getValueAndParameters("/notTest/hello"))
         XCTAssertNil(trie.getValueAndParameters("/Test/")?.value, "true")
         XCTAssertEqual(trie.getValueAndParameters("/Test/one")?.value, "true")
@@ -81,10 +87,11 @@ class TrieRouterTests: XCTestCase {
     }
 
     func testPrefixWildcard() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("*.jpg", value: "jpg")
-        trie.addEntry("test/*.jpg", value: "testjpg")
-        trie.addEntry("*.app/config.json", value: "app")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("*.jpg", value: "jpg")
+        trieBuilder.addEntry("test/*.jpg", value: "testjpg")
+        trieBuilder.addEntry("*.app/config.json", value: "app")
+        let trie = trieBuilder.build()
         XCTAssertNil(trie.getValueAndParameters("/hello.png"))
         XCTAssertEqual(trie.getValueAndParameters("/hello.jpg")?.value, "jpg")
         XCTAssertEqual(trie.getValueAndParameters("/test/hello.jpg")?.value, "testjpg")
@@ -92,10 +99,11 @@ class TrieRouterTests: XCTestCase {
     }
 
     func testSuffixWildcard() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("file.*", value: "file")
-        trie.addEntry("test/file.*", value: "testfile")
-        trie.addEntry("file.*/test", value: "filetest")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("file.*", value: "file")
+        trieBuilder.addEntry("test/file.*", value: "testfile")
+        trieBuilder.addEntry("file.*/test", value: "filetest")
+        let trie = trieBuilder.build()
         XCTAssertNil(trie.getValueAndParameters("/file2.png"))
         XCTAssertEqual(trie.getValueAndParameters("/file.jpg")?.value, "file")
         XCTAssertEqual(trie.getValueAndParameters("/test/file.jpg")?.value, "testfile")
@@ -103,10 +111,11 @@ class TrieRouterTests: XCTestCase {
     }
 
     func testPrefixCapture() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("${file}.jpg", value: "jpg")
-        trie.addEntry("test/${file}.jpg", value: "testjpg")
-        trie.addEntry("${app}.app/config.json", value: "app")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("${file}.jpg", value: "jpg")
+        trieBuilder.addEntry("test/${file}.jpg", value: "testjpg")
+        trieBuilder.addEntry("${app}.app/config.json", value: "app")
+        let trie = trieBuilder.build()
         XCTAssertNil(trie.getValueAndParameters("/hello.png"))
         XCTAssertEqual(trie.getValueAndParameters("/hello.jpg")?.parameters?.get("file"), "hello")
         XCTAssertEqual(trie.getValueAndParameters("/test/hello.jpg")?.parameters?.get("file"), "hello")
@@ -114,10 +123,11 @@ class TrieRouterTests: XCTestCase {
     }
 
     func testSuffixCapture() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("file.${ext}", value: "file")
-        trie.addEntry("test/file.${ext}", value: "testfile")
-        trie.addEntry("file.${ext}/test", value: "filetest")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("file.${ext}", value: "file")
+        trieBuilder.addEntry("test/file.${ext}", value: "testfile")
+        trieBuilder.addEntry("file.${ext}/test", value: "filetest")
+        let trie = trieBuilder.build()
         XCTAssertNil(trie.getValueAndParameters("/file2.png"))
         XCTAssertEqual(trie.getValueAndParameters("/file.jpg")?.parameters?.get("ext"), "jpg")
         XCTAssertEqual(trie.getValueAndParameters("/test/file.jpg")?.parameters?.get("ext"), "jpg")
@@ -125,14 +135,16 @@ class TrieRouterTests: XCTestCase {
     }
 
     func testPrefixFullComponentCapture() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("${text}", value: "test")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("${text}", value: "test")
+        let trie = trieBuilder.build()
         XCTAssertEqual(trie.getValueAndParameters("/file.jpg")?.parameters?.get("text"), "file.jpg")
     }
 
     func testIncompletSuffixCapture() {
-        let trie = RouterPathTrie<String>()
-        trie.addEntry("text}", value: "test")
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("text}", value: "test")
+        let trie = trieBuilder.build()
         XCTAssertEqual(trie.getValueAndParameters("/text}")?.value, "test")
         XCTAssertNil(trie.getValueAndParameters("/text"))
     }


### PR DESCRIPTION
In general this is a simple change, but it complicates the router builder slightly as it needs a mutable trie while the responder needs a sendable trie. So split it into two types, builder and type used by responder. 