### PR TITLE
HBRequest.collateBody

### DIFF
--- a/Benchmarks/Benchmarks/Router/RouterBenchmarks.swift
+++ b/Benchmarks/Benchmarks/Router/RouterBenchmarks.swift
@@ -106,7 +106,7 @@ func routerBenchmarks() {
         await bodyStream.send(buffer)
     } setupRouter: { router in
         router.put { request, _ in
-            let body = try await request.body.collect(upTo: .max)
+            let body = try await request.body.collate(maxSize: .max)
             return body.readableBytes.description
         }
     }

--- a/Sources/Hummingbird/Server/Request.swift
+++ b/Sources/Hummingbird/Server/Request.swift
@@ -15,6 +15,20 @@
 import HummingbirdCore
 
 extension HBRequest {
+    /// Collapse body into one ByteBuffer.
+    ///
+    /// This will store the collated ByteBuffer back into the request so is a mutating method. If
+    /// you don't need to store the collated ByteBuffer on the request then use
+    /// `request.body.collate(maxSize:)`.
+    ///
+    /// - Parameter context: request context
+    /// - Returns: Collated body
+    public mutating func collateBody(context: some HBBaseRequestContext) async throws -> ByteBuffer {
+        let byteBuffer = try await self.body.collate(maxSize: context.maxUploadSize)
+        self.body = .byteBuffer(byteBuffer)
+        return byteBuffer
+    }
+
     /// Decode request using decoder stored at `HBApplication.decoder`.
     /// - Parameter type: Type you want to decode to
     public func decode<Type: Decodable>(as type: Type.Type, using context: some HBBaseRequestContext) async throws -> Type {

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -33,13 +33,14 @@ public enum HBRequestBody: Sendable, AsyncSequence {
         }
     }
 
-    /// Return new HBRequestBody as a single ByteBuffer
-    public func collate(maxSize: Int) async throws -> HBRequestBody {
+    /// Return as a single ByteBuffer. This function is required as `ByteBuffer.collect(upTo:)`
+    /// assumes the request body can be iterated.
+    public func collate(maxSize: Int) async throws -> ByteBuffer {
         switch self {
-        case .byteBuffer:
-            return self
-        case .stream(let streamer):
-            return try await .byteBuffer(streamer.collect(upTo: maxSize))
+        case .byteBuffer(let buffer):
+            return buffer
+        case .stream:
+            return try await collect(upTo: maxSize)
         }
     }
 }

--- a/Sources/HummingbirdFoundation/Codable/JSON/JSONCoding.swift
+++ b/Sources/HummingbirdFoundation/Codable/JSON/JSONCoding.swift
@@ -41,7 +41,7 @@ extension JSONDecoder: HBRequestDecoder {
     ///   - type: Type to decode
     ///   - request: Request to decode from
     public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) async throws -> T {
-        let buffer = try await request.body.collect(upTo: context.maxUploadSize)
+        let buffer = try await request.body.collate(maxSize: context.maxUploadSize)
         return try self.decode(T.self, from: buffer)
     }
 }

