### PR TITLE
Add RequestContextSource protocol

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -175,7 +175,7 @@ extension HBApplication: Service {
             )
             let context = Responder.Context(
                 applicationContext: context,
-                channel: channel,
+                source: ChannelContextSource(channel: channel),
                 logger: HBApplication.loggerWithRequestId(context.logger)
             )
             // respond to request
@@ -214,6 +214,15 @@ extension HBApplication: Service {
     public static func loggerWithRequestId(_ logger: Logger) -> Logger {
         let requestId = globalRequestID.loadThenWrappingIncrement(by: 1, ordering: .relaxed)
         return logger.with(metadataKey: "hb_id", value: .stringConvertible(requestId))
+    }
+
+    /// Request Context Source from NIO Channel
+    public struct ChannelContextSource: RequestContextSource {
+        let channel: Channel
+
+        public var eventLoop: EventLoop { self.channel.eventLoop }
+        public var allocator: ByteBufferAllocator { self.channel.allocator }
+        public var remoteAddress: SocketAddress? { self.channel.remoteAddress }
     }
 }
 

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOCore
 import Tracing
 
 /// Middleware creating Distributed Tracing spans for each request.
@@ -115,6 +116,15 @@ public struct HBTracingMiddleware<Context: HBRequestContext>: HBMiddleware {
         }
         return attributes
     }
+}
+
+/// Protocol for request context that stores the remote address of connected client.
+///
+/// If you want the HBTracingMiddleware to record the remote address of requests
+/// then your request context will need to conform to this protocol
+public protocol HBRemoteAddressRequestContext: HBRequestContext {
+    /// Connected host address
+    var remoteAddress: SocketAddress? { get }
 }
 
 struct RecordingHeader: Hashable {

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -16,7 +16,7 @@ import NIOCore
 import NIOHTTP1
 
 /// Options available to routes
-public struct HBRouterMethodOptions: OptionSet {
+public struct HBRouterMethodOptions: OptionSet, Sendable {
     public let rawValue: Int
     public init(rawValue: Int) {
         self.rawValue = rawValue

--- a/Sources/HummingbirdXCT/Application+XCT.swift
+++ b/Sources/HummingbirdXCT/Application+XCT.swift
@@ -67,7 +67,7 @@ extension HBApplication {
     }
 }
 
-extension HBApplication where Responder.Context: HBTestRouterContextProtocol, ChannelSetup == HTTP1Channel {
+extension HBApplication where ChannelSetup == HTTP1Channel {
     // MARK: Initialization
 
     /// Creates a version of `HBApplication` that can be used for testing code

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -19,7 +19,7 @@ import NIOCore
 import NIOPosix
 
 struct MyRequestContext: HBRequestContext {
-        /// core context
+    /// core context
     public var coreContext: HBCoreRequestContext
 
     ///  Initialize an `HBRequestContext`
@@ -28,10 +28,10 @@ struct MyRequestContext: HBRequestContext {
     ///   - channelContext: Context providing source for EventLoop
     public init(
         applicationContext: HBApplicationContext,
-        channel: Channel,
+        source: some RequestContextSource,
         logger: Logger
     ) {
-        self.coreContext = .init(applicationContext: applicationContext, channel: channel, logger: logger)
+        self.coreContext = .init(applicationContext: applicationContext, eventLoop: source.eventLoop, logger: logger, allocator: source.allocator)
     }
 }
 

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -356,7 +356,7 @@ final class RouterTests: XCTestCase {
 
     // Test redirect response
     func testRedirect() async throws {
-        let router = HBRouterBuilder(context: HBTestRouterContext.self)
+        let router = HBRouterBuilder()
         router.get("redirect") { _, _ in
             return HBResponse.redirect(to: "/other")
         }
@@ -370,16 +370,15 @@ final class RouterTests: XCTestCase {
     }
 }
 
-public struct HBTestRouterContext2: HBTestRouterContextProtocol {
-    public init(applicationContext: HBApplicationContext, eventLoop: EventLoop, logger: Logger) {
-        self.coreContext = .init(applicationContext: applicationContext, eventLoop: eventLoop, logger: logger)
+public struct HBTestRouterContext2: HBRequestContext {
+    public init(applicationContext: HBApplicationContext, source: some RequestContextSource, logger: Logger) {
+        self.coreContext = .init(applicationContext: applicationContext, source: source, logger: logger)
+
         self.string = ""
     }
 
     /// parameters
     public var coreContext: HBCoreRequestContext
-    /// Connected remote host
-    public var remoteAddress: SocketAddress? { nil }
 
     /// additional data
     public var string: String


### PR DESCRIPTION
This is a protocol for extracting EventLoop, allocator and remote address from source of requests. eg NIO Channel or Lambda Event

In theory I could remove `TestRequestContext` also as it is no different to the basic request context anymore.