### PR TITLE
2.x.x - Add HBApplication.init(router:...)

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -203,6 +203,26 @@ public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel
         self.services = []
     }
 
+    /// Initialize new Application
+    public init<Context>(
+        router: HBRouter<Context>,
+        server: HBHTTPChannelBuilder<ChildChannel> = .http1(),
+        configuration: HBApplicationConfiguration = HBApplicationConfiguration(),
+        eventLoopGroupProvider: EventLoopGroupProvider = .singleton
+    ) where Responder == HBRouterResponder<Context> {
+        var logger = Logger(label: configuration.serverName ?? "HummingBird")
+        logger.logLevel = configuration.logLevel
+        self.logger = logger
+
+        self.responder = router.buildResponder()
+        self.server = server
+        self.configuration = configuration
+        self._onServerRunning = { _ in }
+
+        self.eventLoopGroup = eventLoopGroupProvider.eventLoopGroup
+        self.services = []
+    }
+
     // MARK: Methods
 
     ///  Add service to be managed by application ServiceGroup

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -66,7 +66,7 @@ public final class HBRouter<Context: HBBaseRequestContext>: HBRouterMethods {
     }
 
     /// build router
-    public func buildResponder() -> some HBResponder<Context> {
+    public func buildResponder() -> HBRouterResponder<Context> {
         HBRouterResponder(context: Context.self, trie: self.trie.build(), notFoundResponder: self.middlewares.constructResponder(finalResponder: NotFoundResponder<Context>()))
     }
 

--- a/Sources/Hummingbird/Router/RouterResponder.swift
+++ b/Sources/Hummingbird/Router/RouterResponder.swift
@@ -17,7 +17,7 @@
 /// Conforms to `HBResponder` so need to provide its own implementation of
 /// `func respond(to request: HBRequest, context: Context) async throws -> HBResponse`.
 ///
-struct HBRouterResponder<Context: HBBaseRequestContext>: HBResponder {
+public struct HBRouterResponder<Context: HBBaseRequestContext>: HBResponder {
     let trie: RouterPathTrie<HBEndpointResponders<Context>>
     let notFoundResponder: any HBResponder<Context>
 

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -571,6 +571,25 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
+    /// test we can create out own application type conforming to HBApplicationProtocol
+    func testApplicationRouterInit() async throws {
+        let router = HBRouter()
+        router.get("/") { _, _ -> String in
+            "Hello"
+        }
+        let app = HBApplication(router: router)
+        try await app.test(.live) { client in
+            try await client.XCTExecute(uri: "/", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+                let body = try XCTUnwrap(response.body)
+                let string = String(buffer: body)
+                XCTAssertEqual(string, "Hello")
+            }
+        }
+    }
+
+    // MARK: Helper functions
+
     func getServerTLSConfiguration() throws -> TLSConfiguration {
         let caCertificate = try NIOSSLCertificate(bytes: [UInt8](caCertificateData.utf8), format: .pem)
         let certificate = try NIOSSLCertificate(bytes: [UInt8](serverCertificateData.utf8), format: .pem)


### PR DESCRIPTION
Add `HBApplication(router:server:configuration:eventLoopGroupProvider:)`. Removes requirement for calling `buildResponder` therefore cleaner API

Need to make HBRouterResponder public and explicitly return it from `buildResponder` to get this to work