--- a/Sources/HummingbirdFoundation/Codable/URLEncodedForm/URLEncodedForm+Request.swift
+++ b/Sources/HummingbirdFoundation/Codable/URLEncodedForm/URLEncodedForm+Request.swift
@@ -37,7 +37,7 @@ extension URLEncodedFormDecoder: HBRequestDecoder {
     ///   - type: Type to decode
     ///   - request: Request to decode from
     public func decode<T: Decodable>(_ type: T.Type, from request: HBRequest, context: some HBBaseRequestContext) async throws -> T {
-        let buffer = try await request.body.collect(upTo: context.maxUploadSize)
+        let buffer = try await request.body.collate(maxSize: context.maxUploadSize)
         let string = String(buffer: buffer)
         return try self.decode(T.self, from: string)
     }

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -93,7 +93,7 @@ class HummingBirdCoreTests: XCTestCase {
     func testConsumeBody() async throws {
         try await testServer(
             responder: { request, _ in
-                let buffer = try await request.body.collect(upTo: .max)
+                let buffer = try await request.body.collate(maxSize: .max)
                 return HBResponse(status: .ok, body: .init(byteBuffer: buffer))
             },
             configuration: .init(address: .hostname(port: 0)),
@@ -198,7 +198,7 @@ class HummingBirdCoreTests: XCTestCase {
         }
         try await testServer(
             responder: { request, _ in
-                _ = try await request.body.collect(upTo: .max)
+                _ = try await request.body.collate(maxSize: .max)
                 return HBResponse(status: .ok)
             },
             httpChannelSetup: .http1(additionalChannelHandlers: [CreateErrorHandler()]),
@@ -264,7 +264,7 @@ class HummingBirdCoreTests: XCTestCase {
         }
         try await testServer(
             responder: { request, _ in
-                _ = try await request.body.collect(upTo: .max)
+                _ = try await request.body.collate(maxSize: .max)
                 return .init(status: .ok)
             },
             httpChannelSetup: .http1(additionalChannelHandlers: [HTTPServerIncompleteRequest(), IdleStateHandler(readTimeout: .seconds(1))]),
@@ -287,7 +287,7 @@ class HummingBirdCoreTests: XCTestCase {
     func testWriteIdleTimeout() async throws {
         try await testServer(
             responder: { request, _ in
-                _ = try await request.body.collect(upTo: .max)
+                _ = try await request.body.collate(maxSize: .max)
                 return .init(status: .ok)
             },
             httpChannelSetup: .http1(additionalChannelHandlers: [IdleStateHandler(writeTimeout: .seconds(1))]),

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -275,7 +275,7 @@ final class ApplicationTests: XCTestCase {
         struct CollateMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
             public func handle(_ request: HBRequest, context: Context, next: (HBRequest, Context) async throws -> HBResponse) async throws -> HBResponse {
                 var request = request
-                request.body = try await request.body.collate(maxSize: context.maxUploadSize)
+                _ = try await request.collateBody(context: context)
                 return try await next(request, context)
             }
         }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -204,7 +204,7 @@ final class ApplicationTests: XCTestCase {
         router
             .group("/echo-body")
             .post { request, _ -> HBResponse in
-                let buffer = try await request.body.collect(upTo: .max)
+                let buffer = try await request.body.collate(maxSize: .max)
                 return .init(status: .ok, headers: [:], body: .init(byteBuffer: buffer))
             }
         let app = HBApplication(responder: router.buildResponder())
@@ -301,7 +301,7 @@ final class ApplicationTests: XCTestCase {
         router
             .group("/echo-body")
             .post { request, _ -> ByteBuffer? in
-                let buffer = try await request.body.collect(upTo: .max)
+                let buffer = try await request.body.collate(maxSize: .max)
                 return buffer.readableBytes > 0 ? buffer : nil
             }
         let app = HBApplication(responder: router.buildResponder())

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -24,14 +24,14 @@ final class PersistTests: XCTestCase {
         let persist = HBMemoryPersistDriver()
 
         router.put("/persist/:tag") { request, context -> HTTPResponse.Status in
-            let buffer = try await request.body.collect(upTo: .max)
+            let buffer = try await request.body.collate(maxSize: .max)
             let tag = try context.parameters.require("tag")
             try await persist.set(key: tag, value: String(buffer: buffer))
             return .ok
         }
         router.put("/persist/:tag/:time") { request, context -> HTTPResponse.Status in
             guard let time = context.parameters.get("time", as: Int.self) else { throw HBHTTPError(.badRequest) }
-            let buffer = try await request.body.collect(upTo: .max)
+            let buffer = try await request.body.collate(maxSize: .max)
             let tag = try context.parameters.require("tag")
             try await persist.set(key: tag, value: String(buffer: buffer), expires: .seconds(time))
             return .ok
@@ -65,7 +65,7 @@ final class PersistTests: XCTestCase {
         let (router, persist) = try createRouter()
 
         router.put("/create/:tag") { request, context -> HTTPResponse.Status in
-            let buffer = try await request.body.collect(upTo: .max)
+            let buffer = try await request.body.collate(maxSize: .max)
             let tag = try context.parameters.require("tag")
             try await persist.create(key: tag, value: String(buffer: buffer))
             return .ok
@@ -84,7 +84,7 @@ final class PersistTests: XCTestCase {
     func testDoubleCreateFail() async throws {
         let (router, persist) = try createRouter()
         router.put("/create/:tag") { request, context -> HTTPResponse.Status in
-            let buffer = try await request.body.collect(upTo: .max)
+            let buffer = try await request.body.collate(maxSize: .max)
             let tag = try context.parameters.require("tag")
             do {
                 try await persist.create(key: tag, value: String(buffer: buffer))
@@ -154,7 +154,7 @@ final class PersistTests: XCTestCase {
         let (router, persist) = try createRouter()
         router.put("/codable/:tag") { request, context -> HTTPResponse.Status in
             guard let tag = context.parameters.get("tag") else { throw HBHTTPError(.badRequest) }
-            let buffer = try await request.body.collect(upTo: .max)
+            let buffer = try await request.body.collate(maxSize: .max)
             try await persist.set(key: tag, value: TestCodable(buffer: String(buffer: buffer)))
             return .ok
         }


### PR DESCRIPTION
There is an issue with the current API for read request bodies. As it is a stream of ByteBuffers you can read it only once. I had to provide a solution for someone who wants to read the request body in middleware (never a great idea) but still have it available for route handlers.

With the current setup it is very difficult to get the contents of the request a second time if it has been collated into one buffer previously.

The changes I've made change the `HBRequestBody.collate(maxSize:)`  to return a ByteBuffer instead of a new `HBRequestBody` and this should be the function people use instead of `AsyncSequence.collect(upTo:)`. I've also added a helper function that collates the request body in place in a request which can be used by Middleware if they need it.