### PR TITLE
2.x.x - Add HBParameter by UUID conversion functions

### DIFF
--- a/Sources/Hummingbird/Router/Parameters.swift
+++ b/Sources/Hummingbird/Router/Parameters.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2022 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -69,7 +69,7 @@ public extension HBParameters {
     ///   - s: parameter id
     ///   - as: type we want returned
     func requireAll<T: LosslessStringConvertible>(_ s: String, as: T.Type) throws -> [T] {
-        return try self[values: s[...]].compactMap {
+        return try self[values: s[...]].map {
             guard let result = T(String($0)) else {
                 throw HBHTTPError(.badRequest)
             }

--- a/Sources/HummingbirdFoundation/Extensions/Parameters+UUID.swift
+++ b/Sources/HummingbirdFoundation/Extensions/Parameters+UUID.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Hummingbird
+
+/// It is common for UUID's to be passed in as parameters. So lets add helper
+/// functions to extract them from HBParameters
+public extension HBParameters {
+    /// Return parameter with specified id as a certain type
+    /// - Parameters:
+    ///   - s: parameter id
+    ///   - as: type we want returned
+    func get(_ s: String, as: UUID.Type) -> UUID? {
+        return self[s[...]].map { UUID(uuidString: String($0)) } ?? nil
+    }
+
+    /// Return parameter with specified id as a certain type
+    /// - Parameters:
+    ///   - s: parameter id
+    ///   - as: type we want returned
+    func require(_ s: String, as: UUID.Type) throws -> UUID {
+        guard let param = self[s[...]],
+              let result = UUID(uuidString: String(param))
+        else {
+            throw HBHTTPError(.badRequest)
+        }
+        return result
+    }
+
+    /// Return parameter with specified id as a certain type
+    /// - Parameters:
+    ///   - s: parameter id
+    ///   - as: type we want returned
+    func getAll(_ s: String, as: UUID.Type) -> [UUID] {
+        return self[values: s[...]].compactMap { UUID(uuidString: String($0)) }
+    }
+
+    /// Return parameter with specified id as a certain type
+    /// - Parameters:
+    ///   - s: parameter id
+    ///   - as: type we want returned
+    func requireAll(_ s: String, as: UUID.Type) throws -> [UUID] {
+        return try self[values: s[...]].map {
+            guard let result = UUID(uuidString: String($0)) else {
+                throw HBHTTPError(.badRequest)
+            }
+            return result
+        }
+    }
+}

--- a/Sources/HummingbirdFoundation/Utils/UUID.swift
+++ b/Sources/HummingbirdFoundation/Utils/UUID.swift
@@ -17,12 +17,12 @@ import Hummingbird
 
 /// It is common for UUID's to be passed in as parameters. So lets add helper
 /// functions to extract them from HBParameters
-public extension HBParameters {
+extension HBParameters {
     /// Return parameter with specified id as a certain type
     /// - Parameters:
     ///   - s: parameter id
     ///   - as: type we want returned
-    func get(_ s: String, as: UUID.Type) -> UUID? {
+    public func get(_ s: String, as: UUID.Type) -> UUID? {
         return self[s[...]].map { UUID(uuidString: String($0)) } ?? nil
     }
 
@@ -30,7 +30,7 @@ public extension HBParameters {
     /// - Parameters:
     ///   - s: parameter id
     ///   - as: type we want returned
-    func require(_ s: String, as: UUID.Type) throws -> UUID {
+    public func require(_ s: String, as: UUID.Type) throws -> UUID {
         guard let param = self[s[...]],
               let result = UUID(uuidString: String(param))
         else {
@@ -43,7 +43,7 @@ public extension HBParameters {
     /// - Parameters:
     ///   - s: parameter id
     ///   - as: type we want returned
-    func getAll(_ s: String, as: UUID.Type) -> [UUID] {
+    public func getAll(_ s: String, as: UUID.Type) -> [UUID] {
         return self[values: s[...]].compactMap { UUID(uuidString: String($0)) }
     }
 
@@ -51,7 +51,7 @@ public extension HBParameters {
     /// - Parameters:
     ///   - s: parameter id
     ///   - as: type we want returned
-    func requireAll(_ s: String, as: UUID.Type) throws -> [UUID] {
+    public func requireAll(_ s: String, as: UUID.Type) throws -> [UUID] {
         return try self[values: s[...]].map {
             guard let result = UUID(uuidString: String($0)) else {
                 throw HBHTTPError(.badRequest)
@@ -60,3 +60,5 @@ public extension HBParameters {
         }
     }
 }
+
+extension UUID: HBResponseEncodable {}

--- a/Tests/HummingbirdFoundationTests/UUIDTests.swift
+++ b/Tests/HummingbirdFoundationTests/UUIDTests.swift
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+import HummingbirdFoundation
+import Logging
+import XCTest
+
+final class UUIDTests: XCTestCase {
+    /// Custom request context setting up JSON decoding and encoding
+    struct JSONRequestContext: HBRequestContext {
+        // Requirement of `HBRequestContext`
+        var coreContext: HBCoreRequestContext
+
+        init(allocator: ByteBufferAllocator, logger: Logger) {
+            self.coreContext = .init(
+                requestDecoder: JSONDecoder(),
+                responseEncoder: JSONEncoder(),
+                allocator: allocator,
+                logger: logger
+            )
+        }
+    }
+
+    func testGetUUID() async throws {
+        let router = HBRouter(context: JSONRequestContext.self)
+        router.get(":id") { _, context -> UUID? in
+            return context.parameters.get("id", as: UUID.self)
+        }
+        let app = HBApplication(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            let uuid = UUID()
+            try await client.XCTExecute(uri: "\(uuid)", method: .get) { response in
+                let body = try XCTUnwrap(response.body)
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertEqual(String(buffer: body), "\"\(uuid.uuidString)\"")
+            }
+        }
+    }
+
+    func testRequireUUID() async throws {
+        let router = HBRouter(context: JSONRequestContext.self)
+        router.get(":id") { _, context -> UUID in
+            return try context.parameters.require("id", as: UUID.self)
+        }
+        let app = HBApplication(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            let uuid = UUID()
+            try await client.XCTExecute(uri: "\(uuid)", method: .get) { response in
+                let body = try XCTUnwrap(response.body)
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertEqual(String(buffer: body), "\"\(uuid.uuidString)\"")
+            }
+        }
+    }
+
+    func testGetUUIDs() async throws {
+        let router = HBRouter(context: JSONRequestContext.self)
+        router.get { request, _ -> [UUID] in
+            let queryParameters = request.uri.queryParameters
+            return queryParameters.getAll("id", as: UUID.self)
+        }
+        let app = HBApplication(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            let uuid = UUID()
+            let uuid2 = UUID()
+            try await client.XCTExecute(uri: "/?id=\(uuid)&id=\(uuid2)&id=Wrong", method: .get) { response in
+                let body = try XCTUnwrap(response.body)
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertEqual(String(buffer: body), "[\"\(uuid.uuidString)\",\"\(uuid2.uuidString)\"]")
+            }
+        }
+    }
+
+    func testRequireUUIDs() async throws {
+        let router = HBRouter(context: JSONRequestContext.self)
+        router.get { request, _ -> [UUID] in
+            let queryParameters = request.uri.queryParameters
+            return try queryParameters.requireAll("id", as: UUID.self)
+        }
+        let app = HBApplication(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            let uuid = UUID()
+            let uuid2 = UUID()
+            // test good request
+            try await client.XCTExecute(uri: "/?id=\(uuid)&id=\(uuid2)", method: .get) { response in
+                let body = try XCTUnwrap(response.body)
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertEqual(String(buffer: body), "[\"\(uuid.uuidString)\",\"\(uuid2.uuidString)\"]")
+            }
+            // test bad request
+            try await client.XCTExecute(uri: "/?id=\(uuid)&id=\(uuid2)&id=Wrong", method: .get) { response in
+                XCTAssertEqual(response.status, .badRequest)
+            }
+        }
+    }
+}


### PR DESCRIPTION
UUIDs are common parameter types, but they do not conform to LosslessStringConvertible so need custom conversion functions