### PR TITLE
Remove encoder/decoder from Application

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -46,19 +46,11 @@ public enum EventLoopGroupProvider {
 public final class HBApplicationContext: Sendable {
     /// Configuration
     public let configuration: HBApplicationConfiguration
-    /// Encoder used by router
-    public let encoder: HBResponseEncoder
-    /// decoder used by router
-    public let decoder: HBRequestDecoder
 
     public init(
-        configuration: HBApplicationConfiguration,
-        encoder: HBResponseEncoder,
-        decoder: HBRequestDecoder
+        configuration: HBApplicationConfiguration
     ) {
         self.configuration = configuration
-        self.encoder = encoder
-        self.decoder = decoder
     }
 }
 
@@ -85,10 +77,6 @@ public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup
     public var configuration: HBApplicationConfiguration
     /// Logger
     public var logger: Logger
-    /// Encoder used by router
-    public var encoder: HBResponseEncoder
-    /// decoder used by router
-    public var decoder: HBRequestDecoder
     /// on server running
     public var onServerRunning: @Sendable (Channel) async -> Void
     /// Server channel setup
@@ -112,8 +100,6 @@ public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup
         self.responder = responder
         self.channelSetup = channelSetup
         self.configuration = configuration
-        self.encoder = NullEncoder()
-        self.decoder = NullDecoder()
         self.onServerRunning = { _ in }
 
         self.eventLoopGroup = eventLoopGroupProvider.eventLoopGroup
@@ -138,9 +124,7 @@ public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup
 extension HBApplication: Service where Responder.Context: HBRequestContext {
     public func run() async throws {
         let context = HBApplicationContext(
-            configuration: self.configuration,
-            encoder: self.encoder,
-            decoder: self.decoder
+            configuration: self.configuration
         )
         let dateCache = HBDateCache()
         @Sendable func respond(to request: HBRequest, channel: Channel) async throws -> HBResponse {

--- a/Sources/Hummingbird/Codable/CodableProtocols.swift
+++ b/Sources/Hummingbird/Codable/CodableProtocols.swift
@@ -34,8 +34,9 @@ public protocol HBRequestDecoder: Sendable {
 }
 
 /// Default encoder. Outputs request with the swift string description of object
-struct NullEncoder: HBResponseEncoder {
-    func encode(_ value: some Encodable, from request: HBRequest, context: some HBBaseRequestContext) throws -> HBResponse {
+public struct NullEncoder: HBResponseEncoder {
+    public init() {}
+    public func encode(_ value: some Encodable, from request: HBRequest, context: some HBBaseRequestContext) throws -> HBResponse {
         return HBResponse(
             status: .ok,
             headers: [.contentType: "text/plain; charset=utf-8"],
@@ -45,8 +46,9 @@ struct NullEncoder: HBResponseEncoder {
 }
 
 /// Default decoder. there is no default decoder path so this generates an error
-struct NullDecoder: HBRequestDecoder {
-    func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) throws -> T {
+public struct NullDecoder: HBRequestDecoder {
+    public init() {}
+    public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) throws -> T {
         preconditionFailure("HBApplication.decoder has not been set")
     }
 }

--- a/Sources/Hummingbird/Codable/ResponseEncodable.swift
+++ b/Sources/Hummingbird/Codable/ResponseEncodable.swift
@@ -24,7 +24,7 @@ public protocol HBResponseCodable: HBResponseEncodable, Decodable {}
 /// Extend ResponseEncodable to conform to ResponseGenerator
 extension HBResponseEncodable {
     public func response(from request: HBRequest, context: some HBBaseRequestContext) throws -> HBResponse {
-        return try context.applicationContext.encoder.encode(self, from: request, context: context)
+        return try context.responseEncoder.encode(self, from: request, context: context)
     }
 }
 
@@ -34,7 +34,7 @@ extension Array: HBResponseGenerator where Element: Encodable {}
 /// Extend Array to conform to HBResponseEncodable
 extension Array: HBResponseEncodable where Element: Encodable {
     public func response(from request: HBRequest, context: some HBBaseRequestContext) throws -> HBResponse {
-        return try context.applicationContext.encoder.encode(self, from: request, context: context)
+        return try context.responseEncoder.encode(self, from: request, context: context)
     }
 }
 
@@ -44,6 +44,6 @@ extension Dictionary: HBResponseGenerator where Key: Encodable, Value: Encodable
 /// Extend Array to conform to HBResponseEncodable
 extension Dictionary: HBResponseEncodable where Key: Encodable, Value: Encodable {
     public func response(from request: HBRequest, context: some HBBaseRequestContext) throws -> HBResponse {
-        return try context.applicationContext.encoder.encode(self, from: request, context: context)
+        return try context.responseEncoder.encode(self, from: request, context: context)
     }
 }

--- a/Sources/Hummingbird/Middleware/SetCodableMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/SetCodableMiddleware.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public struct HBSetCodableMiddleware<Decoder: HBRequestDecoder, Encoder: HBResponseEncoder, Context: HBBaseRequestContext>: HBMiddleware {
+    let decoder: @Sendable () -> Decoder
+    let encoder: @Sendable () -> Encoder
+
+    public init(decoder: @autoclosure @escaping @Sendable () -> Decoder, encoder: @autoclosure @escaping @Sendable () -> Encoder) {
+        self.decoder = decoder
+        self.encoder = encoder
+    }
+
+    public func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
+        var context = context
+        context.coreContext.requestDecoder = self.decoder()
+        context.coreContext.responseEncoder = self.encoder()
+        return try await next.respond(to: request, context: context)
+    }
+}

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -19,7 +19,7 @@ extension HBRequest {
     /// - Parameter type: Type you want to decode to
     public func decode<Type: Decodable>(as type: Type.Type, using context: some HBBaseRequestContext) async throws -> Type {
         do {
-            return try await context.applicationContext.decoder.decode(type, from: self, context: context)
+            return try await context.requestDecoder.decode(type, from: self, context: context)
         } catch DecodingError.dataCorrupted(_) {
             let message = "The given data was not valid input."
             throw HBHTTPError(.badRequest, message: message)

--- a/Sources/Hummingbird/Server/RequestContext.swift
+++ b/Sources/Hummingbird/Server/RequestContext.swift
@@ -39,6 +39,12 @@ public struct HBCoreRequestContext: Sendable {
     /// Application context
     @usableFromInline
     let applicationContext: HBApplicationContext
+    /// Request decoder
+    @usableFromInline
+    var requestDecoder: HBRequestDecoder
+    /// Response encoder
+    @usableFromInline
+    var responseEncoder: HBResponseEncoder
     /// EventLoop request is running on
     @usableFromInline
     let eventLoop: EventLoop
@@ -58,11 +64,15 @@ public struct HBCoreRequestContext: Sendable {
     @inlinable
     public init(
         applicationContext: HBApplicationContext,
+        requestDecoder: HBRequestDecoder = NullDecoder(),
+        responseEncoder: HBResponseEncoder = NullEncoder(),
         eventLoop: EventLoop,
         allocator: ByteBufferAllocator,
         logger: Logger
     ) {
         self.applicationContext = applicationContext
+        self.requestDecoder = requestDecoder
+        self.responseEncoder = responseEncoder
         self.eventLoop = eventLoop
         self.allocator = allocator
         self.logger = logger
@@ -84,7 +94,13 @@ extension HBBaseRequestContext {
     /// Application context
     @inlinable
     public var applicationContext: HBApplicationContext { coreContext.applicationContext }
-    /// ThreadPool
+    /// Request decoder
+    @inlinable
+    public var requestDecoder: HBRequestDecoder { coreContext.requestDecoder }
+    /// Response encoder
+    @inlinable
+    public var responseEncoder: HBResponseEncoder { coreContext.responseEncoder }
+    /// ThreadPool attached to application
     @inlinable
     public var threadPool: NIOThreadPool { NIOThreadPool.singleton }
     /// EventLoop request is running on. This is unavailable in concurrency contexts as you

--- a/Sources/HummingbirdXCT/HBXCTRouter.swift
+++ b/Sources/HummingbirdXCT/HBXCTRouter.swift
@@ -73,10 +73,7 @@ struct HBXCTRouter<Responder: HBResponder>: HBXCTApplication where Responder.Con
     init(app: HBApplication<Responder, HTTP1Channel>) {
         self.eventLoopGroup = app.eventLoopGroup
         self.context = HBApplicationContext(
-            threadPool: app.threadPool,
-            configuration: app.configuration,
-            encoder: app.encoder,
-            decoder: app.decoder
+            configuration: app.configuration
         )
         self.responder = app.responder
         self.logger = app.logger

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -18,6 +18,21 @@ import Logging
 import NIOCore
 import NIOPosix
 
+struct PerformanceTestRequestContext: HBRequestContext {
+    var coreContext: HBCoreRequestContext
+
+    init(applicationContext: HBApplicationContext, channel: Channel, logger: Logger) {
+        self.coreContext = .init(
+            applicationContext: applicationContext,
+            requestDecoder: JSONDecoder(),
+            responseEncoder: JSONEncoder(),
+            eventLoop: channel.eventLoop,
+            allocator: channel.allocator,
+            logger: logger
+        )
+    }
+}
+
 // get environment
 let hostname = HBEnvironment.shared.get("SERVER_HOSTNAME") ?? "127.0.0.1"
 let port = HBEnvironment.shared.get("SERVER_PORT", as: Int.self) ?? 8080
@@ -25,7 +40,7 @@ let port = HBEnvironment.shared.get("SERVER_PORT", as: Int.self) ?? 8080
 // create app
 let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
 defer { try? elg.syncShutdownGracefully() }
-var router = HBRouter()
+var router = HBRouter(context: PerformanceTestRequestContext.self)
 // number of raw requests
 // ./wrk -c 128 -d 15s -t 8 http://localhost:8080
 router.get { _, _ in
@@ -60,8 +75,6 @@ var app = HBApplication(
     eventLoopGroupProvider: .shared(elg)
 )
 app.logger.logLevel = .debug
-app.encoder = JSONEncoder()
-app.decoder = JSONDecoder()
 
 // configure app
 

--- a/Tests/HummingbirdFoundationTests/URLEncodedForm/Application+URLEncodedFormTests.swift
+++ b/Tests/HummingbirdFoundationTests/URLEncodedForm/Application+URLEncodedFormTests.swift
@@ -28,6 +28,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
 
     func testDecode() async throws {
         let router = HBRouter(context: HBTestRouterContext.self)
+        router.middlewares.add(HBSetCodableMiddleware(decoder: URLEncodedFormDecoder(), encoder: URLEncodedFormEncoder()))
         router.put("/user") { request, context -> HTTPResponse.Status in
             guard let user = try? await request.decode(as: User.self, using: context) else { throw HBHTTPError(.badRequest) }
             XCTAssertEqual(user.name, "John Smith")
@@ -35,8 +36,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
             XCTAssertEqual(user.age, 25)
             return .ok
         }
-        var app = HBApplication(responder: router.buildResponder())
-        app.decoder = URLEncodedFormDecoder()
+        let app = HBApplication(responder: router.buildResponder())
         try await app.test(.router) { client in
             let body = "name=John%20Smith&email=john.smith%40email.com&age=25"
             try await client.XCTExecute(uri: "/user", method: .put, body: ByteBufferAllocator().buffer(string: body)) {
@@ -47,11 +47,11 @@ class HummingBirdURLEncodedTests: XCTestCase {
 
     func testEncode() async throws {
         let router = HBRouter(context: HBTestRouterContext.self)
+        router.middlewares.add(HBSetCodableMiddleware(decoder: URLEncodedFormDecoder(), encoder: URLEncodedFormEncoder()))
         router.get("/user") { _, _ -> User in
             return User(name: "John Smith", email: "john.smith@email.com", age: 25)
         }
-        var app = HBApplication(responder: router.buildResponder())
-        app.encoder = URLEncodedFormEncoder()
+        let app = HBApplication(responder: router.buildResponder())
         try await app.test(.router) { client in
             try await client.XCTExecute(uri: "/user", method: .get) { response in
                 var body = try XCTUnwrap(response.body)

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -363,6 +363,7 @@ final class ApplicationTests: XCTestCase {
             let value: String
         }
         let router = HBRouter(context: HBTestRouterContext.self)
+        router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.patch("/hello") { _, _ in
             return HBEditedResponse(
                 status: .multipleChoices,
@@ -370,8 +371,7 @@ final class ApplicationTests: XCTestCase {
                 response: Result(value: "true")
             )
         }
-        var app = HBApplication(responder: router.buildResponder())
-        app.encoder = JSONEncoder()
+        let app = HBApplication(responder: router.buildResponder())
         try await app.test(.router) { client in
 
             try await client.XCTExecute(uri: "/hello", method: .patch) { response in

--- a/Tests/HummingbirdTests/HandlerTests.swift
+++ b/Tests/HummingbirdTests/HandlerTests.swift
@@ -28,9 +28,9 @@ final class HandlerTests: XCTestCase {
         }
 
         let router = HBRouter(context: HBTestRouterContext.self)
+        router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.post("/hello", use: DecodeTest.self)
-        var app = HBApplication(responder: router.buildResponder())
-        app.decoder = JSONDecoder()
+        let app = HBApplication(responder: router.buildResponder())
 
         try await app.test(.router) { client in
             let body = ByteBufferAllocator().buffer(string: #"{"foo": "bar"}"#)
@@ -58,9 +58,9 @@ final class HandlerTests: XCTestCase {
         }
 
         let router = HBRouter(context: HBTestRouterContext.self)
+        router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.post("/hello", use: DecodeTest.self)
-        var app = HBApplication(responder: router.buildResponder())
-        app.decoder = JSONDecoder()
+        let app = HBApplication(responder: router.buildResponder())
 
         try await app.test(.router) { client in
             let body = ByteBufferAllocator().buffer(string: #"{"value": "bar"}"#)
@@ -88,9 +88,9 @@ final class HandlerTests: XCTestCase {
         }
 
         let router = HBRouter(context: HBTestRouterContext.self)
+        router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.post("/hello", use: DecodeTest.self)
-        var app = HBApplication(responder: router.buildResponder())
-        app.decoder = JSONDecoder()
+        let app = HBApplication(responder: router.buildResponder())
 
         try await app.test(.router) { client in
             let body = ByteBufferAllocator().buffer(string: #"{"name": null}"#)
@@ -123,9 +123,9 @@ final class HandlerTests: XCTestCase {
         }
 
         let router = HBRouter(context: HBTestRouterContext.self)
+        router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.post("/hello", use: DecodeTest.self)
-        var app = HBApplication(responder: router.buildResponder())
-        app.decoder = JSONDecoder()
+        let app = HBApplication(responder: router.buildResponder())
 
         try await app.test(.router) { client in
             let body = ByteBufferAllocator().buffer(string: #"{invalid}"#)
@@ -151,9 +151,9 @@ final class HandlerTests: XCTestCase {
             }
         }
         let router = HBRouter(context: HBTestRouterContext.self)
+        router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.post("/hello", use: DecodeTest.self)
-        var app = HBApplication(responder: router.buildResponder())
-        app.decoder = JSONDecoder()
+        let app = HBApplication(responder: router.buildResponder())
 
         try await app.test(.router) { client in
 
@@ -172,9 +172,9 @@ final class HandlerTests: XCTestCase {
             }
         }
         let router = HBRouter(context: HBTestRouterContext.self)
+        router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.put("/hello", use: DecodeTest.self)
-        var app = HBApplication(responder: router.buildResponder())
-        app.decoder = JSONDecoder()
+        let app = HBApplication(responder: router.buildResponder())
 
         try await app.test(.router) { client in
 
@@ -194,9 +194,9 @@ final class HandlerTests: XCTestCase {
             }
         }
         let router = HBRouter(context: HBTestRouterContext.self)
+        router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.get("/hello", use: DecodeTest.self)
-        var app = HBApplication(responder: router.buildResponder())
-        app.decoder = JSONDecoder()
+        let app = HBApplication(responder: router.buildResponder())
 
         try await app.test(.router) { client in
             try await client.XCTExecute(uri: "/hello", method: .get, body: ByteBufferAllocator().buffer(string: #"{"name2": "Adam"}"#)) { response in


### PR DESCRIPTION
They are stored on the request context. Added middleware to edit them.