### PR TITLE
HBApplicationProtocol v2

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -53,11 +53,13 @@ public final class HBApplicationContext: Sendable {
     }
 }
 
-public protocol HBApplicationProtocol: Service where Responder.Context: HBRequestContext {
+public protocol HBApplicationProtocol: Service where Context: HBRequestContext {
     /// Responder that generates a response from a requests and context
-    associatedtype Responder: HBResponder<Responder.Context>
+    associatedtype Responder: HBResponder
     /// Child Channel setup. This defaults to support HTTP1
     associatedtype ChannelSetup: HBChannelSetup & HTTPChannelHandler = HTTP1Channel
+    /// Context passed with HBRequest to responder
+    typealias Context = Responder.Context
 
     /// Build the responder
     func buildResponder() async throws -> Responder

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -54,87 +54,76 @@ public final class HBApplicationContext: Sendable {
     }
 }
 
-/// Application class. Brings together all the components of Hummingbird together
-///
-/// ```
-/// let router = HBRouter()
-/// router.middleware.add(MyMiddleware())
-/// router.get("hello") { _ in
-///     return "hello"
-/// }
-/// let app = HBApplication(responder: router.buildResponder())
-/// try await app.runService()
-/// ```
-/// Editing the application setup after calling `runService` will produce undefined behaviour.
-public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup & HTTPChannelHandler> {
-    // MARK: Member variables
+public protocol HBApplicationProtocol: Service {
+    /// Context passed with HBRequest to responder
+    associatedtype Context: HBRequestContext
+    /// Responder that generates a response from a requests and context
+    associatedtype Responder: HBResponder<Context>
+    /// Child Channel setup. This defaults to support HTTP1
+    associatedtype ChannelSetup: HBChannelSetup & HTTPChannelHandler = HTTP1Channel
+
+    /// Build the responder
+    func buildResponder() async throws -> Responder
+    /// Server channel setup
+    func channelSetup(httpResponder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse) throws -> ChannelSetup
 
     /// event loop group used by application
-    public let eventLoopGroup: EventLoopGroup
-    /// routes requests to requestResponders based on URI
-    public let responder: Responder
-    /// Configuration
-    public var configuration: HBApplicationConfiguration
+    var eventLoopGroup: EventLoopGroup { get }
+    /// Application configuration
+    var configuration: HBApplicationConfiguration { get }
     /// Logger
-    public var logger: Logger
-    /// on server running
-    public var onServerRunning: @Sendable (Channel) async -> Void
-    /// Server channel setup
-    let channelSetup: ChannelSetup
+    var logger: Logger { get }
+    /// This is called once the server is running and we have an active Channel
+    @Sendable func onServerRunning(_ channel: Channel) async
     /// services attached to the application.
-    var services: [any Service]
+    var services: [any Service] { get }
+}
 
-    // MARK: Initialization
-
-    /// Initialize new Application
-    public init(
-        responder: Responder,
-        channelSetup: ChannelSetup = HTTP1Channel(),
-        configuration: HBApplicationConfiguration = HBApplicationConfiguration(),
-        eventLoopGroupProvider: EventLoopGroupProvider = .singleton
-    ) {
-        var logger = Logger(label: configuration.serverName ?? "HummingBird")
-        logger.logLevel = configuration.logLevel
-        self.logger = logger
-
-        self.responder = responder
-        self.channelSetup = channelSetup
-        self.configuration = configuration
-        self.onServerRunning = { _ in }
-
-        self.eventLoopGroup = eventLoopGroupProvider.eventLoopGroup
-        self.services = []
-    }
-
-    // MARK: Methods
-
-    ///  Add service to be managed by application ServiceGroup
-    /// - Parameter service: service to be added
-    public mutating func addService(_ service: any Service) {
-        self.services.append(service)
-    }
-
-    public static func loggerWithRequestId(_ logger: Logger) -> Logger {
-        let requestId = globalRequestID.loadThenWrappingIncrement(by: 1, ordering: .relaxed)
-        return logger.with(metadataKey: "hb_id", value: .stringConvertible(requestId))
+extension HBApplicationProtocol where ChannelSetup == HTTP1Channel {
+    /// Defautl channel setup function for HTTP1 channels
+    public func channelSetup(httpResponder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse) -> ChannelSetup {
+        HTTP1Channel(responder: httpResponder)
     }
 }
 
+extension HBApplicationProtocol {
+    /// Default event loop group used by application
+    public var eventLoopGroup: EventLoopGroup { MultiThreadedEventLoopGroup.singleton }
+    /// Default thread pool used by application
+    public var threadPool: NIOThreadPool { NIOThreadPool.singleton }
+    /// Default Configuration
+    public var configuration: HBApplicationConfiguration { .init() }
+    /// Default Logger
+    public var logger: Logger { Logger(label: self.configuration.serverName ?? "HummingBird") }
+    /// Default encoder used by router
+    public var encoder: HBResponseEncoder { NullEncoder() }
+    /// Default decoder used by router
+    public var decoder: HBRequestDecoder { NullDecoder() }
+    /// Default onServerRunning that does nothing
+    public func onServerRunning(_: Channel) async {}
+    /// Default to no extra services attached to the application.
+    public var services: [any Service] { [] }
+}
+
 /// Conform to `Service` from `ServiceLifecycle`.
-extension HBApplication: Service where Responder.Context: HBRequestContext {
+extension HBApplicationProtocol {
+    /// Construct application and run it
     public func run() async throws {
-        let context = HBApplicationContext(
-            configuration: self.configuration
-        )
         let dateCache = HBDateCache()
+        let responder = try await self.buildResponder()
+
+        // Function responding to HTTP request
         @Sendable func respond(to request: HBRequest, channel: Channel) async throws -> HBResponse {
-            let context = Responder.Context(
-                applicationContext: context,
+            let applicationContext = HBApplicationContext(
+                configuration: self.configuration
+            )
+            let context = Self.Responder.Context(
+                applicationContext: applicationContext,
                 channel: channel,
-                logger: HBApplication.loggerWithRequestId(self.logger)
+                logger: loggerWithRequestId(self.logger)
             )
             // respond to request
-            var response = try await self.responder.respond(to: request, context: context)
+            var response = try await responder.respond(to: request, context: context)
             response.headers[.date] = dateCache.date
             // server name header
             if let serverName = self.configuration.serverName {
@@ -142,9 +131,8 @@ extension HBApplication: Service where Responder.Context: HBRequestContext {
             }
             return response
         }
-        // update channel with responder
-        var channelSetup = self.channelSetup
-        channelSetup.responder = respond
+        // get channel Setup
+        let channelSetup = try self.channelSetup(httpResponder: respond)
         // create server
         let server = HBServer(
             childChannelSetup: channelSetup,
@@ -153,14 +141,8 @@ extension HBApplication: Service where Responder.Context: HBRequestContext {
             eventLoopGroup: self.eventLoopGroup,
             logger: self.logger
         )
-        let services: [any Service]
-        if self.configuration.noHTTPServer {
-            services = self.services
-        } else {
-            services = [server, dateCache] + self.services
-        }
         try await withGracefulShutdownHandler {
-            let services: [any Service] = services
+            let services: [any Service] = [server, dateCache] + self.services
             let serviceGroup = ServiceGroup(
                 configuration: .init(services: services, logger: self.logger)
             )
@@ -183,6 +165,92 @@ extension HBApplication: Service where Responder.Context: HBRequestContext {
             )
         )
         try await serviceGroup.run()
+    }
+}
+
+public func loggerWithRequestId(_ logger: Logger) -> Logger {
+    let requestId = globalRequestID.loadThenWrappingIncrement(by: 1, ordering: .relaxed)
+    return logger.with(metadataKey: "hb_id", value: .stringConvertible(requestId))
+}
+
+/// Application class. Brings together all the components of Hummingbird together
+///
+/// ```
+/// let router = HBRouterBuilder()
+/// router.middleware.add(MyMiddleware())
+/// router.get("hello") { _ in
+///     return "hello"
+/// }
+/// let app = HBApplication(responder: router.buildResponder())
+/// try await app.runService()
+/// ```
+/// Editing the application setup after calling `runService` will produce undefined behaviour.
+public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup & HTTPChannelHandler>: HBApplicationProtocol where Responder.Context: HBRequestContext {
+    public typealias Context = Responder.Context
+
+    // MARK: Member variables
+
+    /// event loop group used by application
+    public let eventLoopGroup: EventLoopGroup
+    /// thread pool used by application
+    public let threadPool: NIOThreadPool
+    /// routes requests to requestResponders based on URI
+    public let responder: Responder
+    /// Configuration
+    public var configuration: HBApplicationConfiguration
+    /// Logger
+    public var logger: Logger
+    /// Encoder used by router
+    public var encoder: HBResponseEncoder
+    /// decoder used by router
+    public var decoder: HBRequestDecoder
+    /// on server running
+    private var _onServerRunning: @Sendable (Channel) async -> Void
+    /// Server channel setup
+    let channelSetup: ChannelSetup
+    /// services attached to the application.
+    public var services: [any Service]
+
+    // MARK: Initialization
+
+    /// Initialize new Application
+    public init(
+        responder: Responder,
+        channelSetup: ChannelSetup = HTTP1Channel(),
+        configuration: HBApplicationConfiguration = HBApplicationConfiguration(),
+        threadPool: NIOThreadPool = .singleton,
+        eventLoopGroupProvider: EventLoopGroupProvider = .singleton
+    ) {
+        var logger = Logger(label: configuration.serverName ?? "HummingBird")
+        logger.logLevel = configuration.logLevel
+        self.logger = logger
+
+        self.responder = responder
+        self.channelSetup = channelSetup
+        self.configuration = configuration
+        self.encoder = NullEncoder()
+        self.decoder = NullDecoder()
+        self._onServerRunning = { _ in }
+
+        self.eventLoopGroup = eventLoopGroupProvider.eventLoopGroup
+        self.threadPool = threadPool
+        self.services = []
+    }
+
+    // MARK: Methods
+
+    ///  Add service to be managed by application ServiceGroup
+    /// - Parameter service: service to be added
+    public mutating func addService(_ service: any Service) {
+        self.services.append(service)
+    }
+
+    public func buildResponder() async throws -> Responder {
+        return self.responder
+    }
+
+    public func onServerRunning(_ channel: Channel) async {
+        await self._onServerRunning(channel)
     }
 }
 

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -88,16 +88,10 @@ extension HBApplicationProtocol where ChannelSetup == HTTP1Channel {
 extension HBApplicationProtocol {
     /// Default event loop group used by application
     public var eventLoopGroup: EventLoopGroup { MultiThreadedEventLoopGroup.singleton }
-    /// Default thread pool used by application
-    public var threadPool: NIOThreadPool { NIOThreadPool.singleton }
     /// Default Configuration
     public var configuration: HBApplicationConfiguration { .init() }
     /// Default Logger
     public var logger: Logger { Logger(label: self.configuration.serverName ?? "HummingBird") }
-    /// Default encoder used by router
-    public var encoder: HBResponseEncoder { NullEncoder() }
-    /// Default decoder used by router
-    public var decoder: HBRequestDecoder { NullDecoder() }
     /// Default onServerRunning that does nothing
     public func onServerRunning(_: Channel) async {}
     /// Default to no extra services attached to the application.

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -53,11 +53,9 @@ public final class HBApplicationContext: Sendable {
     }
 }
 
-public protocol HBApplicationProtocol: Service {
-    /// Context passed with HBRequest to responder
-    associatedtype Context: HBRequestContext
+public protocol HBApplicationProtocol: Service where Responder.Context: HBRequestContext {
     /// Responder that generates a response from a requests and context
-    associatedtype Responder: HBResponder<Context>
+    associatedtype Responder: HBResponder<Responder.Context>
     /// Child Channel setup. This defaults to support HTTP1
     associatedtype ChannelSetup: HBChannelSetup & HTTPChannelHandler = HTTP1Channel
 

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -250,7 +250,7 @@ public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup
         return self.responder
     }
 
-    public func channelSetup(httpResponder: @escaping @Sendable (HBHTTPRequest, Channel) async throws -> HBHTTPResponse) throws -> ChannelSetup {
+    public func channelSetup(httpResponder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse) throws -> ChannelSetup {
         var channelSetup = self.channelSetup
         channelSetup.responder = httpResponder
         return channelSetup

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -193,18 +193,12 @@ public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup
 
     /// event loop group used by application
     public let eventLoopGroup: EventLoopGroup
-    /// thread pool used by application
-    public let threadPool: NIOThreadPool
     /// routes requests to requestResponders based on URI
     public let responder: Responder
     /// Configuration
     public var configuration: HBApplicationConfiguration
     /// Logger
     public var logger: Logger
-    /// Encoder used by router
-    public var encoder: HBResponseEncoder
-    /// decoder used by router
-    public var decoder: HBRequestDecoder
     /// on server running
     private var _onServerRunning: @Sendable (Channel) async -> Void
     /// Server channel setup
@@ -219,7 +213,6 @@ public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup
         responder: Responder,
         channelSetup: ChannelSetup = HTTP1Channel(),
         configuration: HBApplicationConfiguration = HBApplicationConfiguration(),
-        threadPool: NIOThreadPool = .singleton,
         eventLoopGroupProvider: EventLoopGroupProvider = .singleton
     ) {
         var logger = Logger(label: configuration.serverName ?? "HummingBird")
@@ -229,12 +222,9 @@ public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup
         self.responder = responder
         self.channelSetup = channelSetup
         self.configuration = configuration
-        self.encoder = NullEncoder()
-        self.decoder = NullDecoder()
         self._onServerRunning = { _ in }
 
         self.eventLoopGroup = eventLoopGroupProvider.eventLoopGroup
-        self.threadPool = threadPool
         self.services = []
     }
 

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -169,7 +169,7 @@ public func loggerWithRequestId(_ logger: Logger) -> Logger {
 /// Application class. Brings together all the components of Hummingbird together
 ///
 /// ```
-/// let router = HBRouterBuilder()
+/// let router = HBRouter()
 /// router.middleware.add(MyMiddleware())
 /// router.get("hello") { _ in
 ///     return "hello"

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import Atomics
-import Dispatch
 import HummingbirdCore
 import Logging
 import NIOCore
@@ -187,6 +186,8 @@ public func loggerWithRequestId(_ logger: Logger) -> Logger {
 /// Editing the application setup after calling `runService` will produce undefined behaviour.
 public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup & HTTPChannelHandler>: HBApplicationProtocol where Responder.Context: HBRequestContext {
     public typealias Context = Responder.Context
+    public typealias ChannelSetup = ChannelSetup
+    public typealias Responder = Responder
 
     // MARK: Member variables
 
@@ -247,6 +248,12 @@ public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup
 
     public func buildResponder() async throws -> Responder {
         return self.responder
+    }
+
+    public func channelSetup(httpResponder: @escaping @Sendable (HBHTTPRequest, Channel) async throws -> HBHTTPResponse) throws -> ChannelSetup {
+        var channelSetup = self.channelSetup
+        channelSetup.responder = httpResponder
+        return channelSetup
     }
 
     public func onServerRunning(_ channel: Channel) async {

--- a/Sources/HummingbirdXCT/Application+XCT.swift
+++ b/Sources/HummingbirdXCT/Application+XCT.swift
@@ -49,7 +49,7 @@ public struct XCTRouterTestingSetup {
 ///     }
 /// }
 /// ```
-extension HBApplication where Responder.Context: HBRequestContext {
+extension HBApplicationProtocol where Responder.Context: HBRequestContext {
     // MARK: Initialization
 
     /// Creates a version of `HBApplication` that can be used for testing code
@@ -67,7 +67,7 @@ extension HBApplication where Responder.Context: HBRequestContext {
     }
 }
 
-extension HBApplication where ChannelSetup == HTTP1Channel, Responder.Context: HBTestRequestContextProtocol {
+extension HBApplicationProtocol where Responder.Context: HBTestRequestContextProtocol {
     // MARK: Initialization
 
     /// Creates a version of `HBApplication` that can be used for testing code
@@ -80,7 +80,7 @@ extension HBApplication where ChannelSetup == HTTP1Channel, Responder.Context: H
         _ test: @escaping @Sendable (any HBXCTClientProtocol) async throws -> Value
     ) async throws -> Value {
         let app: any HBXCTApplication
-        app = HBXCTRouter(app: self)
+        app = try await HBXCTRouter(app: self)
         return try await app.run(test)
     }
 }

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -24,10 +24,9 @@ import ServiceLifecycle
 import XCTest
 
 /// Test using a live server
-final class HBXCTLive<App: HBApplicationProtocol>: HBXCTApplication where App.Context: HBRequestContext {
+final class HBXCTLive<App: HBApplicationProtocol>: HBXCTApplication {
     /// TestApplication used to wrap HBApplication being tested
-    struct TestApplication<BaseApp: HBApplicationProtocol>: HBApplicationProtocol, Service where BaseApp.Context: HBRequestContext {
-        typealias Context = BaseApp.Context
+    struct TestApplication<BaseApp: HBApplicationProtocol>: HBApplicationProtocol, Service where BaseApp.Responder.Context: HBRequestContext {
         typealias Responder = BaseApp.Responder
         typealias ChannelSetup = BaseApp.ChannelSetup
 

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -26,7 +26,7 @@ import XCTest
 /// Test using a live server
 final class HBXCTLive<App: HBApplicationProtocol>: HBXCTApplication {
     /// TestApplication used to wrap HBApplication being tested
-    struct TestApplication<BaseApp: HBApplicationProtocol>: HBApplicationProtocol, Service where BaseApp.Responder.Context: HBRequestContext {
+    struct TestApplication<BaseApp: HBApplicationProtocol>: HBApplicationProtocol, Service {
         typealias Responder = BaseApp.Responder
         typealias ChannelSetup = BaseApp.ChannelSetup
 

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -43,16 +43,10 @@ final class HBXCTLive<App: HBApplicationProtocol>: HBXCTApplication where App.Co
 
         /// event loop group used by application
         var eventLoopGroup: EventLoopGroup { self.base.eventLoopGroup }
-        /// thread pool used by application
-        var threadPool: NIOThreadPool { self.base.threadPool }
         /// Configuration
         var configuration: HBApplicationConfiguration { self.base.configuration.with(address: .hostname("localhost", port: 0)) }
         /// Logger
         var logger: Logger { self.base.logger }
-        /// Encoder used by router
-        var encoder: HBResponseEncoder { self.base.encoder }
-        /// decoder used by router
-        var decoder: HBRequestDecoder { self.base.decoder }
         /// on server running
         @Sendable func onServerRunning(_ channel: Channel) async {
             await self.portPromise.complete(channel.localAddress!.port!)

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -24,9 +24,9 @@ import ServiceLifecycle
 import XCTest
 
 /// Test using a live server
-final class HBXCTLive<App: HBApplicationProtocol>: HBXCTApplication where App.Responder.Context: HBRequestContext {
+final class HBXCTLive<App: HBApplicationProtocol>: HBXCTApplication where App.Context: HBRequestContext {
     /// TestApplication used to wrap HBApplication being tested
-    struct TestApplication<BaseApp: HBApplicationProtocol>: HBApplicationProtocol {
+    struct TestApplication<BaseApp: HBApplicationProtocol>: HBApplicationProtocol, Service where BaseApp.Context: HBRequestContext {
         typealias Context = BaseApp.Context
         typealias Responder = BaseApp.Responder
         typealias ChannelSetup = BaseApp.ChannelSetup

--- a/Sources/HummingbirdXCT/HBXCTRouter.swift
+++ b/Sources/HummingbirdXCT/HBXCTRouter.swift
@@ -61,19 +61,6 @@ public struct HBTestRouterContext: HBTestRequestContextProtocol {
         )
     }
 
-    public init(
-        applicationContext: HBApplicationContext,
-        channel: Channel,
-        logger: Logger
-    ) {
-        self.coreContext = .init(
-            applicationContext: applicationContext,
-            eventLoop: channel.eventLoop,
-            allocator: channel.allocator,
-            logger: logger
-        )
-    }
-
     /// router context
     public var coreContext: HBCoreRequestContext
 }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -452,7 +452,7 @@ final class ApplicationTests: XCTestCase {
     /// is more a compilation test than a runtime test
     func testApplicationProtocolReturnValue() async throws {
         func createApplication() -> some HBApplicationProtocol {
-            let router = HBRouterBuilder(context: HBTestRouterContext.self)
+            let router = HBRouter(context: HBTestRouterContext.self)
             router.get("/hello") { _, context -> ByteBuffer in
                 return context.allocator.buffer(string: "GET: Hello")
             }
@@ -476,7 +476,7 @@ final class ApplicationTests: XCTestCase {
             typealias ChannelSetup = HTTP1Channel
 
             func buildResponder() async throws -> some HBResponder<Context> {
-                let router = HBRouterBuilder(context: Context.self)
+                let router = HBRouter(context: Context.self)
                 router.get("/hello") { _, context -> ByteBuffer in
                     return context.allocator.buffer(string: "GET: Hello")
                 }


### PR DESCRIPTION
This is version 2 of the `HBApplicationProtocol`.

Instead of making `HBApplication` a protocol, I have added the protocol `HBApplicationProtocol` and conform `HBApplication` to it. This means we can use the old method of creating an `HBApplication` but pass it around as `some HBApplicationProtocol`.

Also someone can still create their own application type conforming to `HBApplicationProtocol`