### PR TITLE
Remove Application Context

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -42,17 +42,6 @@ public enum EventLoopGroupProvider {
     }
 }
 
-public final class HBApplicationContext: Sendable {
-    /// Configuration
-    public let configuration: HBApplicationConfiguration
-
-    public init(
-        configuration: HBApplicationConfiguration
-    ) {
-        self.configuration = configuration
-    }
-}
-
 public protocol HBApplicationProtocol: Service where Context: HBRequestContext {
     /// Responder that generates a response from a requests and context
     associatedtype Responder: HBResponder
@@ -107,11 +96,7 @@ extension HBApplicationProtocol {
 
         // Function responding to HTTP request
         @Sendable func respond(to request: HBRequest, channel: Channel) async throws -> HBResponse {
-            let applicationContext = HBApplicationContext(
-                configuration: self.configuration
-            )
             let context = Self.Responder.Context(
-                applicationContext: applicationContext,
                 channel: channel,
                 logger: loggerWithRequestId(self.logger)
             )

--- a/Sources/Hummingbird/Configuration.swift
+++ b/Sources/Hummingbird/Configuration.swift
@@ -29,9 +29,6 @@ public struct HBApplicationConfiguration: Sendable {
     public let address: HBBindAddress
     /// Server name to return in "server" header
     public let serverName: String?
-    /// Maximum upload size allowed for routes that don't stream the request payload. This
-    /// limits how much memory would be used for one request
-    public let maxUploadSize: Int
     /// Defines the maximum length for the queue of pending connections
     public let backlog: Int
     /// Allows socket to be bound to an address that is already in use.
@@ -53,7 +50,6 @@ public struct HBApplicationConfiguration: Sendable {
     /// - Parameters:
     ///   - address: Bind address for server
     ///   - serverName: Server name to return in "server" header
-    ///   - maxUploadSize: Maximum upload size allowed for routes that don't stream the request payload
     ///   - backlog: the maximum length for the queue of pending connections.  If a connection request arrives with the queue full,
     ///         the client may receive an error with an indication of ECONNREFUSE
     ///   - reuseAddress: Allows socket to be bound to an address that is already in use.
@@ -62,7 +58,6 @@ public struct HBApplicationConfiguration: Sendable {
     public init(
         address: HBBindAddress = .hostname(),
         serverName: String? = nil,
-        maxUploadSize: Int = 1 * 1024 * 1024,
         backlog: Int = 256,
         reuseAddress: Bool = true,
         threadPoolSize: Int = 2,
@@ -73,7 +68,6 @@ public struct HBApplicationConfiguration: Sendable {
 
         self.address = address
         self.serverName = serverName
-        self.maxUploadSize = maxUploadSize
         self.backlog = backlog
         self.reuseAddress = reuseAddress
         #if canImport(Network)
@@ -97,7 +91,6 @@ public struct HBApplicationConfiguration: Sendable {
     /// - Parameters:
     ///   - address: Bind address for server
     ///   - serverName: Server name to return in "server" header
-    ///   - maxUploadSize: Maximum upload size allowed for routes that don't stream the request payload
     ///   - reuseAddress: Allows socket to be bound to an address that is already in use.
     ///   - logLevel: Logging level
     ///   - noHTTPServer: Don't start up the HTTP server.
@@ -105,7 +98,6 @@ public struct HBApplicationConfiguration: Sendable {
     public init(
         address: HBBindAddress = .hostname(),
         serverName: String? = nil,
-        maxUploadSize: Int = 1 * 1024 * 1024,
         reuseAddress: Bool = true,
         logLevel: Logger.Level? = nil,
         noHTTPServer: Bool = false,
@@ -115,7 +107,6 @@ public struct HBApplicationConfiguration: Sendable {
 
         self.address = address
         self.serverName = serverName
-        self.maxUploadSize = maxUploadSize
         self.backlog = 256 // not used by Network framework
         self.reuseAddress = reuseAddress
         self.tlsOptions = tlsOptions
@@ -137,7 +128,6 @@ public struct HBApplicationConfiguration: Sendable {
     public func with(
         address: HBBindAddress? = nil,
         serverName: String? = nil,
-        maxUploadSize: Int? = nil,
         backlog: Int? = nil,
         reuseAddress: Bool? = nil,
         logLevel: Logger.Level? = nil
@@ -145,7 +135,6 @@ public struct HBApplicationConfiguration: Sendable {
         return .init(
             address: address ?? self.address,
             serverName: serverName ?? self.serverName,
-            maxUploadSize: maxUploadSize ?? self.maxUploadSize,
             backlog: backlog ?? self.backlog,
             reuseAddress: reuseAddress ?? self.reuseAddress,
             logLevel: logLevel ?? self.logLevel

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -25,18 +25,17 @@ import Tracing
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct HBTracingMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
     private let headerNamesToRecord: Set<RecordingHeader>
+    private let attributes: SpanAttributes?
 
     /// Intialize a new HBTracingMiddleware.
     ///
-    /// - Parameter recordingHeaders: A list of HTTP header names to be recorded as span attributes. By default, no headers
+    /// - Parameters
+    ///     - recordingHeaders: A list of HTTP header names to be recorded as span attributes. By default, no headers
+    ///     - parameters: A list of static parameters added to every span. These could be
     /// are being recorded.
-    public init(recordingHeaders headerNamesToRecord: some Collection<HTTPField.Name>) {
+    public init(recordingHeaders headerNamesToRecord: some Collection<HTTPField.Name> = [], attributes: SpanAttributes? = nil) {
         self.headerNamesToRecord = Set(headerNamesToRecord.map(RecordingHeader.init))
-    }
-
-    /// Intialize a new HBTracingMiddleware.
-    public init() {
-        self.init(recordingHeaders: [])
+        self.attributes = attributes
     }
 
     public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
@@ -52,6 +51,9 @@ public struct HBTracingMiddleware<Context: HBBaseRequestContext>: HBMiddlewarePr
 
         return try await InstrumentationSystem.tracer.withSpan(operationName, context: serviceContext, ofKind: .server) { span in
             span.updateAttributes { attributes in
+                if let staticAttributes = self.attributes {
+                    attributes.merge(staticAttributes)
+                }
                 attributes["http.method"] = request.method.rawValue
                 attributes["http.target"] = request.uri.path
                 // TODO: Get HTTP version and scheme
@@ -59,9 +61,6 @@ public struct HBTracingMiddleware<Context: HBBaseRequestContext>: HBMiddlewarePr
                 // attributes["http.scheme"] = request.uri.scheme?.rawValue
                 attributes["http.user_agent"] = request.headers[.userAgent]
                 attributes["http.request_content_length"] = request.headers[.contentLength].map { Int($0) } ?? nil
-
-                attributes["net.host.name"] = context.applicationContext.configuration.address.host
-                attributes["net.host.port"] = context.applicationContext.configuration.address.port
 
                 if let remoteAddress = (context as? HBRemoteAddressRequestContext)?.remoteAddress {
                     attributes["net.sock.peer.port"] = remoteAddress.port

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -31,8 +31,9 @@ public struct HBTracingMiddleware<Context: HBBaseRequestContext>: HBMiddlewarePr
     ///
     /// - Parameters
     ///     - recordingHeaders: A list of HTTP header names to be recorded as span attributes. By default, no headers
-    ///     - parameters: A list of static parameters added to every span. These could be
-    /// are being recorded.
+    ///         are being recorded.
+    ///     - parameters: A list of static parameters added to every span. These could be the "net.host.name", 
+    ///         "net.host.port" or "http.scheme"
     public init(recordingHeaders headerNamesToRecord: some Collection<HTTPField.Name> = [], attributes: SpanAttributes? = nil) {
         self.headerNamesToRecord = Set(headerNamesToRecord.map(RecordingHeader.init))
         self.attributes = attributes

--- a/Sources/HummingbirdFoundation/Codable/JSON/JSONCoding.swift
+++ b/Sources/HummingbirdFoundation/Codable/JSON/JSONCoding.swift
@@ -41,7 +41,7 @@ extension JSONDecoder: HBRequestDecoder {
     ///   - type: Type to decode
     ///   - request: Request to decode from
     public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) async throws -> T {
-        let buffer = try await request.body.collect(upTo: context.applicationContext.configuration.maxUploadSize)
+        let buffer = try await request.body.collect(upTo: context.maxUploadSize)
         return try self.decode(T.self, from: buffer)
     }
 }

--- a/Sources/HummingbirdFoundation/Codable/URLEncodedForm/URLEncodedForm+Request.swift
+++ b/Sources/HummingbirdFoundation/Codable/URLEncodedForm/URLEncodedForm+Request.swift
@@ -37,7 +37,7 @@ extension URLEncodedFormDecoder: HBRequestDecoder {
     ///   - type: Type to decode
     ///   - request: Request to decode from
     public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) async throws -> T {
-        let buffer = try await request.body.collect(upTo: context.applicationContext.configuration.maxUploadSize)
+        let buffer = try await request.body.collect(upTo: context.maxUploadSize)
         let string = String(buffer: buffer)
         return try self.decode(T.self, from: string)
     }

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -21,9 +21,8 @@ import NIOPosix
 struct PerformanceTestRequestContext: HBRequestContext {
     var coreContext: HBCoreRequestContext
 
-    init(applicationContext: HBApplicationContext, channel: Channel, logger: Logger) {
+    init(channel: Channel, logger: Logger) {
         self.coreContext = .init(
-            applicationContext: applicationContext,
             requestDecoder: JSONDecoder(),
             responseEncoder: JSONEncoder(),
             eventLoop: channel.eventLoop,

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -272,7 +272,7 @@ final class ApplicationTests: XCTestCase {
             public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
                 var request = request
                 request.body = try await request.body.collate(maxSize: context.maxUploadSize)
-                return try await next.respond(to: request, context: context)
+                return try await next(request, context)
             }
         }
         let router = HBRouter(context: HBTestRouterContext.self)

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -372,12 +372,11 @@ final class RouterTests: XCTestCase {
 
 public struct HBTestRouterContext2: HBTestRequestContextProtocol {
     public init(
-        applicationContext: HBApplicationContext,
         eventLoop: EventLoop,
         allocator: ByteBufferAllocator,
         logger: Logger
     ) {
-        self.coreContext = .init(applicationContext: applicationContext, eventLoop: eventLoop, allocator: allocator, logger: logger)
+        self.coreContext = .init(eventLoop: eventLoop, allocator: allocator, logger: logger)
         self.string = ""
     }
 

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -36,7 +36,7 @@ final class TracingTests: XCTestCase {
         InstrumentationSystem.bootstrapInternal(tracer)
 
         let router = HBRouter(context: HBTestRouterContext.self)
-        router.middlewares.add(HBTracingMiddleware())
+        router.middlewares.add(HBTracingMiddleware(attributes: ["net.host.name": "127.0.0.1", "net.host.port": 8080]))
         router.get("users/:id") { _, _ -> String in
             return "42"
         }
@@ -104,8 +104,6 @@ final class TracingTests: XCTestCase {
             "http.target": "/users",
             "http.status_code": 500,
             "http.request_content_length": 2,
-            "net.host.name": "127.0.0.1",
-            "net.host.port": 8080,
         ])
     }
 
@@ -156,8 +154,6 @@ final class TracingTests: XCTestCase {
             "http.target": "/users/42",
             "http.status_code": 200,
             "http.response_content_length": 2,
-            "net.host.name": "127.0.0.1",
-            "net.host.port": 8080,
             "http.request.header.accept": .stringArray(["text/plain", "application/json"]),
             "http.request.header.cache_control": "no-cache",
             "http.response.header.content_type": "text/plain",
@@ -198,8 +194,6 @@ final class TracingTests: XCTestCase {
             "http.target": "/users",
             "http.status_code": 204,
             "http.response_content_length": 0,
-            "net.host.name": "127.0.0.1",
-            "net.host.port": 8080,
         ])
     }
 
@@ -236,8 +230,6 @@ final class TracingTests: XCTestCase {
             "http.target": "/",
             "http.status_code": 200,
             "http.response_content_length": 0,
-            "net.host.name": "127.0.0.1",
-            "net.host.port": 8080,
         ])
     }
 
@@ -272,8 +264,6 @@ final class TracingTests: XCTestCase {
             "http.method": "GET",
             "http.target": "/",
             "http.status_code": 404,
-            "net.host.name": "127.0.0.1",
-            "net.host.port": 8080,
         ])
     }
 


### PR DESCRIPTION
Remove application context from request context
- maxUploadSize is now a requirement for the HBBaseRequestContext with a default of 2MB. If someone want to override this value they have to provide their own context type
- Added a method for adding static span attributes to tracing middleware so users can add the missing host name and port if they require