### PR TITLE
Tests for HTTP2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.20.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
     ],
     targets: [
         .target(name: "Hummingbird", dependencies: [
@@ -119,8 +120,10 @@ let package = Package(
             dependencies:
             [
                 .byName(name: "HummingbirdCore"),
+                .byName(name: "HummingbirdHTTP2"),
                 .byName(name: "HummingbirdTLS"),
                 .byName(name: "HummingbirdCoreXCT"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
             ],
             resources: [.process("Certificates")]
         ),

--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -77,7 +77,7 @@ public struct HTTP2Channel: HTTPChannelHandler {
 
             return http2ChildChannel
                 .pipeline
-                .addHandler(HTTP2FramePayloadToHTTPClientCodec())
+                .addHandler(HTTP2FramePayloadToHTTPServerCodec())
                 .flatMap {
                     http2ChildChannel.pipeline.addHandlers(childChannelHandlers)
                 }.flatMapThrowing {


### PR DESCRIPTION
Requires AsyncHTTPClient
But given I found a bug in the HTTP2 code, I think it is worthwhile