### PR TITLE
Remove EventLoop from request context

### DIFF
--- a/Benchmarks/Benchmarks/Router/RouterBenchmarks.swift
+++ b/Benchmarks/Benchmarks/Router/RouterBenchmarks.swift
@@ -22,28 +22,14 @@ import NIOCore
 import NIOPosix
 
 /// Implementation of a basic request context that supports everything the Hummingbird library needs
-protocol BenchmarkContext: HBBaseRequestContext {
-    ///  Initialize an `HBRequestContext`
-    /// - Parameters:
-    ///   - applicationContext: Context from Application that instigated the request
-    ///   - source: Source of request context
-    ///   - logger: Logger
-    init(
-        eventLoop: EventLoop,
-        allocator: ByteBufferAllocator,
-        logger: Logger
-    )
-}
-
-struct BasicBenchmarkContext: BenchmarkContext {
+struct BasicBenchmarkContext: HBBaseRequestContext {
     var coreContext: HBCoreRequestContext
 
     init(
-        eventLoop: EventLoop,
         allocator: ByteBufferAllocator,
         logger: Logger
     ) {
-        self.coreContext = .init(eventLoop: eventLoop, allocator: allocator, logger: logger)
+        self.coreContext = .init(allocator: allocator, logger: logger)
     }
 }
 
@@ -54,7 +40,7 @@ struct BenchmarkBodyWriter: Sendable, HBResponseBodyWriter {
 
 extension Benchmark {
     @discardableResult
-    convenience init?<Context: BenchmarkContext>(
+    convenience init?<Context: HBBaseRequestContext>(
         name: String,
         context: Context.Type = BasicBenchmarkContext.self,
         configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
@@ -71,7 +57,6 @@ extension Benchmark {
                 for _ in 0..<50 {
                     try await withThrowingTaskGroup(of: Void.self) { group in
                         let context = Context(
-                            eventLoop: MultiThreadedEventLoopGroup.singleton.any(), 
                             allocator: ByteBufferAllocator(), 
                             logger: Logger(label: "Benchmark")
                         )

--- a/Sources/HummingbirdRouter/RouterBuilder.swift
+++ b/Sources/HummingbirdRouter/RouterBuilder.swift
@@ -37,8 +37,8 @@ public struct HBBasicRouterRequestContext: HBRequestContext, HBRouterRequestCont
     public var routerContext: HBRouterBuilderContext
     public var coreContext: HBCoreRequestContext
 
-    public init(eventLoop: EventLoop, allocator: ByteBufferAllocator, logger: Logger) {
-        self.coreContext = .init(eventLoop: eventLoop, allocator: allocator, logger: logger)
+    public init(allocator: ByteBufferAllocator, logger: Logger) {
+        self.coreContext = .init(allocator: allocator, logger: logger)
         self.routerContext = .init()
     }
 }

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -21,11 +21,10 @@ import NIOPosix
 struct PerformanceTestRequestContext: HBRequestContext {
     var coreContext: HBCoreRequestContext
 
-    init(eventLoop: EventLoop, allocator: ByteBufferAllocator, logger: Logger) {
+    init(allocator: ByteBufferAllocator, logger: Logger) {
         self.coreContext = .init(
             requestDecoder: JSONDecoder(),
             responseEncoder: JSONEncoder(),
-            eventLoop: eventLoop,
             allocator: allocator,
             logger: logger
         )

--- a/Tests/HummingbirdRouterTests/RouterTests.swift
+++ b/Tests/HummingbirdRouterTests/RouterTests.swift
@@ -440,9 +440,9 @@ public struct HBTestRouterContext2: HBRouterRequestContext, HBRequestContext {
     /// additional data
     public var string: String
 
-    public init(eventLoop: EventLoop, allocator: ByteBufferAllocator, logger: Logger) {
+    public init(allocator: ByteBufferAllocator, logger: Logger) {
         self.routerContext = .init()
-        self.coreContext = .init(eventLoop: eventLoop, allocator: allocator, logger: logger)
+        self.coreContext = .init(allocator: allocator, logger: logger)
         self.string = ""
     }
 }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -390,8 +390,8 @@ final class ApplicationTests: XCTestCase {
 
     func testMaxUploadSize() async throws {
         struct MaxUploadRequestContext: HBRequestContext {
-            init(eventLoop: EventLoop, allocator: ByteBufferAllocator, logger: Logger) {
-                self.coreContext = .init(eventLoop: eventLoop, allocator: allocator, logger: logger)
+            init(allocator: ByteBufferAllocator, logger: Logger) {
+                self.coreContext = .init(allocator: allocator, logger: logger)
             }
 
             var coreContext: HBCoreRequestContext
@@ -431,12 +431,12 @@ final class ApplicationTests: XCTestCase {
                 channel: Channel,
                 logger: Logger
             ) {
-                self.coreContext = .init(eventLoop: channel.eventLoop, allocator: channel.allocator, logger: logger)
+                self.coreContext = .init(allocator: channel.allocator, logger: logger)
                 self.remoteAddress = channel.remoteAddress
             }
 
-            init(eventLoop: EventLoop, allocator: ByteBufferAllocator, logger: Logger) {
-                self.coreContext = .init(eventLoop: eventLoop, allocator: allocator, logger: logger)
+            init(allocator: ByteBufferAllocator, logger: Logger) {
+                self.coreContext = .init(allocator: allocator, logger: logger)
                 self.remoteAddress = nil
             }
         }

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -372,11 +372,10 @@ final class RouterTests: XCTestCase {
 
 public struct HBTestRouterContext2: HBRequestContext {
     public init(
-        eventLoop: EventLoop,
         allocator: ByteBufferAllocator,
         logger: Logger
     ) {
-        self.coreContext = .init(eventLoop: eventLoop, allocator: allocator, logger: logger)
+        self.coreContext = .init(allocator: allocator, logger: logger)
         self.string = ""
     }
 


### PR DESCRIPTION
The EventLoop as part of the request context does not make sense anymore as we are not running on it anymore.