### PR TITLE
Don't collate the request body by default

### DIFF
--- a/Sources/Hummingbird/Codable/CodableProtocols.swift
+++ b/Sources/Hummingbird/Codable/CodableProtocols.swift
@@ -28,7 +28,7 @@ public protocol HBRequestDecoder: Sendable {
     /// - Parameters:
     ///   - type: type to decode to
     ///   - request: request
-    func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) throws -> T
+    func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) async throws -> T
 }
 
 /// Default encoder. Outputs request with the swift string description of object

--- a/Sources/Hummingbird/Codable/RequestDecodable.swift
+++ b/Sources/Hummingbird/Codable/RequestDecodable.swift
@@ -33,7 +33,7 @@ extension HBRequestDecodable {
     /// Create using `Codable` interfaces
     /// - Parameter request: request
     /// - Throws: HBHTTPError
-    public init(from request: HBRequest, context: some HBBaseRequestContext) throws {
-        self = try request.decode(as: Self.self, using: context)
+    public init(from request: HBRequest, context: some HBBaseRequestContext) async throws {
+        self = try await request.decode(as: Self.self, using: context)
     }
 }

--- a/Sources/Hummingbird/Router/RouteHandler.swift
+++ b/Sources/Hummingbird/Router/RouteHandler.swift
@@ -39,7 +39,7 @@
 /// ```
 public protocol HBRouteHandler {
     associatedtype _Output
-    init(from: HBRequest, context: some HBBaseRequestContext) throws
+    init(from: HBRequest, context: some HBBaseRequestContext) async throws
     func handle(request: HBRequest, context: some HBBaseRequestContext) async throws -> _Output
 }
 
@@ -52,7 +52,7 @@ extension HBRouterMethods {
         use handlerType: Handler.Type
     ) -> Self where Handler._Output == _Output {
         return self.on(path, method: method, options: options) { request, context -> _Output in
-            let handler = try Handler(from: request, context: context)
+            let handler = try await Handler(from: request, context: context)
             return try await handler.handle(request: request, context: context)
         }
     }

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -56,9 +56,9 @@ public struct HBRequest: Sendable {
 
     /// Decode request using decoder stored at `HBApplication.decoder`.
     /// - Parameter type: Type you want to decode to
-    public func decode<Type: Decodable>(as type: Type.Type, using context: some HBBaseRequestContext) throws -> Type {
+    public func decode<Type: Decodable>(as type: Type.Type, using context: some HBBaseRequestContext) async throws -> Type {
         do {
-            return try context.applicationContext.decoder.decode(type, from: self, context: context)
+            return try await context.applicationContext.decoder.decode(type, from: self, context: context)
         } catch DecodingError.dataCorrupted(_) {
             let message = "The given data was not valid input."
             throw HBHTTPError(.badRequest, message: message)

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -40,7 +40,7 @@ public enum HBRequestBody: Sendable, AsyncSequence {
         case .byteBuffer:
             return self
         case .stream(let streamer):
-            return try .byteBuffer(await streamer.collect(upTo: maxSize))
+            return try await .byteBuffer(streamer.collect(upTo: maxSize))
         }
     }
 }

--- a/Sources/HummingbirdFoundation/Codable/JSON/JSONCoding.swift
+++ b/Sources/HummingbirdFoundation/Codable/JSON/JSONCoding.swift
@@ -40,13 +40,9 @@ extension JSONDecoder: HBRequestDecoder {
     /// - Parameters:
     ///   - type: Type to decode
     ///   - request: Request to decode from
-    public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) throws -> T {
-        guard case .byteBuffer(var buffer) = request.body,
-              let data = buffer.readData(length: buffer.readableBytes)
-        else {
-            throw HBHTTPError(.badRequest)
-        }
-        return try self.decode(T.self, from: data)
+    public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) async throws -> T {
+        let buffer = try await request.body.collect(upTo: context.applicationContext.configuration.maxUploadSize)
+        return try self.decode(T.self, from: buffer)
     }
 }
 

--- a/Sources/HummingbirdFoundation/Codable/URLEncodedForm/URLEncodedForm+Request.swift
+++ b/Sources/HummingbirdFoundation/Codable/URLEncodedForm/URLEncodedForm+Request.swift
@@ -36,12 +36,9 @@ extension URLEncodedFormDecoder: HBRequestDecoder {
     /// - Parameters:
     ///   - type: Type to decode
     ///   - request: Request to decode from
-    public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) throws -> T {
-        guard case .byteBuffer(var buffer) = request.body,
-              let string = buffer.readString(length: buffer.readableBytes)
-        else {
-            throw HBHTTPError(.badRequest)
-        }
+    public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) async throws -> T {
+        let buffer = try await request.body.collect(upTo: context.applicationContext.configuration.maxUploadSize)
+        let string = String(buffer: buffer)
         return try self.decode(T.self, from: string)
     }
 }

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -34,7 +34,7 @@ router.get { _, _ in
 
 // request with a body
 // ./wrk -c 128 -d 15s -t 8 -s scripts/post.lua http://localhost:8080
-router.post(options: .streamBody) { request, _ in
+router.post { request, _ in
     return HBResponse(status: .ok, body: .init(asyncSequence: request.body))
 }
 

--- a/Tests/HummingbirdFoundationTests/HummingBirdJSONTests.swift
+++ b/Tests/HummingbirdFoundationTests/HummingBirdJSONTests.swift
@@ -29,7 +29,7 @@ class HummingbirdJSONTests: XCTestCase {
     func testDecode() async throws {
         let router = HBRouterBuilder(context: HBTestRouterContext.self)
         router.put("/user") { request, context -> HTTPResponseStatus in
-            guard let user = try? request.decode(as: User.self, using: context) else { throw HBHTTPError(.badRequest) }
+            guard let user = try? await request.decode(as: User.self, using: context) else { throw HBHTTPError(.badRequest) }
             XCTAssertEqual(user.name, "John Smith")
             XCTAssertEqual(user.email, "john.smith@email.com")
             XCTAssertEqual(user.age, 25)

--- a/Tests/HummingbirdFoundationTests/URLEncodedForm/Application+URLEncodedFormTests.swift
+++ b/Tests/HummingbirdFoundationTests/URLEncodedForm/Application+URLEncodedFormTests.swift
@@ -29,7 +29,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
     func testDecode() async throws {
         let router = HBRouterBuilder(context: HBTestRouterContext.self)
         router.put("/user") { request, context -> HTTPResponseStatus in
-            guard let user = try? request.decode(as: User.self, using: context) else { throw HBHTTPError(.badRequest) }
+            guard let user = try? await request.decode(as: User.self, using: context) else { throw HBHTTPError(.badRequest) }
             XCTAssertEqual(user.name, "John Smith")
             XCTAssertEqual(user.email, "john.smith@email.com")
             XCTAssertEqual(user.age, 25)

--- a/Tests/HummingbirdTests/FileIOTests.swift
+++ b/Tests/HummingbirdTests/FileIOTests.swift
@@ -71,7 +71,7 @@ class FileIOTests: XCTestCase {
     func testWriteLargeFile() async throws {
         let filename = "testWriteLargeFile.txt"
         let router = HBRouterBuilder(context: HBTestRouterContext.self)
-        router.put("store", options: .streamBody) { request, context -> HTTPResponseStatus in
+        router.put("store") { request, context -> HTTPResponseStatus in
             let fileIO = HBFileIO(threadPool: context.threadPool)
             try await fileIO.writeFile(contents: request.body, path: filename, context: context, logger: context.logger)
             return .ok

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -157,7 +157,7 @@ final class MiddlewareTests: XCTestCase {
         let router = HBRouterBuilder(context: HBTestRouterContext.self)
         router.group()
             .add(middleware: TransformMiddleware())
-            .get("test", options: .streamBody) { request, _ in
+            .get("test") { request, _ in
                 return HBResponse(status: .ok, body: .init(asyncSequence: request.body))
             }
         let app = HBApplication(responder: router.buildResponder())

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -24,14 +24,14 @@ final class PersistTests: XCTestCase {
         let persist = HBMemoryPersistDriver()
 
         router.put("/persist/:tag") { request, context -> HTTPResponseStatus in
-            guard case .byteBuffer(let buffer) = request.body else { throw HBHTTPError(.badRequest) }
+            let buffer = try await request.body.collect(upTo: .max)
             let tag = try context.parameters.require("tag")
             try await persist.set(key: tag, value: String(buffer: buffer))
             return .ok
         }
         router.put("/persist/:tag/:time") { request, context -> HTTPResponseStatus in
             guard let time = context.parameters.get("time", as: Int.self) else { throw HBHTTPError(.badRequest) }
-            guard case .byteBuffer(let buffer) = request.body else { throw HBHTTPError(.badRequest) }
+            let buffer = try await request.body.collect(upTo: .max)
             let tag = try context.parameters.require("tag")
             try await persist.set(key: tag, value: String(buffer: buffer), expires: .seconds(time))
             return .ok
@@ -65,7 +65,7 @@ final class PersistTests: XCTestCase {
         let (router, persist) = try createRouter()
 
         router.put("/create/:tag") { request, context -> HTTPResponseStatus in
-            guard case .byteBuffer(let buffer) = request.body else { throw HBHTTPError(.badRequest) }
+            let buffer = try await request.body.collect(upTo: .max)
             let tag = try context.parameters.require("tag")
             try await persist.create(key: tag, value: String(buffer: buffer))
             return .ok
@@ -84,7 +84,7 @@ final class PersistTests: XCTestCase {
     func testDoubleCreateFail() async throws {
         let (router, persist) = try createRouter()
         router.put("/create/:tag") { request, context -> HTTPResponseStatus in
-            guard case .byteBuffer(let buffer) = request.body else { throw HBHTTPError(.badRequest) }
+            let buffer = try await request.body.collect(upTo: .max)
             let tag = try context.parameters.require("tag")
             do {
                 try await persist.create(key: tag, value: String(buffer: buffer))
@@ -154,7 +154,7 @@ final class PersistTests: XCTestCase {
         let (router, persist) = try createRouter()
         router.put("/codable/:tag") { request, context -> HTTPResponseStatus in
             guard let tag = context.parameters.get("tag") else { throw HBHTTPError(.badRequest) }
-            guard case .byteBuffer(let buffer) = request.body else { throw HBHTTPError(.badRequest) }
+            let buffer = try await request.body.collect(upTo: .max)
             try await persist.set(key: tag, value: TestCodable(buffer: String(buffer: buffer)))
             return .ok
         }


### PR DESCRIPTION
Only collate it when we need to ie when using a decoder