### PR TITLE
2.x.x - Renaming HBChannelSetup and HBHTTPChannelSetupBuilder

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -188,7 +188,7 @@ public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel
     /// Initialize new Application
     public init(
         responder: Responder,
-        channelSetup: HBHTTPChannelBuilder<ChildChannel> = .http1(),
+        server: HBHTTPChannelBuilder<ChildChannel> = .http1(),
         configuration: HBApplicationConfiguration = HBApplicationConfiguration(),
         eventLoopGroupProvider: EventLoopGroupProvider = .singleton
     ) {

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -53,7 +53,7 @@ public protocol HBApplicationProtocol: Service where Context: HBRequestContext {
     /// Build the responder
     var responder: Responder { get async throws }
     /// Server channel setup
-    var channelSetup: HBHTTPChannelBuilder<ChildChannel> { get }
+    var server: HBHTTPChannelBuilder<ChildChannel> { get }
 
     /// event loop group used by application
     var eventLoopGroup: EventLoopGroup { get }
@@ -69,7 +69,7 @@ public protocol HBApplicationProtocol: Service where Context: HBRequestContext {
 
 extension HBApplicationProtocol {
     /// Server channel setup
-    public var channelSetup: HBHTTPChannelBuilder<HTTP1Channel> { .http1() }
+    public var server: HBHTTPChannelBuilder<HTTP1Channel> { .http1() }
 }
 
 extension HBApplicationProtocol {
@@ -108,7 +108,7 @@ extension HBApplicationProtocol {
             return response
         }
         // get channel Setup
-        let channelSetup = try self.channelSetup.build(respond)
+        let channelSetup = try self.server.build(respond)
         // create server
         let server = HBServer(
             childChannelSetup: channelSetup,
@@ -179,7 +179,7 @@ public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel
     /// on server running
     private var _onServerRunning: @Sendable (Channel) async -> Void
     /// Server channel setup
-    public let channelSetup: HBHTTPChannelBuilder<ChildChannel>
+    public let server: HBHTTPChannelBuilder<ChildChannel>
     /// services attached to the application.
     public var services: [any Service]
 
@@ -197,7 +197,7 @@ public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel
         self.logger = logger
 
         self.responder = responder
-        self.channelSetup = channelSetup
+        self.server = server
         self.configuration = configuration
         self._onServerRunning = { _ in }
 

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -46,14 +46,14 @@ public protocol HBApplicationProtocol: Service where Context: HBRequestContext {
     /// Responder that generates a response from a requests and context
     associatedtype Responder: HBResponder
     /// Child Channel setup. This defaults to support HTTP1
-    associatedtype ChannelSetup: HBChannelSetup & HTTPChannelHandler = HTTP1Channel
+    associatedtype ChildChannel: HBChildChannel & HTTPChannelHandler = HTTP1Channel
     /// Context passed with HBRequest to responder
     typealias Context = Responder.Context
 
     /// Build the responder
     var responder: Responder { get async throws }
     /// Server channel setup
-    var channelSetup: HBHTTPChannelSetupBuilder<ChannelSetup> { get }
+    var channelSetup: HBHTTPChannelBuilder<ChildChannel> { get }
 
     /// event loop group used by application
     var eventLoopGroup: EventLoopGroup { get }
@@ -69,7 +69,7 @@ public protocol HBApplicationProtocol: Service where Context: HBRequestContext {
 
 extension HBApplicationProtocol {
     /// Server channel setup
-    public var channelSetup: HBHTTPChannelSetupBuilder<HTTP1Channel> { .http1() }
+    public var channelSetup: HBHTTPChannelBuilder<HTTP1Channel> { .http1() }
 }
 
 extension HBApplicationProtocol {
@@ -161,9 +161,9 @@ public func loggerWithRequestId(_ logger: Logger) -> Logger {
 /// try await app.runService()
 /// ```
 /// Editing the application setup after calling `runService` will produce undefined behaviour.
-public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup & HTTPChannelHandler>: HBApplicationProtocol where Responder.Context: HBRequestContext {
+public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel & HTTPChannelHandler>: HBApplicationProtocol where Responder.Context: HBRequestContext {
     public typealias Context = Responder.Context
-    public typealias ChannelSetup = ChannelSetup
+    public typealias ChildChannel = ChildChannel
     public typealias Responder = Responder
 
     // MARK: Member variables
@@ -179,7 +179,7 @@ public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup
     /// on server running
     private var _onServerRunning: @Sendable (Channel) async -> Void
     /// Server channel setup
-    public let channelSetup: HBHTTPChannelSetupBuilder<ChannelSetup>
+    public let channelSetup: HBHTTPChannelBuilder<ChildChannel>
     /// services attached to the application.
     public var services: [any Service]
 
@@ -188,7 +188,7 @@ public struct HBApplication<Responder: HBResponder, ChannelSetup: HBChannelSetup
     /// Initialize new Application
     public init(
         responder: Responder,
-        channelSetup: HBHTTPChannelSetupBuilder<ChannelSetup> = .http1(),
+        channelSetup: HBHTTPChannelBuilder<ChildChannel> = .http1(),
         configuration: HBApplicationConfiguration = HBApplicationConfiguration(),
         eventLoopGroupProvider: EventLoopGroupProvider = .singleton
     ) {

--- a/Sources/HummingbirdCore/Server/ChildChannel.swift
+++ b/Sources/HummingbirdCore/Server/ChildChannel.swift
@@ -16,7 +16,7 @@ import Logging
 import NIOCore
 
 /// HTTPServer child channel setup protocol
-public protocol HBChannelSetup: Sendable {
+public protocol HBChildChannel: Sendable {
     associatedtype Value: Sendable
 
     /// Initialize channel
@@ -24,7 +24,7 @@ public protocol HBChannelSetup: Sendable {
     ///   - channel: channel
     ///   - childHandlers: Channel handlers to add
     ///   - configuration: server configuration
-    func initialize(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value>
+    func setup(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value>
 
     /// handle async channel
     func handle(value: Value, logger: Logger) async

--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -18,7 +18,7 @@ import NIOCore
 import NIOHTTPTypes
 import NIOHTTPTypesHTTP1
 
-public struct HTTP1Channel: HBChannelSetup, HTTPChannelHandler {
+public struct HTTP1Channel: HBChildChannel, HTTPChannelHandler {
     public typealias Value = NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>
 
     public init(
@@ -29,7 +29,7 @@ public struct HTTP1Channel: HBChannelSetup, HTTPChannelHandler {
         self.responder = responder
     }
 
-    public func initialize(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value> {
+    public func setup(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value> {
         let childChannelHandlers: [any ChannelHandler] =
             [HTTP1ToHTTPServerCodec(secure: false)] +
             self.additionalChannelHandlers() +

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelBuilder.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelBuilder.swift
@@ -15,17 +15,17 @@
 import NIOCore
 
 /// Build Channel Setup that takes an HTTP responder
-public struct HBHTTPChannelSetupBuilder<ChannelSetup: HBChannelSetup>: Sendable {
-    public let build: @Sendable (@escaping HTTPChannelHandler.Responder) throws -> ChannelSetup
-    public init(_ build: @escaping @Sendable (@escaping HTTPChannelHandler.Responder) throws -> ChannelSetup) {
+public struct HBHTTPChannelBuilder<ChildChannel: HBChildChannel>: Sendable {
+    public let build: @Sendable (@escaping HTTPChannelHandler.Responder) throws -> ChildChannel
+    public init(_ build: @escaping @Sendable (@escaping HTTPChannelHandler.Responder) throws -> ChildChannel) {
         self.build = build
     }
 }
 
-extension HBHTTPChannelSetupBuilder {
+extension HBHTTPChannelBuilder {
     public static func http1(
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
-    ) -> HBHTTPChannelSetupBuilder<HTTP1Channel> {
+    ) -> HBHTTPChannelBuilder<HTTP1Channel> {
         return .init { responder in
             return HTTP1Channel(responder: responder, additionalChannelHandlers: additionalChannelHandlers)
         }

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -20,7 +20,7 @@ import NIOHTTPTypes
 import ServiceLifecycle
 
 /// Protocol for HTTP channels
-public protocol HTTPChannelHandler: HBChannelSetup {
+public protocol HTTPChannelHandler: HBChildChannel {
     typealias Responder = @Sendable (HBRequest, Channel) async throws -> HBResponse
     var responder: Responder { get }
 }

--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -43,7 +43,7 @@ public struct HTTP2Channel: HTTPChannelHandler {
         self.http1 = HTTP1Channel(responder: responder, additionalChannelHandlers: additionalChannelHandlers)
     }
 
-    public func initialize(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value> {
+    public func setup(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value> {
         do {
             try channel.pipeline.syncOperations.addHandler(NIOSSLServerHandler(context: self.sslContext))
         } catch {

--- a/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
@@ -13,15 +13,20 @@
 //===----------------------------------------------------------------------===//
 
 import HummingbirdCore
+import NIOCore
 import NIOSSL
 
-extension HBHTTPChannelSetupBuilder {
-    public static func tls<BaseChannel: HBChannelSetup>(
-        _ base: HBHTTPChannelSetupBuilder<BaseChannel> = .http1(),
-        tlsConfiguration: TLSConfiguration
-    ) throws -> HBHTTPChannelSetupBuilder<TLSChannel<BaseChannel>> {
+extension HBHTTPChannelBuilder {
+    public static func http2(
+        tlsConfiguration: TLSConfiguration,
+        additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
+    ) throws -> HBHTTPChannelBuilder<HTTP2Channel> {
         return .init { responder in
-            return try TLSChannel(base.build(responder), tlsConfiguration: tlsConfiguration)
+            return try HTTP2Channel(
+                tlsConfiguration: tlsConfiguration,
+                additionalChannelHandlers: additionalChannelHandlers,
+                responder: responder
+            )
         }
     }
 }

--- a/Sources/HummingbirdTLS/TLSChannel.swift
+++ b/Sources/HummingbirdTLS/TLSChannel.swift
@@ -4,7 +4,7 @@ import NIOCore
 import NIOSSL
 
 /// Sets up child channel to use TLS before accessing base channel setup
-public struct TLSChannel<BaseChannel: HBChannelSetup>: HBChannelSetup {
+public struct TLSChannel<BaseChannel: HBChildChannel>: HBChildChannel {
     public typealias Value = BaseChannel.Value
 
     public init(_ baseChannel: BaseChannel, tlsConfiguration: TLSConfiguration) throws {
@@ -13,9 +13,9 @@ public struct TLSChannel<BaseChannel: HBChannelSetup>: HBChannelSetup {
     }
 
     @inlinable
-    public func initialize(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value> {
+    public func setup(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value> {
         return channel.pipeline.addHandler(NIOSSLServerHandler(context: self.sslContext)).flatMap {
-            self.baseChannel.initialize(channel: channel, configuration: configuration, logger: logger)
+            self.baseChannel.setup(channel: channel, configuration: configuration, logger: logger)
         }
     }
 

--- a/Sources/HummingbirdTLS/TLSChannelBuilder.swift
+++ b/Sources/HummingbirdTLS/TLSChannelBuilder.swift
@@ -13,20 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 import HummingbirdCore
-import NIOCore
 import NIOSSL
 
-extension HBHTTPChannelSetupBuilder {
-    public static func http2(
-        tlsConfiguration: TLSConfiguration,
-        additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
-    ) throws -> HBHTTPChannelSetupBuilder<HTTP2Channel> {
+extension HBHTTPChannelBuilder {
+    public static func tls<BaseChannel: HBChildChannel>(
+        _ base: HBHTTPChannelBuilder<BaseChannel> = .http1(),
+        tlsConfiguration: TLSConfiguration
+    ) throws -> HBHTTPChannelBuilder<TLSChannel<BaseChannel>> {
         return .init { responder in
-            return try HTTP2Channel(
-                tlsConfiguration: tlsConfiguration,
-                additionalChannelHandlers: additionalChannelHandlers,
-                responder: responder
-            )
+            return try TLSChannel(base.build(responder), tlsConfiguration: tlsConfiguration)
         }
     }
 }

--- a/Sources/HummingbirdXCT/TestApplication.swift
+++ b/Sources/HummingbirdXCT/TestApplication.swift
@@ -23,7 +23,7 @@ import ServiceLifecycle
 /// This is needed to override the `onServerRunning` function
 struct TestApplication<BaseApp: HBApplicationProtocol>: HBApplicationProtocol, Service {
     typealias Responder = BaseApp.Responder
-    typealias ChannelSetup = BaseApp.ChannelSetup
+    typealias ChildChannel = BaseApp.ChildChannel
 
     let base: BaseApp
 
@@ -31,8 +31,8 @@ struct TestApplication<BaseApp: HBApplicationProtocol>: HBApplicationProtocol, S
         get async throws { try await self.base.responder }
     }
 
-    var channelSetup: HBHTTPChannelSetupBuilder<ChannelSetup> {
-        self.base.channelSetup
+    var server: HBHTTPChannelBuilder<ChildChannel> {
+        self.base.server
     }
 
     /// event loop group used by application

--- a/Tests/HummingbirdCoreTests/TestUtils.swift
+++ b/Tests/HummingbirdCoreTests/TestUtils.swift
@@ -31,13 +31,13 @@ public enum TestErrors: Error {
 }
 
 /// Helper function for testing a server
-public func testServer<ChannelSetup: HBChannelSetup, Value: Sendable>(
+public func testServer<ChildChannel: HBChildChannel, Value: Sendable>(
     responder: @escaping HTTPChannelHandler.Responder,
-    httpChannelSetup: HBHTTPChannelSetupBuilder<ChannelSetup>,
+    httpChannelSetup: HBHTTPChannelBuilder<ChildChannel>,
     configuration: HBServerConfiguration,
     eventLoopGroup: EventLoopGroup,
     logger: Logger,
-    _ test: @escaping @Sendable (HBServer<ChannelSetup>, Int) async throws -> Value
+    _ test: @escaping @Sendable (HBServer<ChildChannel>, Int) async throws -> Value
 ) async throws -> Value {
     try await withThrowingTaskGroup(of: Void.self) { group in
         let promise = Promise<Int>()
@@ -68,14 +68,14 @@ public func testServer<ChannelSetup: HBChannelSetup, Value: Sendable>(
 ///
 /// Creates test client, runs test function abd ensures everything is
 /// shutdown correctly
-public func testServer<ChannelSetup: HBChannelSetup, Value: Sendable>(
+public func testServer<ChildChannel: HBChildChannel, Value: Sendable>(
     responder: @escaping HTTPChannelHandler.Responder,
-    httpChannelSetup: HBHTTPChannelSetupBuilder<ChannelSetup>,
+    httpChannelSetup: HBHTTPChannelBuilder<ChildChannel>,
     configuration: HBServerConfiguration,
     eventLoopGroup: EventLoopGroup,
     logger: Logger,
     clientConfiguration: HBXCTClient.Configuration = .init(),
-    _ test: @escaping @Sendable (HBServer<ChannelSetup>, HBXCTClient) async throws -> Value
+    _ test: @escaping @Sendable (HBServer<ChildChannel>, HBXCTClient) async throws -> Value
 ) async throws -> Value {
     try await withThrowingTaskGroup(of: Void.self) { group in
         let promise = Promise<Int>()
@@ -112,7 +112,7 @@ public func testServer<ChannelSetup: HBChannelSetup, Value: Sendable>(
 
 public func testServer<Value: Sendable>(
     responder: @escaping HTTPChannelHandler.Responder,
-    httpChannelSetup: HBHTTPChannelSetupBuilder<some HBChannelSetup> = .http1(),
+    httpChannelSetup: HBHTTPChannelBuilder<some HBChildChannel> = .http1(),
     configuration: HBServerConfiguration,
     eventLoopGroup: EventLoopGroup,
     logger: Logger,

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -516,7 +516,7 @@ final class ApplicationTests: XCTestCase {
         }
         let app = try HBApplication(
             responder: router.buildResponder(),
-            channelSetup: .tls(tlsConfiguration: self.getServerTLSConfiguration())
+            server: .tls(tlsConfiguration: self.getServerTLSConfiguration())
         )
         try await app.test(.ahc(.https)) { client in
             try await client.XCTExecute(uri: "/", method: .get) { response in
@@ -536,7 +536,7 @@ final class ApplicationTests: XCTestCase {
         }
         let app = try HBApplication(
             responder: router.buildResponder(),
-            channelSetup: .http2(tlsConfiguration: self.getServerTLSConfiguration())
+            server: .http2(tlsConfiguration: self.getServerTLSConfiguration())
         )
         try await app.test(.ahc(.https)) { client in
             try await client.XCTExecute(uri: "/", method: .get) { response in


### PR DESCRIPTION
- `HBChannelSetup` -> `HBChildChannel` (It doesn't just setup the child channel it handles data flowing through it)
- `HBChannelSetup.initialize` -> `HBChildChannel.setup` (initialize is too near to init)
- `HBHTTPChannelSetupBuilder` -> `HBHTTPChannelBuilder` (SetupBuilder is just weird and now HBChannelSetup has been renamed it seems sensible to remove the Setup from the name)
- `HBApplication.init(responder:channelSetup:...)` -> `HBApplication.init(responder:server:...)` (channelSetup doesn't really make sense to the user, unless they know the internals of HB)

Most of these names are internal to HB and many people won't see them, but I think it is worthwhile getting them right