### PR TITLE
Make HBMethods.constructResponder static and public

### DIFF
--- a/Sources/Hummingbird/AsyncAwaitSupport/Router+async.swift
+++ b/Sources/Hummingbird/AsyncAwaitSupport/Router+async.swift
@@ -70,7 +70,7 @@ extension HBRouterMethods {
         return on(path, method: .PATCH, options: options, use: handler)
     }
 
-    func constructResponder<Output: HBResponseGenerator>(
+    public static func constructResponder<Output: HBResponseGenerator>(
         options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) async throws -> Output
     ) -> HBResponder {
@@ -101,7 +101,7 @@ extension HBRouterBuilder {
         options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) async throws -> Output
     ) -> Self {
-        let responder = constructResponder(options: options, use: closure)
+        let responder = Self.constructResponder(options: options, use: closure)
         add(path, method: method, responder: responder)
         return self
     }
@@ -116,7 +116,7 @@ extension HBRouterGroup {
         options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) async throws -> Output
     ) -> Self {
-        let responder = constructResponder(options: options, use: closure)
+        let responder = Self.constructResponder(options: options, use: closure)
         let path = self.combinePaths(self.path, path)
         self.router.add(path, method: method, responder: self.middlewares.constructResponder(finalResponder: responder))
         return self

--- a/Sources/Hummingbird/Router/RouterBuilder.swift
+++ b/Sources/Hummingbird/Router/RouterBuilder.swift
@@ -83,7 +83,7 @@ public final class HBRouterBuilder: HBRouterMethods {
         options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) throws -> Output
     ) -> Self {
-        let responder = constructResponder(options: options, use: closure)
+        let responder = Self.constructResponder(options: options, use: closure)
         self.add(path, method: method, responder: responder)
         return self
     }
@@ -95,7 +95,7 @@ public final class HBRouterBuilder: HBRouterMethods {
         options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
-        let responder = constructResponder(options: options, use: closure)
+        let responder = Self.constructResponder(options: options, use: closure)
         self.add(path, method: method, responder: responder)
         return self
     }

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -64,7 +64,7 @@ public struct HBRouterGroup: HBRouterMethods {
         options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) throws -> Output
     ) -> Self {
-        let responder = constructResponder(options: options, use: closure)
+        let responder = Self.constructResponder(options: options, use: closure)
         let path = self.combinePaths(self.path, path)
         self.router.add(path, method: method, responder: self.middlewares.constructResponder(finalResponder: responder))
         return self
@@ -77,7 +77,7 @@ public struct HBRouterGroup: HBRouterMethods {
         options: HBRouterMethodOptions = [],
         use closure: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> Self {
-        let responder = constructResponder(options: options, use: closure)
+        let responder = Self.constructResponder(options: options, use: closure)
         let path = self.combinePaths(self.path, path)
         self.router.add(path, method: method, responder: self.middlewares.constructResponder(finalResponder: responder))
         return self

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -170,7 +170,7 @@ extension HBRouterMethods {
 }
 
 extension HBRouterMethods {
-    func constructResponder<Output: HBResponseGenerator>(
+    public static func constructResponder<Output: HBResponseGenerator>(
         options: HBRouterMethodOptions,
         use closure: @escaping (HBRequest) throws -> Output
     ) -> HBResponder {
@@ -219,7 +219,7 @@ extension HBRouterMethods {
         }
     }
 
-    func constructResponder<Output: HBResponseGenerator>(
+    public static func constructResponder<Output: HBResponseGenerator>(
         options: HBRouterMethodOptions,
         use closure: @escaping (HBRequest) -> EventLoopFuture<Output>
     ) -> HBResponder {


### PR DESCRIPTION
Allow for other router implementations to use this