### PR TITLE
Add HBBaseRequestContext protocol

### DIFF
--- a/Sources/Hummingbird/Codable/CodableProtocols.swift
+++ b/Sources/Hummingbird/Codable/CodableProtocols.swift
@@ -19,7 +19,7 @@ public protocol HBResponseEncoder: Sendable {
     /// - Parameters:
     ///   - value: value to encode
     ///   - request: request that generated this value
-    func encode<T: Encodable>(_ value: T, from request: HBRequest, context: HBRequestContext) throws -> HBResponse
+    func encode<T: Encodable, Context: HBBaseRequestContext>(_ value: T, from request: HBRequest, context: Context) throws -> HBResponse
 }
 
 /// protocol for decoder deserializing from a Request body
@@ -28,12 +28,12 @@ public protocol HBRequestDecoder: Sendable {
     /// - Parameters:
     ///   - type: type to decode to
     ///   - request: request
-    func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: HBRequestContext) throws -> T
+    func decode<T: Decodable, Context: HBBaseRequestContext>(_ type: T.Type, from request: HBRequest, context: Context) throws -> T
 }
 
 /// Default encoder. Outputs request with the swift string description of object
 struct NullEncoder: HBResponseEncoder {
-    func encode<T: Encodable>(_ value: T, from request: HBRequest, context: HBRequestContext) throws -> HBResponse {
+    func encode<T: Encodable, Context: HBBaseRequestContext>(_ value: T, from request: HBRequest, context: Context) throws -> HBResponse {
         return HBResponse(
             status: .ok,
             headers: ["content-type": "text/plain; charset=utf-8"],
@@ -44,7 +44,7 @@ struct NullEncoder: HBResponseEncoder {
 
 /// Default decoder. there is no default decoder path so this generates an error
 struct NullDecoder: HBRequestDecoder {
-    func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: HBRequestContext) throws -> T {
+    func decode<T: Decodable, Context: HBBaseRequestContext>(_ type: T.Type, from request: HBRequest, context: Context) throws -> T {
         preconditionFailure("HBApplication.decoder has not been set")
     }
 }

--- a/Sources/Hummingbird/Codable/RequestDecodable.swift
+++ b/Sources/Hummingbird/Codable/RequestDecodable.swift
@@ -33,7 +33,7 @@ extension HBRequestDecodable {
     /// Create using `Codable` interfaces
     /// - Parameter request: request
     /// - Throws: HBHTTPError
-    public init(from request: HBRequest, context: HBRequestContext) throws {
+    public init<Context: HBBaseRequestContext>(from request: HBRequest, context: Context) throws {
         self = try request.decode(as: Self.self, using: context)
     }
 }

--- a/Sources/Hummingbird/Codable/ResponseEncodable.swift
+++ b/Sources/Hummingbird/Codable/ResponseEncodable.swift
@@ -23,7 +23,7 @@ public protocol HBResponseCodable: HBResponseEncodable, Decodable {}
 
 /// Extend ResponseEncodable to conform to ResponseGenerator
 extension HBResponseEncodable {
-    public func response(from request: HBRequest, context: HBRequestContext) throws -> HBResponse {
+    public func response<Context: HBBaseRequestContext>(from request: HBRequest, context: Context) throws -> HBResponse {
         return try context.applicationContext.encoder.encode(self, from: request, context: context)
     }
 }
@@ -33,7 +33,7 @@ extension Array: HBResponseGenerator where Element: Encodable {}
 
 /// Extend Array to conform to HBResponseEncodable
 extension Array: HBResponseEncodable where Element: Encodable {
-    public func response(from request: HBRequest, context: HBRequestContext) throws -> HBResponse {
+    public func response<Context: HBBaseRequestContext>(from request: HBRequest, context: Context) throws -> HBResponse {
         return try context.applicationContext.encoder.encode(self, from: request, context: context)
     }
 }
@@ -43,7 +43,7 @@ extension Dictionary: HBResponseGenerator where Key: Encodable, Value: Encodable
 
 /// Extend Array to conform to HBResponseEncodable
 extension Dictionary: HBResponseEncodable where Key: Encodable, Value: Encodable {
-    public func response(from request: HBRequest, context: HBRequestContext) throws -> HBResponse {
+    public func response<Context: HBBaseRequestContext>(from request: HBRequest, context: Context) throws -> HBResponse {
         return try context.applicationContext.encoder.encode(self, from: request, context: context)
     }
 }

--- a/Sources/Hummingbird/Middleware/CORSMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/CORSMiddleware.swift
@@ -20,7 +20,7 @@ import NIOCore
 /// then return an empty body with all the standard CORS headers otherwise send
 /// request onto the next handler and when you receive the response add a
 /// "access-control-allow-origin" header
-public struct HBCORSMiddleware<Context: HBRequestContext>: HBMiddleware {
+public struct HBCORSMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
     /// Defines what origins are allowed
     public enum AllowOrigin: Sendable {
         case none

--- a/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
@@ -15,7 +15,7 @@
 import Logging
 
 /// Middleware outputting to log for every call to server
-public struct HBLogRequestsMiddleware<Context: HBRequestContext>: HBMiddleware {
+public struct HBLogRequestsMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
     let logLevel: Logger.Level
     let includeHeaders: Bool
 

--- a/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
@@ -19,7 +19,7 @@ import Metrics
 ///
 /// Records the number of requests, the request duration and how many errors were thrown. Each metric has additional
 /// dimensions URI and method.
-public struct HBMetricsMiddleware<Context: HBRequestContext>: HBMiddleware {
+public struct HBMetricsMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
     public init() {}
 
     public func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {

--- a/Sources/Hummingbird/Middleware/Middleware.swift
+++ b/Sources/Hummingbird/Middleware/Middleware.swift
@@ -40,11 +40,11 @@ import NIOCore
 /// }
 /// ```
 public protocol HBMiddleware<Context>: Sendable {
-    associatedtype Context: HBRequestContext
+    associatedtype Context
     func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse
 }
 
-struct MiddlewareResponder<Context: HBRequestContext>: HBResponder {
+struct MiddlewareResponder<Context>: HBResponder {
     let middleware: any HBMiddleware<Context>
     let next: any HBResponder<Context>
 

--- a/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Group of middleware that can be used to create a responder chain. Each middleware calls the next one
-public final class HBMiddlewareGroup<Context: HBRequestContext> {
+public final class HBMiddlewareGroup<Context> {
     var middlewares: [any HBMiddleware<Context>]
 
     /// Initialize `HBMiddlewareGroup`

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -22,7 +22,7 @@ import Tracing
 /// You may opt in to recording a specific subset of HTTP request/response header values by passing
 /// a set of header names to ``init(recordingHeaders:)``.
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-public struct HBTracingMiddleware<Context: HBRequestContext>: HBMiddleware {
+public struct HBTracingMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
     private let headerNamesToRecord: Set<RecordingHeader>
 
     /// Intialize a new HBTracingMiddleware.
@@ -122,7 +122,7 @@ public struct HBTracingMiddleware<Context: HBRequestContext>: HBMiddleware {
 ///
 /// If you want the HBTracingMiddleware to record the remote address of requests
 /// then your request context will need to conform to this protocol
-public protocol HBRemoteAddressRequestContext: HBRequestContext {
+public protocol HBRemoteAddressRequestContext: HBBaseRequestContext {
     /// Connected host address
     var remoteAddress: SocketAddress? { get }
 }

--- a/Sources/Hummingbird/Router/EndpointResponder.swift
+++ b/Sources/Hummingbird/Router/EndpointResponder.swift
@@ -16,7 +16,7 @@ import NIOCore
 import NIOHTTP1
 
 /// Stores endpoint responders for each HTTP method
-struct HBEndpointResponders<Context: HBRequestContext>: Sendable {
+struct HBEndpointResponders<Context: HBBaseRequestContext>: Sendable {
     init(path: String) {
         self.path = path
         self.methods = [:]

--- a/Sources/Hummingbird/Router/RouteHandler.swift
+++ b/Sources/Hummingbird/Router/RouteHandler.swift
@@ -39,8 +39,8 @@
 /// ```
 public protocol HBRouteHandler {
     associatedtype _Output
-    init(from: HBRequest, context: HBRequestContext) throws
-    func handle(request: HBRequest, context: HBRequestContext) async throws -> _Output
+    init<Context: HBBaseRequestContext>(from: HBRequest, context: Context) throws
+    func handle<Context: HBBaseRequestContext>(request: HBRequest, context: Context) async throws -> _Output
 }
 
 extension HBRouterMethods {

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -17,7 +17,7 @@
 /// Conforms to `HBResponder` so need to provide its own implementation of
 /// `func apply(to request: Request) -> EventLoopFuture<Response>`.
 ///
-struct HBRouter<Context: HBRequestContext>: HBResponder {
+struct HBRouter<Context: HBBaseRequestContext>: HBResponder {
     let trie: RouterPathTrie<HBEndpointResponders<Context>>
     let notFoundResponder: any HBResponder<Context>
 

--- a/Sources/Hummingbird/Router/RouterBuilder.swift
+++ b/Sources/Hummingbird/Router/RouterBuilder.swift
@@ -45,7 +45,7 @@ import NIOHTTP1
 /// Both of these match routes which start with "/user" and the next path segment being anything.
 /// The second version extracts the path segment out and adds it to `HBRequest.parameters` with the
 /// key "id".
-public final class HBRouterBuilder<Context: HBRequestContext>: HBRouterMethods {
+public final class HBRouterBuilder<Context: HBBaseRequestContext>: HBRouterMethods {
     var trie: RouterPathTrieBuilder<HBEndpointResponders<Context>>
     public let middlewares: HBMiddlewareGroup<Context>
 
@@ -83,7 +83,7 @@ public final class HBRouterBuilder<Context: HBRequestContext>: HBRouterMethods {
         self.add(path, method: method, responder: responder)
         return self
     }
-    
+
     /// return new `RouterGroup`
     /// - Parameter path: prefix to add to paths inside the group
     public func group(_ path: String = "") -> HBRouterGroup<Context> {
@@ -92,7 +92,7 @@ public final class HBRouterBuilder<Context: HBRequestContext>: HBRouterMethods {
 }
 
 /// Responder that return a not found error
-struct NotFoundResponder<Context: HBRequestContext>: HBResponder {
+struct NotFoundResponder<Context: HBBaseRequestContext>: HBResponder {
     func respond(to request: HBRequest, context: Context) throws -> HBResponse {
         throw HBHTTPError(.notFound)
     }

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -30,7 +30,7 @@ import NIOHTTP1
 /// .put(":id", use: todoController.update)
 /// .delete(":id", use: todoController.delete)
 /// ```
-public struct HBRouterGroup<Context: HBRequestContext>: HBRouterMethods {
+public struct HBRouterGroup<Context: HBBaseRequestContext>: HBRouterMethods {
     let path: String
     let router: HBRouterBuilder<Context>
     let middlewares: HBMiddlewareGroup<Context>

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -28,7 +28,7 @@ public struct HBRouterMethodOptions: OptionSet, Sendable {
 
 /// Conform to `HBRouterMethods` to add standard router verb (get, post ...) methods
 public protocol HBRouterMethods {
-    associatedtype Context: HBRequestContext
+    associatedtype Context: HBBaseRequestContext
 
     /// Add path for async closure
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -56,7 +56,7 @@ public struct HBRequest: Sendable {
 
     /// Decode request using decoder stored at `HBApplication.decoder`.
     /// - Parameter type: Type you want to decode to
-    public func decode<Type: Decodable>(as type: Type.Type, using context: HBRequestContext) throws -> Type {
+    public func decode<Type: Decodable>(as type: Type.Type, using context: HBBaseRequestContext) throws -> Type {
         do {
             return try context.applicationContext.decoder.decode(type, from: self, context: context)
         } catch DecodingError.dataCorrupted(_) {

--- a/Sources/Hummingbird/Server/Responder.swift
+++ b/Sources/Hummingbird/Server/Responder.swift
@@ -19,13 +19,13 @@ import ServiceContextModule
 ///
 /// This is the core protocol for Hummingbird. It defines an object that can respond to a request.
 public protocol HBResponder<Context>: Sendable {
-    associatedtype Context: HBRequestContext
+    associatedtype Context
     /// Return EventLoopFuture that will be fulfilled with response to the request supplied
     func respond(to request: HBRequest, context: Context) async throws -> HBResponse
 }
 
 /// Responder that calls supplied closure
-public struct HBCallbackResponder<Context: HBRequestContext>: HBResponder {
+public struct HBCallbackResponder<Context>: HBResponder {
     let callback: @Sendable (HBRequest, Context) async throws -> HBResponse
 
     public init(callback: @escaping @Sendable (HBRequest, Context) async throws -> HBResponse) {

--- a/Sources/HummingbirdFoundation/Codable/JSON/JSONCoding.swift
+++ b/Sources/HummingbirdFoundation/Codable/JSON/JSONCoding.swift
@@ -23,7 +23,7 @@ extension JSONEncoder: HBResponseEncoder {
     /// - Parameters:
     ///   - value: Value to encode
     ///   - request: Request used to generate response
-    public func encode<T: Encodable>(_ value: T, from request: HBRequest, context: HBRequestContext) throws -> HBResponse {
+    public func encode<T: Encodable, Context: HBBaseRequestContext>(_ value: T, from request: HBRequest, context: Context) throws -> HBResponse {
         var buffer = context.allocator.buffer(capacity: 0)
         let data = try self.encode(value)
         buffer.writeBytes(data)
@@ -40,7 +40,7 @@ extension JSONDecoder: HBRequestDecoder {
     /// - Parameters:
     ///   - type: Type to decode
     ///   - request: Request to decode from
-    public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: HBRequestContext) throws -> T {
+    public func decode<T: Decodable, Context: HBBaseRequestContext>(_ type: T.Type, from request: HBRequest, context: Context) throws -> T {
         guard case .byteBuffer(var buffer) = request.body,
               let data = buffer.readData(length: buffer.readableBytes)
         else {

--- a/Sources/HummingbirdFoundation/Codable/URLEncodedForm/URLEncodedForm+Request.swift
+++ b/Sources/HummingbirdFoundation/Codable/URLEncodedForm/URLEncodedForm+Request.swift
@@ -19,7 +19,7 @@ extension URLEncodedFormEncoder: HBResponseEncoder {
     /// - Parameters:
     ///   - value: Value to encode
     ///   - request: Request used to generate response
-    public func encode<T: Encodable>(_ value: T, from request: HBRequest, context: HBRequestContext) throws -> HBResponse {
+    public func encode<T: Encodable, Context: HBBaseRequestContext>(_ value: T, from request: HBRequest, context: Context) throws -> HBResponse {
         var buffer = context.allocator.buffer(capacity: 0)
         let string = try self.encode(value)
         buffer.writeString(string)
@@ -36,7 +36,7 @@ extension URLEncodedFormDecoder: HBRequestDecoder {
     /// - Parameters:
     ///   - type: Type to decode
     ///   - request: Request to decode from
-    public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: HBRequestContext) throws -> T {
+    public func decode<T: Decodable, Context: HBBaseRequestContext>(_ type: T.Type, from request: HBRequest, context: Context) throws -> T {
         guard case .byteBuffer(var buffer) = request.body,
               let string = buffer.readString(length: buffer.readableBytes)
         else {

--- a/Sources/HummingbirdFoundation/Files/FileIO.swift
+++ b/Sources/HummingbirdFoundation/Files/FileIO.swift
@@ -38,7 +38,7 @@ public struct HBFileIO: Sendable {
     ///   - path: System file path
     ///   - context: Context this request is being called in
     /// - Returns: Response body
-    public func loadFile(path: String, context: HBRequestContext, logger: Logger) async throws -> HBResponseBody {
+    public func loadFile<Context: HBBaseRequestContext>(path: String, context: Context, logger: Logger) async throws -> HBResponseBody {
         do {
             let (handle, region) = try await self.fileIO.openFile(path: path, eventLoop: context.eventLoop).get()
             logger.debug("[FileIO] GET", metadata: ["file": .string(path)])
@@ -66,7 +66,7 @@ public struct HBFileIO: Sendable {
     ///   - range:Range defining how much of the file is to be loaded
     ///   - context: Context this request is being called in
     /// - Returns: Response body plus file size
-    public func loadFile(path: String, range: ClosedRange<Int>, context: HBRequestContext, logger: Logger) async throws -> (HBResponseBody, Int) {
+    public func loadFile<Context: HBBaseRequestContext>(path: String, range: ClosedRange<Int>, context: Context, logger: Logger) async throws -> (HBResponseBody, Int) {
         do {
             let (handle, region) = try await self.fileIO.openFile(path: path, eventLoop: context.eventLoop).get()
             logger.debug("[FileIO] GET", metadata: ["file": .string(path)])
@@ -100,7 +100,7 @@ public struct HBFileIO: Sendable {
     ///   - contents: Request body to write.
     ///   - path: Path to write to
     ///   - logger: Logger
-    public func writeFile(contents: HBRequestBody, path: String, context: HBRequestContext, logger: Logger) async throws {
+    public func writeFile<Context: HBBaseRequestContext>(contents: HBRequestBody, path: String, context: Context, logger: Logger) async throws {
         let handle = try await self.fileIO.openFile(path: path, mode: .write, flags: .allowFileCreation(), eventLoop: context.eventLoop).get()
         defer {
             try? handle.close()
@@ -115,7 +115,7 @@ public struct HBFileIO: Sendable {
     }
 
     /// Load file as ByteBuffer
-    func loadFile(handle: NIOFileHandle, region: FileRegion, context: HBRequestContext) async throws -> HBResponseBody {
+    func loadFile<Context: HBBaseRequestContext>(handle: NIOFileHandle, region: FileRegion, context: Context) async throws -> HBResponseBody {
         let buffer = try await self.fileIO.read(
             fileHandle: handle,
             fromOffset: Int64(region.readerIndex),
@@ -127,7 +127,7 @@ public struct HBFileIO: Sendable {
     }
 
     /// Return streamer that will load file
-    func streamFile(handle: NIOFileHandle, region: FileRegion, context: HBRequestContext) throws -> HBResponseBody {
+    func streamFile<Context: HBBaseRequestContext>(handle: NIOFileHandle, region: FileRegion, context: Context) throws -> HBResponseBody {
         let fileOffset = region.readerIndex
         let endOffset = region.endIndex
         return HBResponseBody(contentLength: region.readableBytes) { writer in

--- a/Sources/HummingbirdFoundation/Files/FileMiddleware.swift
+++ b/Sources/HummingbirdFoundation/Files/FileMiddleware.swift
@@ -28,7 +28,7 @@ import NIOPosix
 /// "if-modified-since", "if-none-match", "if-range" and 'range" headers. It will output "content-length",
 /// "modified-date", "eTag", "content-type", "cache-control" and "content-range" headers where
 /// they are relevant.
-public struct HBFileMiddleware<Context: HBRequestContext>: HBMiddleware {
+public struct HBFileMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
     struct IsDirectoryError: Error {}
 
     let rootFolder: URL

--- a/Sources/HummingbirdXCT/Application+XCT.swift
+++ b/Sources/HummingbirdXCT/Application+XCT.swift
@@ -50,7 +50,7 @@ public struct XCTRouterTestingSetup {
 ///     }
 /// }
 /// ```
-extension HBApplication {
+extension HBApplication where Responder.Context: HBRequestContext {
     // MARK: Initialization
 
     /// Creates a version of `HBApplication` that can be used for testing code
@@ -68,7 +68,7 @@ extension HBApplication {
     }
 }
 
-extension HBApplication where ChannelSetup == HTTP1Channel {
+extension HBApplication where ChannelSetup == HTTP1Channel, Responder.Context: HBTestRequestContextProtocol {
     // MARK: Initialization
 
     /// Creates a version of `HBApplication` that can be used for testing code

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -23,7 +23,7 @@ import ServiceLifecycle
 import XCTest
 
 /// Test using a live server
-final class HBXCTLive<Responder: HBResponder, ChannelSetup: HBChannelSetup & HTTPChannelHandler>: HBXCTApplication {
+final class HBXCTLive<Responder: HBResponder, ChannelSetup: HBChannelSetup & HTTPChannelHandler>: HBXCTApplication where Responder.Context: HBRequestContext {
     struct Client: HBXCTClientProtocol {
         let client: HBXCTClient
 

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -18,23 +18,6 @@ import Logging
 import NIOCore
 import NIOPosix
 
-struct MyRequestContext: HBRequestContext {
-    /// core context
-    public var coreContext: HBCoreRequestContext
-
-    ///  Initialize an `HBRequestContext`
-    /// - Parameters:
-    ///   - applicationContext: Context from Application that instigated the request
-    ///   - channelContext: Context providing source for EventLoop
-    public init(
-        applicationContext: HBApplicationContext,
-        source: some RequestContextSource,
-        logger: Logger
-    ) {
-        self.coreContext = .init(applicationContext: applicationContext, eventLoop: source.eventLoop, logger: logger, allocator: source.allocator)
-    }
-}
-
 // get environment
 let hostname = HBEnvironment.shared.get("SERVER_HOSTNAME") ?? "127.0.0.1"
 let port = HBEnvironment.shared.get("SERVER_PORT", as: Int.self) ?? 8080
@@ -42,7 +25,7 @@ let port = HBEnvironment.shared.get("SERVER_PORT", as: Int.self) ?? 8080
 // create app
 let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
 defer { try? elg.syncShutdownGracefully() }
-var router = HBRouterBuilder(context: MyRequestContext.self)
+var router = HBRouterBuilder()
 // number of raw requests
 // ./wrk -c 128 -d 15s -t 8 http://localhost:8080
 router.get { _, _ in

--- a/Tests/HummingbirdFoundationTests/FilesTests.swift
+++ b/Tests/HummingbirdFoundationTests/FilesTests.swift
@@ -348,7 +348,7 @@ class HummingbirdFilesTests: XCTestCase {
 
     func testWriteLargeFile() async throws {
         let filename = "testWriteLargeFile.txt"
-        let router = HBRouterBuilder(context: HBTestRouterContext.self)
+        let router = HBRouterBuilder(context: HBBasicRequestContext.self)
         router.put("store", options: .streamBody) { request, context -> HTTPResponseStatus in
             let fileIO = HBFileIO(threadPool: context.threadPool)
             try await fileIO.writeFile(contents: request.body, path: filename, context: context, logger: context.logger)

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -281,7 +281,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testCollateBody() async throws {
-        struct CollateMiddleware<Context: HBRequestContext>: HBMiddleware {
+        struct CollateMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
             func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
                 var request = request
                 request.body = try await request.body.collate(maxSize: context.applicationContext.configuration.maxUploadSize)
@@ -432,11 +432,11 @@ final class ApplicationTests: XCTestCase {
 
             public init(
                 applicationContext: HBApplicationContext,
-                source: some RequestContextSource,
+                channel: Channel,
                 logger: Logger
             ) {
-                self.coreContext = .init(applicationContext: applicationContext, source: source, logger: logger)
-                self.remoteAddress = source.remoteAddress
+                self.coreContext = .init(applicationContext: applicationContext, eventLoop: channel.eventLoop, allocator: channel.allocator, logger: logger)
+                self.remoteAddress = channel.remoteAddress
             }
         }
         let router = HBRouterBuilder(context: HBSocketAddressRequestContext.self)

--- a/Tests/HummingbirdTests/HandlerTests.swift
+++ b/Tests/HummingbirdTests/HandlerTests.swift
@@ -23,7 +23,7 @@ final class HandlerTests: XCTestCase {
         struct DecodeTest: HBRequestDecodable {
             let name: String
 
-            func handle(request: HBRequest, context: HBRequestContext) -> String {
+            func handle<Context: HBBaseRequestContext>(request: HBRequest, context: Context) -> String {
                 return "Hello \(self.name)"
             }
         }
@@ -53,7 +53,7 @@ final class HandlerTests: XCTestCase {
         struct DecodeTest: HBRequestDecodable {
             let value: Int
 
-            func handle(request: HBRequest, context: HBRequestContext) -> String {
+            func handle<Context: HBBaseRequestContext>(request: HBRequest, context: Context) -> String {
                 return "Value: \(self.value)"
             }
         }
@@ -83,7 +83,7 @@ final class HandlerTests: XCTestCase {
         struct DecodeTest: HBRequestDecodable {
             let name: String
 
-            func handle(request: HBRequest, context: HBRequestContext) -> String {
+            func handle<Context: HBBaseRequestContext>(request: HBRequest, context: Context) -> String {
                 return "Hello \(self.name)"
             }
         }
@@ -118,7 +118,7 @@ final class HandlerTests: XCTestCase {
         struct DecodeTest: HBRequestDecodable {
             let name: String
 
-            func handle(request: HBRequest, context: HBRequestContext) -> String {
+            func handle<Context: HBBaseRequestContext>(request: HBRequest, context: Context) -> String {
                 return "Hello \(self.name)"
             }
         }
@@ -147,7 +147,7 @@ final class HandlerTests: XCTestCase {
     func testDecode() async throws {
         struct DecodeTest: HBRequestDecodable {
             let name: String
-            func handle(request: HBRequest, context: HBRequestContext) -> String {
+            func handle<Context: HBBaseRequestContext>(request: HBRequest, context: Context) -> String {
                 return "Hello \(self.name)"
             }
         }
@@ -168,7 +168,7 @@ final class HandlerTests: XCTestCase {
     func testDecodeFutureResponse() async throws {
         struct DecodeTest: HBRequestDecodable {
             let name: String
-            func handle(request: HBRequest, context: HBRequestContext) async throws -> String {
+            func handle<Context: HBBaseRequestContext>(request: HBRequest, context: Context) -> String {
                 "Hello \(self.name)"
             }
         }
@@ -190,7 +190,7 @@ final class HandlerTests: XCTestCase {
         struct DecodeTest: HBRequestDecodable {
             let name: String
 
-            func handle(request: HBRequest, context: HBRequestContext) -> HTTPResponseStatus {
+            func handle<Context: HBBaseRequestContext>(request: HBRequest, context: Context) -> HTTPResponseStatus {
                 return .ok
             }
         }
@@ -209,11 +209,11 @@ final class HandlerTests: XCTestCase {
     func testEmptyRequest() async throws {
         struct ParameterTest: HBRouteHandler {
             let parameter: Int
-            init(from request: HBRequest, context: HBRequestContext) throws {
+            init<Context: HBBaseRequestContext>(from request: HBRequest, context: Context) throws {
                 self.parameter = try context.parameters.require("test", as: Int.self)
             }
 
-            func handle(request: HBRequest, context: HBRequestContext) -> String {
+            func handle<Context: HBBaseRequestContext>(request: HBRequest, context: Context) -> String {
                 return "\(self.parameter)"
             }
         }

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -24,7 +24,7 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testMiddleware() async throws {
-        struct TestMiddleware<Context: HBRequestContext>: HBMiddleware {
+        struct TestMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
             func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
                 var response = try await next.respond(to: request, context: context)
                 response.headers.replaceOrAdd(name: "middleware", value: "TestMiddleware")
@@ -45,7 +45,7 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testMiddlewareOrder() async throws {
-        struct TestMiddleware<Context: HBRequestContext>: HBMiddleware {
+        struct TestMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
             let string: String
             func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
                 var response = try await next.respond(to: request, context: context)
@@ -70,7 +70,7 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testMiddlewareRunOnce() async throws {
-        struct TestMiddleware<Context: HBRequestContext>: HBMiddleware {
+        struct TestMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
             func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
                 var response = try await next.respond(to: request, context: context)
                 XCTAssertNil(response.headers["alreadyRun"].first)
@@ -91,7 +91,7 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testMiddlewareRunWhenNoRouteFound() async throws {
-        struct TestMiddleware<Context: HBRequestContext>: HBMiddleware {
+        struct TestMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
             func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
                 do {
                     return try await next.respond(to: request, context: context)
@@ -114,7 +114,7 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testEndpointPathInGroup() async throws {
-        struct TestMiddleware<Context: HBRequestContext>: HBMiddleware {
+        struct TestMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
             func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
                 XCTAssertNotNil(context.endpointPath)
                 return try await next.respond(to: request, context: context)
@@ -143,7 +143,7 @@ final class MiddlewareTests: XCTestCase {
                 try await self.parentWriter.write(output)
             }
         }
-        struct TransformMiddleware<Context: HBRequestContext>: HBMiddleware {
+        struct TransformMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
             func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
                 let response = try await next.respond(to: request, context: context)
                 var editedResponse = response

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -361,7 +361,7 @@ final class TracingTests: XCTestCase {
         let expectation = expectation(description: "Expected span to be ended.")
         expectation.expectedFulfillmentCount = 2
 
-        struct SpanMiddleware<Context: HBRequestContext>: HBMiddleware {
+        struct SpanMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
             public func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
                 var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
                 serviceContext.testID = "testMiddleware"


### PR DESCRIPTION
Add HBBaseRequestContext protocol that doesn't require an init using a NIO Channel
Remove HBRequestContextSource as this is no longer needed

I also found a number of places where `HBRequestContext` was being used as an existential so I fixed those at the same time. 