### PR TITLE
Remove TestRequestContextProtocol

### DIFF
--- a/Sources/Hummingbird/Server/RequestContext.swift
+++ b/Sources/Hummingbird/Server/RequestContext.swift
@@ -86,6 +86,12 @@ public protocol HBBaseRequestContext: Sendable {
     /// Maximum upload size allowed for routes that don't stream the request payload. This
     /// limits how much memory would be used for one request
     var maxUploadSize: Int { get }
+    /// initialize a request context
+    /// - Parameters
+    ///   - eventLoop: EventLoop that created the context
+    ///   - allocator: ByteBuffer allocator
+    ///   - logger: Logger used by context
+    init(eventLoop: EventLoop, allocator: ByteBufferAllocator, logger: Logger)
 }
 
 extension HBBaseRequestContext {
@@ -137,6 +143,16 @@ public protocol HBRequestContext: HBBaseRequestContext {
     init(channel: Channel, logger: Logger)
 }
 
+extension HBRequestContext {
+    ///  Initialize an `HBRequestContext`
+    /// - Parameters:
+    ///   - channel: Source of request context
+    ///   - logger: Logger
+    public init(channel: Channel, logger: Logger) {
+        self.init(eventLoop: channel.eventLoop, allocator: channel.allocator, logger: logger)
+    }
+}
+
 /// Implementation of a basic request context that supports everything the Hummingbird library needs
 public struct HBBasicRequestContext: HBRequestContext {
     /// core context
@@ -144,13 +160,18 @@ public struct HBBasicRequestContext: HBRequestContext {
 
     ///  Initialize an `HBRequestContext`
     /// - Parameters:
-    ///   - applicationContext: Context from Application that instigated the request
-    ///   - source: Source of request context
+    ///   - eventLoop: EventLoop context was created on
+    ///   - allocator: Allocator
     ///   - logger: Logger
     public init(
-        channel: Channel,
+        eventLoop: EventLoop,
+        allocator: ByteBufferAllocator,
         logger: Logger
     ) {
-        self.coreContext = .init(eventLoop: channel.eventLoop, allocator: channel.allocator, logger: logger)
+        self.coreContext = .init(
+            eventLoop: eventLoop,
+            allocator: allocator,
+            logger: logger
+        )
     }
 }

--- a/Sources/HummingbirdXCT/Application+XCT.swift
+++ b/Sources/HummingbirdXCT/Application+XCT.swift
@@ -67,7 +67,7 @@ extension HBApplicationProtocol where Responder.Context: HBRequestContext {
     }
 }
 
-extension HBApplicationProtocol where Responder.Context: HBTestRequestContextProtocol {
+extension HBApplicationProtocol where Responder.Context: HBBaseRequestContext {
     // MARK: Initialization
 
     /// Creates a version of `HBApplication` that can be used for testing code

--- a/Sources/HummingbirdXCT/HBXCTRouter.swift
+++ b/Sources/HummingbirdXCT/HBXCTRouter.swift
@@ -22,46 +22,8 @@ import NIOCore
 import NIOPosix
 import Tracing
 
-public protocol HBTestRequestContextProtocol: HBRequestContext {
-    init(
-        eventLoop: EventLoop,
-        allocator: ByteBufferAllocator,
-        logger: Logger
-    )
-}
-
-extension HBTestRequestContextProtocol {
-    public init(
-        channel: Channel,
-        logger: Logger
-    ) {
-        self.init(
-            eventLoop: channel.eventLoop,
-            allocator: channel.allocator,
-            logger: logger
-        )
-    }
-}
-
-public struct HBTestRouterContext: HBTestRequestContextProtocol {
-    public init(
-        eventLoop: EventLoop,
-        allocator: ByteBufferAllocator,
-        logger: Logger
-    ) {
-        self.coreContext = .init(
-            eventLoop: eventLoop,
-            allocator: allocator,
-            logger: logger
-        )
-    }
-
-    /// router context
-    public var coreContext: HBCoreRequestContext
-}
-
 /// Test sending values to requests to router. This does not setup a live server
-struct HBXCTRouter<Responder: HBResponder>: HBXCTApplication where Responder.Context: HBTestRequestContextProtocol {
+struct HBXCTRouter<Responder: HBResponder>: HBXCTApplication where Responder.Context: HBBaseRequestContext {
     let eventLoopGroup: EventLoopGroup
     let responder: Responder
     let logger: Logger

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -21,12 +21,12 @@ import NIOPosix
 struct PerformanceTestRequestContext: HBRequestContext {
     var coreContext: HBCoreRequestContext
 
-    init(channel: Channel, logger: Logger) {
+    init(eventLoop: EventLoop, allocator: ByteBufferAllocator, logger: Logger) {
         self.coreContext = .init(
             requestDecoder: JSONDecoder(),
             responseEncoder: JSONEncoder(),
-            eventLoop: channel.eventLoop,
-            allocator: channel.allocator,
+            eventLoop: eventLoop,
+            allocator: allocator,
             logger: logger
         )
     }

--- a/Tests/HummingbirdFoundationTests/CookiesTests.swift
+++ b/Tests/HummingbirdFoundationTests/CookiesTests.swift
@@ -65,7 +65,7 @@ class CookieTests: XCTestCase {
     }
 
     func testSetCookie() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.post("/") { _, _ -> HBResponse in
             var response = HBResponse(status: .ok, headers: [:], body: .init())
             response.setCookie(.init(name: "test", value: "value"))
@@ -80,7 +80,7 @@ class CookieTests: XCTestCase {
     }
 
     func testSetCookieViaRequest() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.post("/") { _, _ in
             return HBEditedResponse(headers: [.setCookie: HBCookie(name: "test", value: "value").description], response: "Hello")
         }
@@ -93,7 +93,7 @@ class CookieTests: XCTestCase {
     }
 
     func testReadCookieFromRequest() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.post("/") { request, _ -> String? in
             return request.cookies["test"]?.value
         }

--- a/Tests/HummingbirdFoundationTests/FileMiddlewareTests.swift
+++ b/Tests/HummingbirdFoundationTests/FileMiddlewareTests.swift
@@ -35,7 +35,7 @@ class HummingbirdFilesTests: XCTestCase {
     }
 
     func testRead() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBFileMiddleware("."))
         let app = HBApplication(responder: router.buildResponder())
 
@@ -55,7 +55,7 @@ class HummingbirdFilesTests: XCTestCase {
     }
 
     func testReadLargeFile() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBFileMiddleware("."))
         let app = HBApplication(responder: router.buildResponder())
 
@@ -74,7 +74,7 @@ class HummingbirdFilesTests: XCTestCase {
     }
 
     func testReadRange() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBFileMiddleware("."))
         let app = HBApplication(responder: router.buildResponder())
 
@@ -119,7 +119,7 @@ class HummingbirdFilesTests: XCTestCase {
     }
 
     func testIfRangeRead() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBFileMiddleware("."))
         let app = HBApplication(responder: router.buildResponder())
 
@@ -155,7 +155,7 @@ class HummingbirdFilesTests: XCTestCase {
     }
 
     func testHead() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBFileMiddleware("."))
         let app = HBApplication(responder: router.buildResponder())
 
@@ -179,7 +179,7 @@ class HummingbirdFilesTests: XCTestCase {
     }
 
     func testETag() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBFileMiddleware("."))
         let app = HBApplication(responder: router.buildResponder())
 
@@ -201,7 +201,7 @@ class HummingbirdFilesTests: XCTestCase {
     }
 
     func testIfNoneMatch() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBFileMiddleware("."))
         let app = HBApplication(responder: router.buildResponder())
 
@@ -230,7 +230,7 @@ class HummingbirdFilesTests: XCTestCase {
     }
 
     func testIfModifiedSince() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBFileMiddleware("."))
         let app = HBApplication(responder: router.buildResponder())
 
