### PR TITLE
Fix searchForIndexHtml returns wrong content-type in HBFileMiddleware

### DIFF
--- a/Sources/HummingbirdFoundation/Files/FileMiddleware.swift
+++ b/Sources/HummingbirdFoundation/Files/FileMiddleware.swift
@@ -127,12 +127,8 @@ public struct HBFileMiddleware: HBMiddleware {
                 headers.add(name: "eTag", value: eTag)
 
                 // content-type
-                if let extPointIndex = path.lastIndex(of: ".") {
-                    let extIndex = path.index(after: extPointIndex)
-                    let ext = String(path.suffix(from: extIndex))
-                    if let contentType = HBMediaType.getMediaType(forExtension: ext) {
-                        headers.add(name: "content-type", value: contentType.description)
-                    }
+                if let contentType = HBMediaType.getMediaType(forExtension: fullPath.pathExtension) {
+                    headers.add(name: "content-type", value: contentType.description)
                 }
 
                 headers.replaceOrAdd(name: "accept-ranges", value: "bytes")

--- a/Tests/HummingbirdFoundationTests/FileMiddlewareTests.swift
+++ b/Tests/HummingbirdFoundationTests/FileMiddlewareTests.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+@testable import HummingbirdFoundation
+import HummingbirdXCT
+import XCTest
+
+final class FileMiddlewareTests: XCTestCase {
+    func testSearchForIndexHtml() throws {
+        let tmp = NSTemporaryDirectory() + UUID().uuidString + "/"
+        try FileManager.default.createDirectory(atPath: tmp, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: tmp + "index.html", contents: Data())
+        addTeardownBlock {
+            try? FileManager.default.removeItem(atPath: tmp)
+        }
+
+        let app = HBApplication(testing: .live)
+        app.middleware.add(HBFileMiddleware(
+            tmp,
+            searchForIndexHtml: true,
+            application: app
+        ))
+        try app.XCTStart()
+        defer { app.XCTStop() }
+
+        try app.XCTExecute(uri: "/index.html", method: .GET) { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(response.headers.first(name: "content-type"), "text/html")
+        }
+
+        try app.XCTExecute(uri: "/", method: .GET) { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertEqual(response.headers.first(name: "content-type"), "text/html")
+        }
+
+        try app.XCTExecute(uri: "/\(UUID()).html", method: .GET) { response in
+            XCTAssertEqual(response.status, .notFound)
+        }
+    }
+}


### PR DESCRIPTION
When searchForIndexHtml is true, it may return `index.html`, but in that case, the `content-type` is not properly set.