### PR TITLE
Use MiddlewareProtocol for middleware

### DIFF
--- a/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -15,7 +15,7 @@
 import Logging
 
 /// Middleware outputting to log for every call to server
-public struct HBLogRequestsMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
+public struct HBLogRequestsMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
     let logLevel: Logger.Level
     let includeHeaders: Bool
 
@@ -24,7 +24,7 @@ public struct HBLogRequestsMiddleware<Context: HBBaseRequestContext>: HBMiddlewa
         self.includeHeaders = includeHeaders
     }
 
-    public func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
+    public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
         if self.includeHeaders {
             context.logger.log(
                 level: self.logLevel,
@@ -38,6 +38,6 @@ public struct HBLogRequestsMiddleware<Context: HBBaseRequestContext>: HBMiddlewa
                 metadata: ["hb_uri": .stringConvertible(request.uri), "hb_method": .string(request.method.rawValue)]
             )
         }
-        return try await next.respond(to: request, context: context)
+        return try await next(request, context)
     }
 }

--- a/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -19,14 +19,14 @@ import Metrics
 ///
 /// Records the number of requests, the request duration and how many errors were thrown. Each metric has additional
 /// dimensions URI and method.
-public struct HBMetricsMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
+public struct HBMetricsMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
     public init() {}
 
