### PR TITLE
Add RequestID to generate unique Identifier for each request

### DIFF
--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2022 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Atomics
 import HummingbirdCore
 import Logging
 import NIOConcurrencyHelpers
@@ -106,7 +105,7 @@ public struct HBRequest: Sendable, HBSendableExtensible {
             context: context
         )
         self.body = body
-        self.logger = application.logger.with(metadataKey: "hb_id", value: .stringConvertible(Self.globalRequestID.loadThenWrappingIncrement(by: 1, ordering: .relaxed)))
+        self.logger = application.logger.with(metadataKey: "hb_id", value: .stringConvertible(RequestID()))
         self.extensions = .init()
     }
 
@@ -215,8 +214,6 @@ public struct HBRequest: Sendable, HBSendableExtensible {
     }
 
     private var _internal: _Internal
-
-    private static let globalRequestID = ManagedAtomic(0)
 }
 
 extension Logger {

--- a/Sources/Hummingbird/Server/RequestID.swift
+++ b/Sources/Hummingbird/Server/RequestID.swift
@@ -17,15 +17,13 @@ import Atomics
 /// Generate Unique ID for each request
 struct RequestID: CustomStringConvertible {
     let low: UInt64
-    let high: UInt64
 
     init() {
         self.low = Self.globalRequestID.loadThenWrappingIncrement(by: 1, ordering: .relaxed)
-        self.high = Self.instanceIdentifier
     }
 
     var description: String {
-        String(self.high, radix: 16) + self.formatAsHexWithLeadingZeros(self.low)
+        String(Self.high, radix: 16) + self.formatAsHexWithLeadingZeros(self.low)
     }
 
     func formatAsHexWithLeadingZeros(_ value: UInt64) -> String {
@@ -37,6 +35,6 @@ struct RequestID: CustomStringConvertible {
         }
     }
 
-    private static let instanceIdentifier = UInt64.random(in: .min ... .max)
+    private static let high = UInt64.random(in: .min ... .max)
     private static let globalRequestID = ManagedAtomic<UInt64>(UInt64.random(in: .min ... .max))
 }

--- a/Sources/Hummingbird/Server/RequestID.swift
+++ b/Sources/Hummingbird/Server/RequestID.swift
@@ -23,7 +23,7 @@ struct RequestID: CustomStringConvertible {
     }
 
     var description: String {
-        String(Self.high, radix: 16) + self.formatAsHexWithLeadingZeros(self.low)
+        Self.high + self.formatAsHexWithLeadingZeros(self.low)
     }
 
     func formatAsHexWithLeadingZeros(_ value: UInt64) -> String {
@@ -35,6 +35,6 @@ struct RequestID: CustomStringConvertible {
         }
     }
 
-    private static let high = UInt64.random(in: .min ... .max)
+    private static let high = String(UInt64.random(in: .min ... .max), radix: 16)
     private static let globalRequestID = ManagedAtomic<UInt64>(UInt64.random(in: .min ... .max))
 }

--- a/Sources/Hummingbird/Server/RequestID.swift
+++ b/Sources/Hummingbird/Server/RequestID.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Atomics
+
+/// Generate Unique ID for each request
+struct RequestID: CustomStringConvertible {
+    let low: UInt64
+    let high: UInt64
+
+    init() {
+        self.low = Self.globalRequestID.loadThenWrappingIncrement(by: 1, ordering: .relaxed)
+        self.high = Self.instanceIdentifier
+    }
+
+    var description: String {
+        self.formatAsHexWithLeadingZeros(self.high) + self.formatAsHexWithLeadingZeros(self.low)
+    }
+
+    func formatAsHexWithLeadingZeros(_ value: UInt64) -> String {
+        let string = String(value, radix: 16)
+        if string.count < 16 {
+            return String(repeating: "0", count: 16 - string.count) + string
+        } else {
+            return string
+        }
+    }
+
+    private static let instanceIdentifier = UInt64.random(in: .min ... .max)
+    private static let globalRequestID = ManagedAtomic<UInt64>(UInt64.random(in: .min ... .max))
+}

--- a/Sources/Hummingbird/Server/RequestID.swift
+++ b/Sources/Hummingbird/Server/RequestID.swift
@@ -25,7 +25,7 @@ struct RequestID: CustomStringConvertible {
     }
 
     var description: String {
-        self.formatAsHexWithLeadingZeros(self.high) + self.formatAsHexWithLeadingZeros(self.low)
+        String(self.high, radix: 16) + self.formatAsHexWithLeadingZeros(self.low)
     }
 
     func formatAsHexWithLeadingZeros(_ value: UInt64) -> String {


### PR DESCRIPTION
Previously this was just an incrementing `Int`, but it was pointed out that ids across instances of an Hummingbird app would clash as they all started at zero. This is now two integers one identifying the instance and the other an incrementing `UInt64` started at a random point in its range. This has all been encapsulated in a `RequestID` type.