### PR TITLE
Store `remoteAddress` in `HBCoreRequestContext`, and move responsibility for instantiation to the HTTP Server

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -173,10 +173,14 @@ extension HBApplication: Service {
                 head: request.head,
                 body: request.body
             )
-            let context = Responder.Context(
+            let logger = HBApplication.loggerWithRequestId(context.logger)
+            let requestContext = HBCoreRequestContext(
                 applicationContext: context,
-                channel: channel,
-                logger: HBApplication.loggerWithRequestId(context.logger)
+                eventLoop: channel.eventLoop, 
+                logger: logger
+            )
+            let context = Responder.Context(
+                coreContext: requestContext
             )
             // respond to request
             var response = try await self.responder.respond(to: request, context: context)

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -176,7 +176,7 @@ extension HBApplication: Service {
             let logger = HBApplication.loggerWithRequestId(context.logger)
             let requestContext = HBCoreRequestContext(
                 applicationContext: context,
-                eventLoop: channel.eventLoop, 
+                channel: channel,
                 logger: logger
             )
             let context = Responder.Context(

--- a/Sources/Hummingbird/Server/RequestContext.swift
+++ b/Sources/Hummingbird/Server/RequestContext.swift
@@ -54,6 +54,8 @@ public struct HBCoreRequestContext: Sendable {
     /// Parameters extracted from URI
     @usableFromInline
     var parameters: HBParameters
+    @usableFromInline
+    var remoteAddress: SocketAddress?
 
     @inlinable
     public init(
@@ -65,6 +67,22 @@ public struct HBCoreRequestContext: Sendable {
         self.applicationContext = applicationContext
         self.eventLoop = eventLoop
         self.allocator = allocator
+        self.logger = logger
+        self.endpointPath = .init()
+        self.parameters = .init()
+        self.remoteAddress = nil
+    }
+
+    @inlinable
+    public init(
+        applicationContext: HBApplicationContext,
+        channel: Channel,
+        logger: Logger
+    ) {
+        self.applicationContext = applicationContext
+        self.eventLoop = channel.eventLoop
+        self.allocator = channel.allocator
+        self.remoteAddress = channel.remoteAddress
         self.logger = logger
         self.endpointPath = .init()
         self.parameters = .init()
@@ -98,6 +116,8 @@ extension HBRequestContext {
     /// ByteBuffer allocator used by request
     @inlinable
     public var allocator: ByteBufferAllocator { coreContext.allocator }
+    @inlinable
+    public var remoteAddress: SocketAddress? { coreContext.remoteAddress }
     /// Logger to use with Request
     @inlinable
     public var logger: Logger {

--- a/Sources/Hummingbird/Server/RequestContext.swift
+++ b/Sources/Hummingbird/Server/RequestContext.swift
@@ -69,15 +69,6 @@ public struct HBCoreRequestContext: Sendable {
         self.endpointPath = .init()
         self.parameters = .init()
     }
-
-    @inlinable
-    public init(
-        applicationContext: HBApplicationContext,
-        channel: Channel,
-        logger: Logger
-    ) {
-        self.init(applicationContext: applicationContext, eventLoop: channel.eventLoop, logger: logger, allocator: channel.allocator)
-    }
 }
 
 /// Protocol that all request contexts should conform to. Holds data associated with
@@ -87,10 +78,8 @@ public protocol HBRequestContext: Sendable {
     var coreContext: HBCoreRequestContext { get set }
     /// initialize an `HBRequestContext`
     /// - Parameters:
-    ///   - applicationContext: Context coming from Application
-    ///   - channel: Channel that created request and context
     ///   - logger: Logger to use with request
-    init(applicationContext: HBApplicationContext, channel: Channel, logger: Logger)
+    init(coreContext: HBCoreRequestContext)
 }
 
 extension HBRequestContext {
@@ -137,22 +126,15 @@ public protocol HBRemoteAddressRequestContext: HBRequestContext {
 public struct HBBasicRequestContext: HBRequestContext, HBRemoteAddressRequestContext {
     /// core context
     public var coreContext: HBCoreRequestContext
-    /// Channel context
-    let channel: Channel
     /// Connected host address
-    public var remoteAddress: SocketAddress? { self.channel.remoteAddress }
+    public var remoteAddress: SocketAddress?
 
     ///  Initialize an `HBRequestContext`
     /// - Parameters:
     ///   - applicationContext: Context from Application that instigated the request
     ///   - channel: Channel that generated this request
     ///   - logger: Logger
-    public init(
-        applicationContext: HBApplicationContext,
-        channel: Channel,
-        logger: Logger
-    ) {
-        self.coreContext = .init(applicationContext: applicationContext, channel: channel, logger: logger)
-        self.channel = channel
+    public init(coreContext: HBCoreRequestContext) {
+        self.coreContext = coreContext
     }
 }

--- a/Sources/HummingbirdXCT/HBXCTRouter.swift
+++ b/Sources/HummingbirdXCT/HBXCTRouter.swift
@@ -85,8 +85,7 @@ struct HBXCTRouter<Responder: HBResponder>: HBXCTApplication where Responder.Con
                 let coreContext = HBCoreRequestContext(
                     applicationContext: applicationContext, 
                     eventLoop: eventLoop,
-                    logger: HBApplication<Responder, HTTP1Channel>.loggerWithRequestId(self.applicationContext.logger)
-                )
+                    logger: HBApplication<Responder, HTTP1Channel>.loggerWithRequestId(self.applicationContext.logger))
                 let context = Responder.Context(
                     coreContext: coreContext
                 )

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -27,11 +27,9 @@ struct MyRequestContext: HBRequestContext {
     ///   - applicationContext: Context from Application that instigated the request
     ///   - channelContext: Context providing source for EventLoop
     public init(
-        applicationContext: HBApplicationContext,
-        channel: Channel,
-        logger: Logger
+        coreContext: HBCoreRequestContext
     ) {
-        self.coreContext = .init(applicationContext: applicationContext, channel: channel, logger: logger)
+        self.coreContext = coreContext
     }
 }
 


### PR DESCRIPTION
This is useful when working with Lambda's, where the server does not have access to a regular `Channel`.