-    public func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
+    public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
         let startTime = DispatchTime.now().uptimeNanoseconds
 
         do {
-            let response = try await next.respond(to: request, context: context)
+            let response = try await next(request, context)
             // need to create dimensions once request has been responded to ensure
             // we have the correct endpoint path
             let dimensions: [(String, String)] = [

--- a/Sources/Hummingbird/Middleware/Middleware.swift
+++ b/Sources/Hummingbird/Middleware/Middleware.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,41 +14,54 @@
 
 import NIOCore
 
+/// Middleware Handler with generic input, context and output types
+public typealias Middleware<Input, Output, Context> = @Sendable (Input, Context, _ next: (Input, Context) async throws -> Output) async throws -> Output
+
+/// Middleware protocol with generic input, context and output types
+public protocol MiddlewareProtocol<Input, Output, Context>: Sendable {
+    associatedtype Input
+    associatedtype Output
+    associatedtype Context
+
+    func handle(_ input: Input, context: Context, next: (Input, Context) async throws -> Output) async throws -> Output
+}
+
 /// Applied to `HBRequest` before it is dealt with by the router. Middleware passes the processed request onto the next responder
-/// (either the next middleware or the router) by calling `next.apply(to: request)`. If you want to shortcut the request you
+/// (either the next middleware or a route) by calling `next(request, context)`. If you want to shortcut the request you
 /// can return a response immediately
 ///
-/// Middleware is added to the application by calling `app.middleware.add(MyMiddleware()`.
+/// Middleware is added to the application by calling `router.middlewares.add(MyMiddleware()`.
 ///
 /// Middleware allows you to process a request before it reaches your request handler and then process the response
 /// returned by that handler.
 /// ```
-/// func apply(to request: HBRequest, next: HBResponder) async throws -> HBResponse {
+/// func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse
 ///     let request = processRequest(request)
-///     let response = try await next.respond(to: request)
+///     let response = try await next(request, context)
 ///     return processResponse(response)
 /// }
 /// ```
 /// Middleware also allows you to shortcut the whole process and not pass on the request to the handler
 /// ```
-/// func apply(to request: HBRequest, next: HBResponder) async throws -> HBResponse {
+/// func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse
 ///     if request.method == .OPTIONS {
 ///         return HBResponse(status: .noContent)
 ///     } else {
-///         return try await next.respond(to: request)
+///         return try await next(request, context)
 ///     }
 /// }
 /// ```
-public protocol HBMiddleware<Context>: Sendable {
-    associatedtype Context
-    func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse
-}
+
+/// Middleware protocol with HBRequest as input and HBResponse as output
+public protocol HBMiddlewareProtocol<Context>: MiddlewareProtocol where Input == HBRequest, Output == HBResponse {}
 
 struct MiddlewareResponder<Context>: HBResponder {
-    let middleware: any HBMiddleware<Context>
-    let next: any HBResponder<Context>
+    let middleware: any HBMiddlewareProtocol<Context>
+    let next: @Sendable (HBRequest, Context) async throws -> HBResponse
 
     func respond(to request: HBRequest, context: Context) async throws -> HBResponse {
-        return try await self.middleware.apply(to: request, context: context, next: self.next)
+        return try await self.middleware.handle(request, context: context) { request, context in
+            try await self.next(request, context)
+        }
     }
 }

--- a/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,7 +14,7 @@
 
 /// Group of middleware that can be used to create a responder chain. Each middleware calls the next one
 public final class HBMiddlewareGroup<Context> {
-    var middlewares: [any HBMiddleware<Context>]
+    var middlewares: [any HBMiddlewareProtocol<Context>]
 
     /// Initialize `HBMiddlewareGroup`
     ///
@@ -24,12 +24,12 @@ public final class HBMiddlewareGroup<Context> {
         self.middlewares = []
     }
 
-    init(middlewares: [any HBMiddleware<Context>]) {
+    init(middlewares: [any HBMiddlewareProtocol<Context>]) {
         self.middlewares = middlewares
     }
 
     /// Add middleware to group
-    public func add(_ middleware: any HBMiddleware<Context>) {
+    public func add(_ middleware: any HBMiddlewareProtocol<Context>) {
         self.middlewares.append(middleware)
     }
 
@@ -39,7 +39,7 @@ public final class HBMiddlewareGroup<Context> {
     public func constructResponder(finalResponder: any HBResponder<Context>) -> any HBResponder<Context> {
         var currentResponser = finalResponder
         for i in (0..<self.middlewares.count).reversed() {
-            let responder = MiddlewareResponder(middleware: middlewares[i], next: currentResponser)
+            let responder = MiddlewareResponder(middleware: middlewares[i], next: currentResponser.respond(to:context:))
             currentResponser = responder
         }
         return currentResponser

--- a/Sources/Hummingbird/Middleware/SetCodableMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/SetCodableMiddleware.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct HBSetCodableMiddleware<Decoder: HBRequestDecoder, Encoder: HBResponseEncoder, Context: HBBaseRequestContext>: HBMiddleware {
+public struct HBSetCodableMiddleware<Decoder: HBRequestDecoder, Encoder: HBResponseEncoder, Context: HBBaseRequestContext>: HBMiddlewareProtocol {
     let decoder: @Sendable () -> Decoder
     let encoder: @Sendable () -> Encoder
 
@@ -21,10 +21,10 @@ public struct HBSetCodableMiddleware<Decoder: HBRequestDecoder, Encoder: HBRespo
         self.encoder = encoder
     }
 
-    public func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
+    public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
         var context = context
         context.coreContext.requestDecoder = self.decoder()
         context.coreContext.responseEncoder = self.encoder()
-        return try await next.respond(to: request, context: context)
+        return try await next(request, context)
     }
 }

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -42,7 +42,7 @@ public struct HBRouterGroup<Context: HBBaseRequestContext>: HBRouterMethods {
     }
 
     /// Add middleware to RouterEndpoint
-    @discardableResult public func add(middleware: any HBMiddleware<Context>) -> HBRouterGroup<Context> {
+    @discardableResult public func add(middleware: any HBMiddlewareProtocol<Context>) -> HBRouterGroup<Context> {
         self.middlewares.add(middleware)
         return self
     }
@@ -58,11 +58,11 @@ public struct HBRouterGroup<Context: HBBaseRequestContext>: HBRouterMethods {
     }
 
     /// Add path for closure returning type using async/await
-    @discardableResult public func on<Output: HBResponseGenerator>(
+    @discardableResult public func on(
         _ path: String = "",
         method: HTTPRequest.Method,
         options: HBRouterMethodOptions = [],
-        use closure: @Sendable @escaping (HBRequest, Context) async throws -> Output
+        use closure: @Sendable @escaping (HBRequest, Context) async throws -> some HBResponseGenerator
     ) -> Self {
         let responder = constructResponder(options: options, use: closure)
         let path = self.combinePaths(self.path, path)

--- a/Sources/Hummingbird/Server/Responder.swift
+++ b/Sources/Hummingbird/Server/Responder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -21,7 +21,7 @@ import ServiceContextModule
 public protocol HBResponder<Context>: Sendable {
     associatedtype Context
     /// Return EventLoopFuture that will be fulfilled with response to the request supplied
-    func respond(to request: HBRequest, context: Context) async throws -> HBResponse
+    @Sendable func respond(to request: HBRequest, context: Context) async throws -> HBResponse
 }
 
 /// Responder that calls supplied closure

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -268,11 +268,11 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testCollateBody() async throws {
-        struct CollateMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
-            func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
+        struct CollateMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
+    public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
                 var request = request
                 request.body = try await request.body.collate(maxSize: context.applicationContext.configuration.maxUploadSize)
-                return try await next.respond(to: request, context: context)
+                return try await next(request, context)
             }
         }
         let router = HBRouter(context: HBTestRouterContext.self)

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -354,13 +354,13 @@ final class TracingTests: XCTestCase {
         let expectation = expectation(description: "Expected span to be ended.")
         expectation.expectedFulfillmentCount = 2
 
-        struct SpanMiddleware<Context: HBBaseRequestContext>: HBMiddleware {
-            public func apply(to request: HBRequest, context: Context, next: any HBResponder<Context>) async throws -> HBResponse {
+        struct SpanMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
+            public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
                 var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
                 serviceContext.testID = "testMiddleware"
 
                 return try await InstrumentationSystem.tracer.withSpan("TestSpan", context: serviceContext, ofKind: .server) { _ in
-                    try await next.respond(to: request, context: context)
+                    try await next(request, context)
                 }
             }
         }


### PR DESCRIPTION
This is a stepping stone to including a separate result builder router. We need the middleware format to be the same between the default router and the result builder version.

I have gone with the format used by the result builder