### PR TITLE
Fix small code mistake in Encoding and Decoding.md

### DIFF
--- a/documentation/Encoding and Decoding.md
+++ b/documentation/Encoding and Decoding.md
@@ -79,7 +79,7 @@ Because the full request is supplied to the `HBRequestDecoder`. You can make dec
 struct MyRequestDecoder: HBRequestDecoder {
     func decode<T>(_ type: T.Type, from request: HBRequest) throws -> T where T : Decodable {
         switch request.headers["content-type"].first {
-        case "json/application", "application/json; charset=utf-8":
+        case "application/json", "application/json; charset=utf-8":
             return try JSONDecoder().decode(type, from: request)
         case "application/x-www-form-urlencoded":
             return try URLEncodedFormDecoder().decode(type, from: request)

--- a/documentation/Encoding and Decoding.md
+++ b/documentation/Encoding and Decoding.md
@@ -78,10 +78,12 @@ Because the full request is supplied to the `HBRequestDecoder`. You can make dec
 ```swift
 struct MyRequestDecoder: HBRequestDecoder {
     func decode<T>(_ type: T.Type, from request: HBRequest) throws -> T where T : Decodable {
-        switch request.headers["content-type"].first {
-        case "application/json", "application/json; charset=utf-8":
+        guard let header = request.headers["content-type"].first else { throw HBHTTPError(.badRequest) }
+        guard let mediaType = HBMediaType(from: header) else { throw HBHTTPError(.badRequest) }
+        switch mediaType {
+        case .applicationJson:
             return try JSONDecoder().decode(type, from: request)
-        case "application/x-www-form-urlencoded":
+        case .applicationUrlEncoded:
             return try URLEncodedFormDecoder().decode(type, from: request)
         default:
             throw HBHTTPError(.badRequest)


### PR DESCRIPTION
Sorry this is small change, but I found small mistake of content-type in document.

And on the other hand, I think this guide should be refined with `HBMediaType`.