@@ -256,7 +256,7 @@ class HummingbirdFilesTests: XCTestCase {
     }
 
     func testCacheControl() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         let cacheControl: HBCacheControl = .init([
             (.text, [.maxAge(60 * 60 * 24 * 30)]),
             (.imageJpeg, [.maxAge(60 * 60 * 24 * 30), .private]),
@@ -284,7 +284,7 @@ class HummingbirdFilesTests: XCTestCase {
     }
 
     func testIndexHtml() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBFileMiddleware(".", searchForIndexHtml: true))
         let app = HBApplication(responder: router.buildResponder())
 

--- a/Tests/HummingbirdFoundationTests/HummingBirdJSONTests.swift
+++ b/Tests/HummingbirdFoundationTests/HummingBirdJSONTests.swift
@@ -27,7 +27,7 @@ class HummingbirdJSONTests: XCTestCase {
     struct Error: Swift.Error {}
 
     func testDecode() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.put("/user") { request, context -> HTTPResponse.Status in
             guard let user = try? await request.decode(as: User.self, using: context) else { throw HBHTTPError(.badRequest) }
@@ -46,7 +46,7 @@ class HummingbirdJSONTests: XCTestCase {
     }
 
     func testEncode() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.get("/user") { _, _ -> User in
             return User(name: "John Smith", email: "john.smith@email.com", age: 25)
@@ -64,7 +64,7 @@ class HummingbirdJSONTests: XCTestCase {
     }
 
     func testEncode2() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.get("/json") { _, _ in
             return ["message": "Hello, world!"]

--- a/Tests/HummingbirdFoundationTests/URLEncodedForm/Application+URLEncodedFormTests.swift
+++ b/Tests/HummingbirdFoundationTests/URLEncodedForm/Application+URLEncodedFormTests.swift
@@ -27,7 +27,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
     struct Error: Swift.Error {}
 
     func testDecode() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: URLEncodedFormDecoder(), encoder: URLEncodedFormEncoder()))
         router.put("/user") { request, context -> HTTPResponse.Status in
             guard let user = try? await request.decode(as: User.self, using: context) else { throw HBHTTPError(.badRequest) }
@@ -46,7 +46,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
     }
 
     func testEncode() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: URLEncodedFormDecoder(), encoder: URLEncodedFormEncoder()))
         router.get("/user") { _, _ -> User in
             return User(name: "John Smith", email: "john.smith@email.com", age: 25)

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -29,7 +29,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testGetRoute() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.get("/hello") { _, context -> ByteBuffer in
             return context.allocator.buffer(string: "GET: Hello")
         }
@@ -45,7 +45,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testHTTPStatusRoute() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.get("/accepted") { _, _ -> HTTPResponse.Status in
             return .accepted
         }
@@ -58,7 +58,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testStandardHeaders() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.get("/hello") { _, _ in
             return "Hello"
         }
@@ -72,7 +72,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testServerHeaders() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.get("/hello") { _, _ in
             return "Hello"
         }
@@ -85,7 +85,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testPostRoute() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.post("/hello") { _, _ -> String in
             return "POST: Hello"
         }
@@ -102,7 +102,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testMultipleMethods() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.post("/hello") { _, _ -> String in
             return "POST"
         }
@@ -124,7 +124,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testMultipleGroupMethods() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.group("hello")
             .post { _, _ -> String in
                 return "POST"
@@ -147,7 +147,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testQueryRoute() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.post("/query") { request, context -> ByteBuffer in
             return context.allocator.buffer(string: request.uri.queryParameters["test"].map { String($0) } ?? "")
         }
@@ -164,7 +164,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testMultipleQueriesRoute() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.post("/add") { request, _ -> String in
             return request.uri.queryParameters.getAll("value", as: Int.self).reduce(0,+).description
         }
@@ -181,7 +181,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testArray() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.get("array") { _, _ -> [String] in
             return ["yes", "no"]
         }
@@ -196,7 +196,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testResponseBody() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .group("/echo-body")
             .post { request, _ -> HBResponse in
@@ -216,7 +216,7 @@ final class ApplicationTests: XCTestCase {
 
     /// Test streaming of requests and streaming of responses by streaming the request body into a response streamer
     func testStreaming() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.post("streaming") { request, _ -> HBResponse in
             return HBResponse(status: .ok, body: .init(asyncSequence: request.body))
         }
@@ -249,7 +249,7 @@ final class ApplicationTests: XCTestCase {
 
     /// Test streaming of requests and streaming of responses by streaming the request body into a response streamer
     func testStreamingSmallBuffer() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.post("streaming") { request, _ -> HBResponse in
             return HBResponse(status: .ok, body: .init(asyncSequence: request.body))
         }
@@ -275,7 +275,7 @@ final class ApplicationTests: XCTestCase {
                 return try await next(request, context)
             }
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(CollateMiddleware())
         router.put("/hello") { request, _ -> String in
             guard case .byteBuffer(let buffer) = request.body else { throw HBHTTPError(.internalServerError) }
@@ -293,7 +293,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testOptional() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .group("/echo-body")
             .post { request, _ -> ByteBuffer? in
@@ -319,7 +319,7 @@ final class ApplicationTests: XCTestCase {
             let first: String
             let last: String
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .group("/name")
             .patch { _, _ -> Name? in
@@ -336,7 +336,7 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testTypedResponse() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.delete("/hello") { _, _ in
             return HBEditedResponse(
                 status: .preconditionRequired,
@@ -362,7 +362,7 @@ final class ApplicationTests: XCTestCase {
         struct Result: HBResponseEncodable {
             let value: String
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.patch("/hello") { _, _ in
             return HBEditedResponse(
@@ -387,8 +387,8 @@ final class ApplicationTests: XCTestCase {
 
     func testMaxUploadSize() async throws {
         struct MaxUploadRequestContext: HBRequestContext {
-            init(channel: Channel, logger: Logger) {
-                self.coreContext = .init(eventLoop: channel.eventLoop, allocator: channel.allocator, logger: logger)
+            init(eventLoop: EventLoop, allocator: ByteBufferAllocator, logger: Logger) {
+                self.coreContext = .init(eventLoop: eventLoop, allocator: allocator, logger: logger)
             }
 
             var coreContext: HBCoreRequestContext
@@ -424,12 +424,17 @@ final class ApplicationTests: XCTestCase {
             // socket address
             let remoteAddress: SocketAddress?
 
-            public init(
+            init(
                 channel: Channel,
                 logger: Logger
             ) {
                 self.coreContext = .init(eventLoop: channel.eventLoop, allocator: channel.allocator, logger: logger)
                 self.remoteAddress = channel.remoteAddress
+            }
+
+            init(eventLoop: EventLoop, allocator: ByteBufferAllocator, logger: Logger) {
+                self.coreContext = .init(eventLoop: eventLoop, allocator: allocator, logger: logger)
+                self.remoteAddress = nil
             }
         }
         let router = HBRouter(context: HBSocketAddressRequestContext.self)
@@ -459,7 +464,7 @@ final class ApplicationTests: XCTestCase {
     /// is more a compilation test than a runtime test
     func testApplicationProtocolReturnValue() async throws {
         func createApplication() -> some HBApplicationProtocol {
-            let router = HBRouter(context: HBTestRouterContext.self)
+            let router = HBRouter()
             router.get("/hello") { _, context -> ByteBuffer in
                 return context.allocator.buffer(string: "GET: Hello")
             }
@@ -479,7 +484,7 @@ final class ApplicationTests: XCTestCase {
     /// test we can create out own application type conforming to HBApplicationProtocol
     func testApplicationProtocol() async throws {
         struct MyApp: HBApplicationProtocol {
-            typealias Context = HBTestRouterContext
+            typealias Context = HBBasicRequestContext
 
             var responder: some HBResponder<Context> {
                 let router = HBRouter(context: Context.self)

--- a/Tests/HummingbirdTests/FileIOTests.swift
+++ b/Tests/HummingbirdTests/FileIOTests.swift
@@ -24,7 +24,7 @@ class FileIOTests: XCTestCase {
     }
 
     func testReadFileIO() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.get("test.jpg") { _, context -> HBResponse in
             let fileIO = HBFileIO(threadPool: context.threadPool)
             let body = try await fileIO.loadFile(path: "test.jpg", context: context, logger: context.logger)
@@ -47,7 +47,7 @@ class FileIOTests: XCTestCase {
 
     func testWrite() async throws {
         let filename = "testWrite.txt"
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.put("store") { request, context -> HTTPResponse.Status in
             let fileIO = HBFileIO(threadPool: context.threadPool)
             try await fileIO.writeFile(contents: request.body, path: filename, context: context, logger: context.logger)
@@ -70,7 +70,7 @@ class FileIOTests: XCTestCase {
 
     func testWriteLargeFile() async throws {
         let filename = "testWriteLargeFile.txt"
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.put("store") { request, context -> HTTPResponse.Status in
             let fileIO = HBFileIO(threadPool: context.threadPool)
             try await fileIO.writeFile(contents: request.body, path: filename, context: context, logger: context.logger)

--- a/Tests/HummingbirdTests/HandlerTests.swift
+++ b/Tests/HummingbirdTests/HandlerTests.swift
@@ -27,7 +27,7 @@ final class HandlerTests: XCTestCase {
             }
         }
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.post("/hello", use: DecodeTest.self)
         let app = HBApplication(responder: router.buildResponder())
@@ -57,7 +57,7 @@ final class HandlerTests: XCTestCase {
             }
         }
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.post("/hello", use: DecodeTest.self)
         let app = HBApplication(responder: router.buildResponder())
@@ -87,7 +87,7 @@ final class HandlerTests: XCTestCase {
             }
         }
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.post("/hello", use: DecodeTest.self)
         let app = HBApplication(responder: router.buildResponder())
@@ -122,7 +122,7 @@ final class HandlerTests: XCTestCase {
             }
         }
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.post("/hello", use: DecodeTest.self)
         let app = HBApplication(responder: router.buildResponder())
@@ -150,7 +150,7 @@ final class HandlerTests: XCTestCase {
                 return "Hello \(self.name)"
             }
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.post("/hello", use: DecodeTest.self)
         let app = HBApplication(responder: router.buildResponder())
@@ -171,7 +171,7 @@ final class HandlerTests: XCTestCase {
                 "Hello \(self.name)"
             }
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.put("/hello", use: DecodeTest.self)
         let app = HBApplication(responder: router.buildResponder())
@@ -193,7 +193,7 @@ final class HandlerTests: XCTestCase {
                 return .ok
             }
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBSetCodableMiddleware(decoder: JSONDecoder(), encoder: JSONEncoder()))
         router.get("/hello", use: DecodeTest.self)
         let app = HBApplication(responder: router.buildResponder())
@@ -217,7 +217,7 @@ final class HandlerTests: XCTestCase {
             }
         }
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.put("/:test", use: ParameterTest.self)
         let app = HBApplication(responder: router.buildResponder())
 

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -184,7 +184,7 @@ final class MetricsTests: XCTestCase {
     }
 
     func testCounter() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBMetricsMiddleware())
         router.get("/hello") { _, _ -> String in
             return "Hello"
@@ -203,7 +203,7 @@ final class MetricsTests: XCTestCase {
     }
 
     func testError() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBMetricsMiddleware())
         router.get("/hello") { _, _ -> String in
             throw HBHTTPError(.badRequest)
@@ -223,7 +223,7 @@ final class MetricsTests: XCTestCase {
     }
 
     func testNotFoundError() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBMetricsMiddleware())
         router.get("/hello") { _, _ -> String in
             return "hello"
@@ -242,7 +242,7 @@ final class MetricsTests: XCTestCase {
     }
 
     func testParameterEndpoint() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBMetricsMiddleware())
         router.get("/user/:id") { _, _ -> String in
             throw HBHTTPError(.badRequest)

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -31,7 +31,7 @@ final class MiddlewareTests: XCTestCase {
                 return response
             }
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(TestMiddleware())
         router.get("/hello") { _, _ -> String in
             return "Hello"
@@ -53,7 +53,7 @@ final class MiddlewareTests: XCTestCase {
                 return response
             }
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(TestMiddleware(string: "first"))
         router.middlewares.add(TestMiddleware(string: "second"))
         router.get("/hello") { _, _ -> String in
@@ -71,14 +71,14 @@ final class MiddlewareTests: XCTestCase {
 
     func testMiddlewareRunOnce() async throws {
         struct TestMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
-    public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
+            public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
                 var response = try await next(request, context)
                 XCTAssertNil(response.headers[.test])
                 response.headers[.test] = "alreadyRun"
                 return response
             }
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(TestMiddleware())
         router.get("/hello") { _, _ -> String in
             return "Hello"
@@ -92,7 +92,7 @@ final class MiddlewareTests: XCTestCase {
 
     func testMiddlewareRunWhenNoRouteFound() async throws {
         struct TestMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
-    public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
+            public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
                 do {
                     return try await next(request, context)
                 } catch let error as HBHTTPError where error.status == .notFound {
@@ -100,7 +100,7 @@ final class MiddlewareTests: XCTestCase {
                 }
             }
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(TestMiddleware())
         let app = HBApplication(responder: router.buildResponder())
 
@@ -115,12 +115,12 @@ final class MiddlewareTests: XCTestCase {
 
     func testEndpointPathInGroup() async throws {
         struct TestMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
-    public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
+            public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
                 XCTAssertNotNil(context.endpointPath)
                 return try await next(request, context)
             }
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.group()
             .add(middleware: TestMiddleware())
             .get("test") { _, _ in
@@ -144,7 +144,7 @@ final class MiddlewareTests: XCTestCase {
             }
         }
         struct TransformMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
-    public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
+            public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
                 let response = try await next(request, context)
                 var editedResponse = response
                 editedResponse.body = .init { writer in
@@ -154,7 +154,7 @@ final class MiddlewareTests: XCTestCase {
                 return editedResponse
             }
         }
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.group()
             .add(middleware: TransformMiddleware())
             .get("test") { request, _ in
@@ -172,7 +172,7 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testCORSUseOrigin() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBCORSMiddleware())
         router.get("/hello") { _, _ -> String in
             return "Hello"
@@ -187,7 +187,7 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testCORSUseAll() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBCORSMiddleware(allowOrigin: .all))
         router.get("/hello") { _, _ -> String in
             return "Hello"
@@ -202,7 +202,7 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testCORSOptions() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBCORSMiddleware(
             allowOrigin: .all,
             allowHeaders: [.contentType, .authorization],
@@ -232,7 +232,7 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testRouteLoggingMiddleware() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBLogRequestsMiddleware(.debug))
         router.put("/hello") { _, _ -> String in
             throw HBHTTPError(.badRequest)

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -19,8 +19,8 @@ import XCTest
 final class PersistTests: XCTestCase {
     static let redisHostname = HBEnvironment.shared.get("REDIS_HOSTNAME") ?? "localhost"
 
-    func createRouter() throws -> (HBRouter<HBTestRouterContext>, HBPersistDriver) {
-        let router = HBRouter(context: HBTestRouterContext.self)
+    func createRouter() throws -> (HBRouter<HBBasicRequestContext>, HBPersistDriver) {
+        let router = HBRouter()
         let persist = HBMemoryPersistDriver()
 
         router.put("/persist/:tag") { request, context -> HTTPResponse.Status in

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -44,7 +44,7 @@ final class RouterTests: XCTestCase {
             }
         }
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(TestEndpointMiddleware())
         router.get("/test/:number") { _, _ in return "xxx" }
         let app = HBApplication(responder: router.buildResponder())
@@ -66,7 +66,7 @@ final class RouterTests: XCTestCase {
             }
         }
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(TestEndpointMiddleware())
         router.get("test") { _, context in
             return context.endpointPath
@@ -104,7 +104,7 @@ final class RouterTests: XCTestCase {
             }
         }
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(TestEndpointMiddleware())
         router.get("test/") { _, context in
             return context.endpointPath
@@ -148,7 +148,7 @@ final class RouterTests: XCTestCase {
 
     /// Test correct endpoints are called from group
     func testMethodEndpoint() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .group("/endpoint")
             .get { _, _ in
@@ -174,7 +174,7 @@ final class RouterTests: XCTestCase {
     /// Test middle in group is applied to group but not to routes outside
     /// group
     func testGroupMiddleware() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .group()
             .add(middleware: TestMiddleware())
@@ -197,7 +197,7 @@ final class RouterTests: XCTestCase {
     }
 
     func testEndpointMiddleware() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .group("/group")
             .add(middleware: TestMiddleware())
@@ -214,7 +214,7 @@ final class RouterTests: XCTestCase {
 
     /// Test middleware in parent group is applied to routes in child group
     func testGroupGroupMiddleware() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .group("/test")
             .add(middleware: TestMiddleware())
@@ -268,7 +268,7 @@ final class RouterTests: XCTestCase {
     }
 
     func testParameters() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .delete("/user/:id") { _, context -> String? in
                 return context.parameters.get("id", as: String.self)
@@ -283,7 +283,7 @@ final class RouterTests: XCTestCase {
     }
 
     func testParameterCollection() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .delete("/user/:username/:id") { _, context -> String? in
                 XCTAssertEqual(context.parameters.count, 2)
@@ -299,7 +299,7 @@ final class RouterTests: XCTestCase {
     }
 
     func testPartialCapture() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .get("/files/file.${ext}/${name}.jpg") { _, context -> String in
                 XCTAssertEqual(context.parameters.count, 2)
@@ -317,7 +317,7 @@ final class RouterTests: XCTestCase {
     }
 
     func testPartialWildcard() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router
             .get("/files/file.*/*.jpg") { _, _ -> HTTPResponse.Status in
                 return .ok
@@ -335,7 +335,7 @@ final class RouterTests: XCTestCase {
 
     /// Test we have a request id and that it increments with each request
     func testRequestId() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.get("id") { _, context in
             return context.id.description
         }
@@ -356,7 +356,7 @@ final class RouterTests: XCTestCase {
 
     // Test redirect response
     func testRedirect() async throws {
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.get("redirect") { _, _ in
             return HBResponse.redirect(to: "/other")
         }
@@ -370,7 +370,7 @@ final class RouterTests: XCTestCase {
     }
 }
 
-public struct HBTestRouterContext2: HBTestRequestContextProtocol {
+public struct HBTestRouterContext2: HBRequestContext {
     public init(
         eventLoop: EventLoop,
         allocator: ByteBufferAllocator,

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -35,7 +35,7 @@ final class TracingTests: XCTestCase {
         tracer.onEndSpan = { _ in expectation.fulfill() }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBTracingMiddleware(attributes: ["net.host.name": "127.0.0.1", "net.host.port": 8080]))
         router.get("users/:id") { _, _ -> String in
             return "42"
@@ -75,7 +75,7 @@ final class TracingTests: XCTestCase {
         tracer.onEndSpan = { _ in expectation.fulfill() }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBTracingMiddleware())
         router.post("users") { _, _ -> String in
             throw HBHTTPError(.internalServerError)
@@ -114,7 +114,7 @@ final class TracingTests: XCTestCase {
         tracer.onEndSpan = { _ in expectation.fulfill() }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBTracingMiddleware(recordingHeaders: [
             .accept, .contentType, .cacheControl, .test,
         ]))
@@ -168,7 +168,7 @@ final class TracingTests: XCTestCase {
         tracer.onEndSpan = { _ in expectation.fulfill() }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBTracingMiddleware())
         router.post("/users") { _, _ -> HTTPResponse.Status in
             return .noContent
@@ -204,7 +204,7 @@ final class TracingTests: XCTestCase {
         tracer.onEndSpan = { _ in expectation.fulfill() }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBTracingMiddleware())
         router.get("/") { _, _ -> HTTPResponse.Status in
             return .ok
@@ -240,7 +240,7 @@ final class TracingTests: XCTestCase {
         tracer.onEndSpan = { _ in expectation.fulfill() }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBTracingMiddleware())
         let app = HBApplication(responder: router.buildResponder())
         try await app.test(.router) { client in
@@ -276,7 +276,7 @@ final class TracingTests: XCTestCase {
         tracer.onEndSpan = { _ in expectation.fulfill() }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBTracingMiddleware())
         router.get("/") { _, _ -> HTTPResponse.Status in
             var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
@@ -310,7 +310,7 @@ final class TracingTests: XCTestCase {
         tracer.onEndSpan = { _ in expectation.fulfill() }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBTracingMiddleware())
         router.get("/") { _, _ -> HTTPResponse.Status in
             var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
@@ -361,7 +361,7 @@ final class TracingTests: XCTestCase {
         }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(SpanMiddleware())
         router.middlewares.add(HBTracingMiddleware())
         router.get("/") { _, _ -> HTTPResponse.Status in
@@ -397,7 +397,7 @@ extension TracingTests {
         tracer.onEndSpan = { _ in expectation.fulfill() }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let router = HBRouter(context: HBTestRouterContext.self)
+        let router = HBRouter()
         router.middlewares.add(HBTracingMiddleware())
         router.get("/") { _, _ -> HTTPResponse.Status in
             try await Task.sleep(nanoseconds: 1000)


### PR DESCRIPTION
Remove `HBTestRequestContextProtocol`
Request contexts shouldn't require to conform an additional protocol to be used in tests.

It does mean any context that is extracting additional data out of `Channel` will have to implement two different `init` functions. I thought that was preferable to requiring that every request context conform to an additional context just so it can be used in testing.