### PR TITLE
Channel setup builder

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -67,9 +67,9 @@ public protocol HBApplicationProtocol: Service where Context: HBRequestContext {
     var services: [any Service] { get }
 }
 
-extension HBApplicationProtocol where ChannelSetup == HTTP1Channel {
+extension HBApplicationProtocol {
     /// Server channel setup
-    public var channelSetup: HBHTTPChannelSetupBuilder<ChannelSetup> { .http1() }
+    public var channelSetup: HBHTTPChannelSetupBuilder<HTTP1Channel> { .http1() }
 }
 
 extension HBApplicationProtocol {

--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -22,8 +22,8 @@ public struct HTTP1Channel: HBChannelSetup, HTTPChannelHandler {
     public typealias Value = NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>
 
     public init(
-        additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = [],
-        responder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse = { _, _ in throw HBHTTPError(.notImplemented) }
+        responder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse = { _, _ in throw HBHTTPError(.notImplemented) },
+        additionalChannelHandlers: @escaping @Sendable () -> [any RemovableChannelHandler] = { [] }
     ) {
         self.additionalChannelHandlers = additionalChannelHandlers
         self.responder = responder

--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -22,7 +22,7 @@ public struct HTTP1Channel: HBChannelSetup, HTTPChannelHandler {
     public typealias Value = NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>
 
     public init(
-        responder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse = { _, _ in throw HBHTTPError(.notImplemented) },
+        responder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse,
         additionalChannelHandlers: @escaping @Sendable () -> [any RemovableChannelHandler] = { [] }
     ) {
         self.additionalChannelHandlers = additionalChannelHandlers
@@ -51,6 +51,6 @@ public struct HTTP1Channel: HBChannelSetup, HTTPChannelHandler {
         await handleHTTP(asyncChannel: asyncChannel, logger: logger)
     }
 
-    public var responder: @Sendable (HBRequest, Channel) async throws -> HBResponse
+    public let responder: @Sendable (HBRequest, Channel) async throws -> HBResponse
     let additionalChannelHandlers: @Sendable () -> [any RemovableChannelHandler]
 }

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -22,7 +22,7 @@ import ServiceLifecycle
 /// Protocol for HTTP channels
 public protocol HTTPChannelHandler: HBChannelSetup {
     typealias Responder = @Sendable (HBRequest, Channel) async throws -> HBResponse
-    var responder: Responder { get set }
+    var responder: Responder { get }
 }
 
 /// Internal error thrown when an unexpected HTTP part is received eg we didn't receive

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -21,7 +21,8 @@ import ServiceLifecycle
 
 /// Protocol for HTTP channels
 public protocol HTTPChannelHandler: HBChannelSetup {
-    var responder: @Sendable (HBRequest, Channel) async throws -> HBResponse { get set }
+    typealias Responder = @Sendable (HBRequest, Channel) async throws -> HBResponse
+    var responder: Responder { get set }
 }
 
 /// Internal error thrown when an unexpected HTTP part is received eg we didn't receive

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelSetupBuilder.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelSetupBuilder.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+/// Build Channel Setup that takes an HTTP responder
+public struct HBHTTPChannelSetupBuilder<ChannelSetup: HBChannelSetup>: Sendable {
+    public let build: @Sendable (@escaping HTTPChannelHandler.Responder) throws -> ChannelSetup
+    public init(_ build: @escaping @Sendable (@escaping HTTPChannelHandler.Responder) throws -> ChannelSetup) {
+        self.build = build
+    }
+}
+
+extension HBHTTPChannelSetupBuilder {
+    public static func http1(
+        additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
+    ) -> HBHTTPChannelSetupBuilder<HTTP1Channel> {
+        return .init { responder in
+            return HTTP1Channel(responder: responder, additionalChannelHandlers: additionalChannelHandlers)
+        }
+    }
+}

--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -36,14 +36,14 @@ public struct HTTP2Channel: HTTPChannelHandler {
 
     public init(
         tlsConfiguration: TLSConfiguration,
-        additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = [],
+        additionalChannelHandlers: @escaping @Sendable () -> [any RemovableChannelHandler] = { [] },
         responder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse = { _, _ in throw HBHTTPError(.notImplemented) }
     ) throws {
         var tlsConfiguration = tlsConfiguration
         tlsConfiguration.applicationProtocols = NIOHTTP2SupportedALPNProtocols
         self.sslContext = try NIOSSLContext(configuration: tlsConfiguration)
         self.additionalChannelHandlers = additionalChannelHandlers
-        self.http1 = HTTP1Channel(additionalChannelHandlers: additionalChannelHandlers(), responder: responder)
+        self.http1 = HTTP1Channel(responder: responder, additionalChannelHandlers: additionalChannelHandlers)
     }
 
     public func initialize(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value> {

--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -27,12 +27,9 @@ public struct HTTP2Channel: HTTPChannelHandler {
     public typealias Value = EventLoopFuture<NIONegotiatedHTTPVersion<HTTP1Channel.Value, (NIOAsyncChannel<HTTP2Frame, HTTP2Frame>, NIOHTTP2Handler.AsyncStreamMultiplexer<HTTP1Channel.Value>)>>
 
     private let sslContext: NIOSSLContext
-    private var http1: HTTP1Channel
+    private let http1: HTTP1Channel
     private let additionalChannelHandlers: @Sendable () -> [any RemovableChannelHandler]
-    public var responder: @Sendable (HBRequest, Channel) async throws -> HBResponse {
-        get { http1.responder }
-        set { http1.responder = newValue }
-    }
+    public var responder: @Sendable (HBRequest, Channel) async throws -> HBResponse { http1.responder }
 
     public init(
         tlsConfiguration: TLSConfiguration,

--- a/Sources/HummingbirdHTTP2/HTTP2ChannelSetupBuilder.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2ChannelSetupBuilder.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HummingbirdCore
+import NIOCore
+import NIOSSL
+
+extension HBHTTPChannelSetupBuilder {
+    public static func http2(
+        tlsConfiguration: TLSConfiguration,
+        additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
+    ) throws -> HBHTTPChannelSetupBuilder<HTTP2Channel> {
+        return .init { responder in
+            return try HTTP2Channel(
+                tlsConfiguration: tlsConfiguration,
+                additionalChannelHandlers: additionalChannelHandlers,
+                responder: responder
+            )
+        }
+    }
+}

--- a/Sources/HummingbirdTLS/TLSChannelSetup.swift
+++ b/Sources/HummingbirdTLS/TLSChannelSetup.swift
@@ -32,7 +32,6 @@ public struct TLSChannel<BaseChannel: HBChannelSetup>: HBChannelSetup {
 
 extension TLSChannel: HTTPChannelHandler where BaseChannel: HTTPChannelHandler {
     public var responder: @Sendable (HBRequest, Channel) async throws -> HBResponse {
-        get { baseChannel.responder }
-        set { baseChannel.responder = newValue }
+        baseChannel.responder
     }
 }

--- a/Sources/HummingbirdTLS/TLSChannelSetupBuilder.swift
+++ b/Sources/HummingbirdTLS/TLSChannelSetupBuilder.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HummingbirdCore
+import NIOSSL
+
+extension HBHTTPChannelSetupBuilder {
+    public static func tls<BaseChannel: HBChannelSetup>(
+        _ base: HBHTTPChannelSetupBuilder<BaseChannel>,
+        tlsConfiguration: TLSConfiguration
+    ) throws -> HBHTTPChannelSetupBuilder<TLSChannel<BaseChannel>> {
+        return .init { responder in
+            return try TLSChannel(base.build(responder), tlsConfiguration: tlsConfiguration)
+        }
+    }
+}

--- a/Sources/HummingbirdTLS/TLSChannelSetupBuilder.swift
+++ b/Sources/HummingbirdTLS/TLSChannelSetupBuilder.swift
@@ -17,7 +17,7 @@ import NIOSSL
 
 extension HBHTTPChannelSetupBuilder {
     public static func tls<BaseChannel: HBChannelSetup>(
-        _ base: HBHTTPChannelSetupBuilder<BaseChannel>,
+        _ base: HBHTTPChannelSetupBuilder<BaseChannel> = .http1(),
         tlsConfiguration: TLSConfiguration
     ) throws -> HBHTTPChannelSetupBuilder<TLSChannel<BaseChannel>> {
         return .init { responder in

--- a/Sources/HummingbirdXCT/HBXCTLive.swift
+++ b/Sources/HummingbirdXCT/HBXCTLive.swift
@@ -32,12 +32,12 @@ final class HBXCTLive<App: HBApplicationProtocol>: HBXCTApplication {
 
         let base: BaseApp
 
-        func buildResponder() async throws -> Responder {
-            try await self.base.buildResponder()
+        var responder: Responder {
+            get async throws { try await self.base.responder }
         }
 
-        func channelSetup(httpResponder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse) throws -> ChannelSetup {
-            try self.base.channelSetup(httpResponder: httpResponder)
+        var channelSetup: HBHTTPChannelSetupBuilder<ChannelSetup> {
+            self.base.channelSetup
         }
 
         /// event loop group used by application

--- a/Sources/HummingbirdXCT/HBXCTRouter.swift
+++ b/Sources/HummingbirdXCT/HBXCTRouter.swift
@@ -68,7 +68,7 @@ struct HBXCTRouter<Responder: HBResponder>: HBXCTApplication where Responder.Con
 
     init<App: HBApplicationProtocol>(app: App) async throws where App.Responder == Responder {
         self.eventLoopGroup = app.eventLoopGroup
-        self.responder = try await app.buildResponder()
+        self.responder = try await app.responder
         self.logger = app.logger
     }
 

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -49,7 +49,8 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testConnect() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel(responder: helloResponder),
+            responder: helloResponder,
+            httpChannelSetup: .http1(),
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: Self.eventLoopGroup,
             logger: Logger(label: "HB")
@@ -62,7 +63,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testMultipleRequests() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel(responder: helloResponder),
+            responder: helloResponder,
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: Self.eventLoopGroup,
             logger: Logger(label: "HB")
@@ -77,7 +78,8 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testError() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel { _, _ in throw HBHTTPError(.unauthorized) },
+            responder: { _, _ in throw HBHTTPError(.unauthorized) },
+            httpChannelSetup: .http1(),
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: Self.eventLoopGroup,
             logger: Logger(label: "HB")
@@ -90,7 +92,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testConsumeBody() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel { request, _ in
+            responder: { request, _ in
                 let buffer = try await request.body.collect(upTo: .max)
                 return HBResponse(status: .ok, body: .init(byteBuffer: buffer))
             },
@@ -107,7 +109,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testWriteBody() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel { _, _ in
+            responder: { _, _ in
                 let buffer = self.randomBuffer(size: 1_140_000)
                 return HBResponse(status: .ok, body: .init(byteBuffer: buffer))
             },
@@ -123,7 +125,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testStreamBody() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel { request, _ in
+            responder: { request, _ in
                 return HBResponse(status: .ok, body: .init(asyncSequence: request.body))
             },
             configuration: .init(address: .hostname(port: 0)),
@@ -139,7 +141,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testStreamBodyWriteSlow() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel { request, _ in
+            responder: { request, _ in
                 return HBResponse(status: .ok, body: .init(asyncSequence: request.body.delayed()))
             },
             configuration: .init(address: .hostname(port: 0)),
@@ -167,11 +169,10 @@ class HummingBirdCoreTests: XCTestCase {
             }
         }
         try await testServer(
-            childChannelSetup: HTTP1Channel { request, _ in
+            responder: { request, _ in
                 return HBResponse(status: .ok, body: .init(asyncSequence: request.body.delayed()))
-            } additionalChannelHandlers: {
-                [SlowInputChannelHandler()]
             },
+            httpChannelSetup: .http1(additionalChannelHandlers: [SlowInputChannelHandler()]),
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: Self.eventLoopGroup,
             logger: Logger(label: "HB")
@@ -196,12 +197,11 @@ class HummingBirdCoreTests: XCTestCase {
             }
         }
         try await testServer(
-            childChannelSetup: HTTP1Channel { request, _ in
+            responder: { request, _ in
                 _ = try await request.body.collect(upTo: .max)
                 return HBResponse(status: .ok)
-            } additionalChannelHandlers: {
-                [CreateErrorHandler()]
             },
+            httpChannelSetup: .http1(additionalChannelHandlers: [CreateErrorHandler()]),
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: Self.eventLoopGroup,
             logger: Logger(label: "HB")
@@ -214,7 +214,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testDropRequestBody() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel { _, _ in
+            responder: { _, _ in
                 // ignore request body
                 return HBResponse(status: .accepted)
             },
@@ -233,7 +233,7 @@ class HummingBirdCoreTests: XCTestCase {
     /// test server closes connection if "connection" header is set to "close"
     func testConnectionClose() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel(responder: helloResponder),
+            responder: helloResponder,
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: Self.eventLoopGroup,
             logger: Logger(label: "HB")
@@ -263,12 +263,11 @@ class HummingBirdCoreTests: XCTestCase {
             }
         }
         try await testServer(
-            childChannelSetup: HTTP1Channel { request, _ in
+            responder: { request, _ in
                 _ = try await request.body.collect(upTo: .max)
                 return .init(status: .ok)
-            } additionalChannelHandlers: {
-                [HTTPServerIncompleteRequest(), IdleStateHandler(readTimeout: .seconds(1))]
             },
+            httpChannelSetup: .http1(additionalChannelHandlers: [HTTPServerIncompleteRequest(), IdleStateHandler(readTimeout: .seconds(1))]),
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: Self.eventLoopGroup,
             logger: Logger(label: "HB")
@@ -287,12 +286,11 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testWriteIdleTimeout() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel { request, _ in
+            responder: { request, _ in
                 _ = try await request.body.collect(upTo: .max)
                 return .init(status: .ok)
-            } additionalChannelHandlers: {
-                [IdleStateHandler(writeTimeout: .seconds(1))]
             },
+            httpChannelSetup: .http1(additionalChannelHandlers: [IdleStateHandler(writeTimeout: .seconds(1))]),
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: Self.eventLoopGroup,
             logger: Logger(label: "HB")
@@ -309,11 +307,12 @@ class HummingBirdCoreTests: XCTestCase {
         let promise = Promise<Void>()
 
         try await testServer(
-            childChannelSetup: HTTP1Channel { request, _ in
+            responder: { request, _ in
                 await promise.complete(())
                 try await Task.sleep(for: .milliseconds(500))
                 return HBResponse(status: .ok, body: .init(asyncSequence: request.body.delayed()))
             },
+            httpChannelSetup: .http1(),
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: Self.eventLoopGroup,
             logger: Logger(label: "HB")
@@ -338,10 +337,11 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testIdleChildChannelGracefulShutdown() async throws {
         try await testServer(
-            childChannelSetup: HTTP1Channel { request, _ in
+            responder: { request, _ in
                 try await Task.sleep(for: .milliseconds(500))
                 return HBResponse(status: .ok, body: .init(asyncSequence: request.body.delayed()))
             },
+            httpChannelSetup: .http1(),
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: Self.eventLoopGroup,
             logger: Logger(label: "HB")

--- a/Tests/HummingbirdCoreTests/HTTP2Tests.swift
+++ b/Tests/HummingbirdCoreTests/HTTP2Tests.swift
@@ -29,9 +29,10 @@ class HummingBirdHTTP2Tests: XCTestCase {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         try await testServer(
-            childChannelSetup: HTTP2Channel(tlsConfiguration: self.getServerTLSConfiguration()) { _, _ in
+            responder: { _, _ in
                 .init(status: .ok)
             },
+            httpChannelSetup: .http2(tlsConfiguration: self.getServerTLSConfiguration()),
             configuration: .init(address: .hostname(port: 0), serverName: testServerName),
             eventLoopGroup: eventLoopGroup,
             logger: Logger(label: "HB")

--- a/Tests/HummingbirdCoreTests/TLSTests.swift
+++ b/Tests/HummingbirdCoreTests/TLSTests.swift
@@ -27,7 +27,8 @@ class HummingBirdTLSTests: XCTestCase {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         try await testServer(
-            childChannelSetup: TLSChannel(HTTP1Channel(responder: helloResponder), tlsConfiguration: self.getServerTLSConfiguration()),
+            responder: helloResponder,
+            httpChannelSetup: .tls(tlsConfiguration: self.getServerTLSConfiguration()),
             configuration: .init(address: .hostname(port: 0), serverName: testServerName),
             eventLoopGroup: eventLoopGroup,
             logger: Logger(label: "HB"),

--- a/Tests/HummingbirdCoreTests/TSTests.swift
+++ b/Tests/HummingbirdCoreTests/TSTests.swift
@@ -34,7 +34,7 @@ class TransportServicesTests: XCTestCase {
         let eventLoopGroup = NIOTSEventLoopGroup()
         defer { try? eventLoopGroup.syncShutdownGracefully() }
         try await testServer(
-            childChannelSetup: HTTP1Channel(responder: helloResponder),
+            responder: helloResponder,
             configuration: .init(address: .hostname(port: 0)),
             eventLoopGroup: eventLoopGroup,
             logger: Logger(label: "HB")
@@ -52,7 +52,7 @@ class TransportServicesTests: XCTestCase {
             serverIdentity: .p12(filename: p12Path, password: "MyPassword")
         ))
         try await testServer(
-            childChannelSetup: HTTP1Channel(responder: helloResponder),
+            responder: helloResponder,
             configuration: .init(address: .hostname(port: 0), serverName: testServerName, tlsOptions: tlsOptions),
             eventLoopGroup: eventLoopGroup,
             logger: Logger(label: "HB"),

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -482,7 +482,7 @@ final class ApplicationTests: XCTestCase {
             typealias Context = HBTestRouterContext
             typealias ChannelSetup = HTTP1Channel
 
-            func buildResponder() async throws -> some HBResponder<Context> {
+            var responder: some HBResponder<Context> {
                 let router = HBRouter(context: Context.self)
                 router.get("/hello") { _, context -> ByteBuffer in
                     return context.allocator.buffer(string: "GET: Hello")

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -480,7 +480,6 @@ final class ApplicationTests: XCTestCase {
     func testApplicationProtocol() async throws {
         struct MyApp: HBApplicationProtocol {
             typealias Context = HBTestRouterContext
-            typealias ChannelSetup = HTTP1Channel
 
             var responder: some HBResponder<Context> {
                 let router = HBRouter(context: Context.self)


### PR DESCRIPTION
Setup type for building HBChannelSetup. Cleans up API

```swift
let app = HBApplication(
    responder: router,
    channelSetup: .http1(),
    ...
)
```