### PR TITLE
2.x.x - Change parameter capture syntax to same as OpenAPI

### DIFF
--- a/Sources/Hummingbird/Router/RouterPath.swift
+++ b/Sources/Hummingbird/Router/RouterPath.swift
@@ -30,11 +30,11 @@ public struct RouterPath: Sendable, ExpressibleByStringLiteral, CustomStringConv
             case .path(let path):
                 return String(path)
             case .capture(let parameter):
-                return "${\(parameter)}"
+                return "{\(parameter)}"
             case .prefixCapture(let suffix, let parameter):
-                return "${\(parameter)}\(suffix)"
+                return "{\(parameter)}\(suffix)"
             case .suffixCapture(let prefix, let parameter):
-                return "\(prefix)${\(parameter)}"
+                return "\(prefix){\(parameter)}"
             case .wildcard:
                 return "*"
             case .prefixWildcard(let suffix):
@@ -88,8 +88,8 @@ public struct RouterPath: Sendable, ExpressibleByStringLiteral, CustomStringConv
         self.components = split.map { component in
             if component.first == ":" {
                 return .capture(component.dropFirst())
-            } else if component.first == "$", component.count > 1, component[component.index(after: component.startIndex)] == "{" {
-                let parameter = component.dropFirst(2)
+            } else if component.first == "{" {
+                let parameter = component.dropFirst(1)
                 if let closingParethesis = parameter.firstIndex(of: "}") {
                     let charAfterClosingParethesis = parameter.index(after: closingParethesis)
                     return .prefixCapture(suffix: parameter[charAfterClosingParethesis...], parameter: parameter[..<closingParethesis])
@@ -99,11 +99,8 @@ public struct RouterPath: Sendable, ExpressibleByStringLiteral, CustomStringConv
             } else if component.last == "}" {
                 let parameter = component.dropLast()
                 if let openingParenthesis = parameter.lastIndex(of: "{"), openingParenthesis != parameter.startIndex {
-                    let dollar = component.index(before: openingParenthesis)
-                    if component[dollar] == "$" {
-                        let charAfterOpeningParenthesis = parameter.index(after: openingParenthesis)
-                        return .suffixCapture(prefix: parameter[..<dollar], parameter: parameter[charAfterOpeningParenthesis...])
-                    }
+                    let charAfterOpeningParenthesis = parameter.index(after: openingParenthesis)
+                    return .suffixCapture(prefix: parameter[..<openingParenthesis], parameter: parameter[charAfterOpeningParenthesis...])
                 }
                 return .path(component)
             } else if component == "*" {

--- a/Tests/HummingbirdRouterTests/RouterTests.swift
+++ b/Tests/HummingbirdRouterTests/RouterTests.swift
@@ -46,7 +46,7 @@ final class RouterTests: XCTestCase {
 
         let router = HBRouterBuilder(context: HBBasicRouterRequestContext.self) {
             TestEndpointMiddleware()
-            Get("/test/:number") { _, _ in
+            Get("/test/{number}") { _, _ in
                 return "xxx"
             }
         }
@@ -55,7 +55,7 @@ final class RouterTests: XCTestCase {
         try await app.test(.router) { client in
             try await client.XCTExecute(uri: "/test/1", method: .get) { response in
                 let body = try XCTUnwrap(response.body)
-                XCTAssertEqual(String(buffer: body), "/test/${number}")
+                XCTAssertEqual(String(buffer: body), "/test/{number}")
             }
         }
     }
@@ -357,7 +357,7 @@ final class RouterTests: XCTestCase {
 
     func testPartialCapture() async throws {
         let router = HBRouterBuilder(context: HBBasicRouterRequestContext.self) {
-            Get("/files/file.${ext}/${name}.jpg") { _, context -> String in
+            Get("/files/file.{ext}/{name}.jpg") { _, context -> String in
                 XCTAssertEqual(context.parameters.count, 2)
                 let ext = try context.parameters.require("ext")
                 let name = try context.parameters.require("name")

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -301,7 +301,7 @@ final class RouterTests: XCTestCase {
     func testPartialCapture() async throws {
         let router = HBRouter()
         router
-            .get("/files/file.${ext}/${name}.jpg") { _, context -> String in
+            .get("/files/file.{ext}/{name}.jpg") { _, context -> String in
                 XCTAssertEqual(context.parameters.count, 2)
                 let ext = try context.parameters.require("ext")
                 let name = try context.parameters.require("name")

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -112,9 +112,9 @@ class TrieRouterTests: XCTestCase {
 
     func testPrefixCapture() {
         let trieBuilder = RouterPathTrieBuilder<String>()
-        trieBuilder.addEntry("${file}.jpg", value: "jpg")
-        trieBuilder.addEntry("test/${file}.jpg", value: "testjpg")
-        trieBuilder.addEntry("${app}.app/config.json", value: "app")
+        trieBuilder.addEntry("{file}.jpg", value: "jpg")
+        trieBuilder.addEntry("test/{file}.jpg", value: "testjpg")
+        trieBuilder.addEntry("{app}.app/config.json", value: "app")
         let trie = trieBuilder.build()
         XCTAssertNil(trie.getValueAndParameters("/hello.png"))
         XCTAssertEqual(trie.getValueAndParameters("/hello.jpg")?.parameters?.get("file"), "hello")
@@ -124,9 +124,9 @@ class TrieRouterTests: XCTestCase {
 
     func testSuffixCapture() {
         let trieBuilder = RouterPathTrieBuilder<String>()
-        trieBuilder.addEntry("file.${ext}", value: "file")
-        trieBuilder.addEntry("test/file.${ext}", value: "testfile")
-        trieBuilder.addEntry("file.${ext}/test", value: "filetest")
+        trieBuilder.addEntry("file.{ext}", value: "file")
+        trieBuilder.addEntry("test/file.{ext}", value: "testfile")
+        trieBuilder.addEntry("file.{ext}/test", value: "filetest")
         let trie = trieBuilder.build()
         XCTAssertNil(trie.getValueAndParameters("/file2.png"))
         XCTAssertEqual(trie.getValueAndParameters("/file.jpg")?.parameters?.get("ext"), "jpg")
@@ -136,7 +136,7 @@ class TrieRouterTests: XCTestCase {
 
     func testPrefixFullComponentCapture() {
         let trieBuilder = RouterPathTrieBuilder<String>()
-        trieBuilder.addEntry("${text}", value: "test")
+        trieBuilder.addEntry("{text}", value: "test")
         let trie = trieBuilder.build()
         XCTAssertEqual(trie.getValueAndParameters("/file.jpg")?.parameters?.get("text"), "file.jpg")
     }


### PR DESCRIPTION
In v1.0 to support prefix and suffix URI parameters we added a new syntax for defining extracted parameters `${parameter}`. Since then the OpenAPI runtime has come on line and it seems more sensible to duplicate the syntax OpenAPI has `{parameter}`. ie remove the `$`