### PR TITLE
2.x.x - Run process before server start

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -184,7 +184,7 @@ public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel
     public let server: HBHTTPChannelBuilder<ChildChannel>
     /// services attached to the application.
     public var services: [any Service]
-    /// processed to be run before server is started
+    /// Processes to be run before server is started
     public private(set) var processesRunBeforeServerStart: [@Sendable () async throws -> Void]
 
     // MARK: Initialization

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2023 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -64,6 +64,9 @@ public protocol HBApplicationProtocol: Service where Context: HBRequestContext {
     @Sendable func onServerRunning(_ channel: Channel) async
     /// services attached to the application.
     var services: [any Service] { get }
+    /// Array of processes run before we kick off the server. These tend to be processes that need
+    /// other services running but need to be run before the server is setup
+    var processesRunBeforeServerStart: [@Sendable () async throws -> Void] { get }
 }
 
 extension HBApplicationProtocol {
@@ -82,6 +85,8 @@ extension HBApplicationProtocol {
     public func onServerRunning(_: Channel) async {}
     /// Default to no extra services attached to the application.
     public var services: [any Service] { [] }
+    /// Default to no processes being run before the server is setup
+    public var processesRunBeforeServerStart: [@Sendable () async throws -> Void] { [] }
 }
 
 /// Conform to `Service` from `ServiceLifecycle`.
@@ -116,7 +121,12 @@ extension HBApplicationProtocol {
             eventLoopGroup: self.eventLoopGroup,
             logger: self.logger
         )
-        let services: [any Service] = self.services + [dateCache, server]
+        let serverService = PrecursorService(service: server) {
+            for process in self.processesRunBeforeServerStart {
+                try await process()
+            }
+        }
+        let services: [any Service] = self.services + [dateCache, serverService]
         let serviceGroup = ServiceGroup(
             configuration: .init(services: services, logger: self.logger)
         )
@@ -174,6 +184,8 @@ public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel
     public let server: HBHTTPChannelBuilder<ChildChannel>
     /// services attached to the application.
     public var services: [any Service]
+    /// processed to be run before server is started
+    public private(set) var processesRunBeforeServerStart: [@Sendable () async throws -> Void]
 
     // MARK: Initialization
 
@@ -208,6 +220,7 @@ public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel
 
         self.eventLoopGroup = eventLoopGroupProvider.eventLoopGroup
         self.services = []
+        self.processesRunBeforeServerStart = []
     }
 
     /// Initialize new Application
@@ -241,6 +254,7 @@ public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel
 
         self.eventLoopGroup = eventLoopGroupProvider.eventLoopGroup
         self.services = []
+        self.processesRunBeforeServerStart = []
     }
 
     // MARK: Methods
@@ -249,6 +263,20 @@ public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel
     /// - Parameter services: list of services to be added
     public mutating func addServices(_ services: any Service...) {
         self.services.append(contentsOf: services)
+    }
+
+    /// Add a process to run before we kick off the server service
+    ///
+    /// This is for processes that might need another Service running but need
+    /// to run before the server has started. For example a database migration
+    /// process might need the database connection pool running but should be
+    /// finished before any request to the server can be made. Also they may be
+    /// situations where you want another Service to have fully initialized
+    /// before starting the server service.
+    ///
+    /// - Parameter process: Process to run before server is started
+    public mutating func runBeforeServerStart(_ process: @escaping @Sendable () async throws -> Void) {
+        self.processesRunBeforeServerStart.append(process)
     }
 
     public func buildResponder() async throws -> Responder {

--- a/Sources/Hummingbird/Utils/GracefulShutdownWaiter.swift
+++ b/Sources/Hummingbird/Utils/GracefulShutdownWaiter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2023 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Hummingbird/Utils/GracefulShutdownWaiter.swift
+++ b/Sources/Hummingbird/Utils/GracefulShutdownWaiter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2023 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Hummingbird/Utils/PrecursorService.swift
+++ b/Sources/Hummingbird/Utils/PrecursorService.swift
@@ -14,18 +14,18 @@
 
 import ServiceLifecycle
 
-/// Wrap another service to run after a preprocess closure has completed
-struct PreprocessService<S: Service>: Service {
-    let preprocess: @Sendable () async throws -> Void
+/// Wrap another service to run after a precursor closure has completed
+struct PrecursorService<S: Service>: Service {
+    let precursor: @Sendable () async throws -> Void
     let service: S
 
-    init(service: S, preprocess: @escaping @Sendable () async throws -> Void) {
+    init(service: S, process: @escaping @Sendable () async throws -> Void) {
         self.service = service
-        self.preprocess = preprocess
+        self.precursor = process
     }
 
     func run() async throws {
-        try await self.preprocess()
+        try await self.precursor()
         try await self.service.run()
     }
 }

--- a/Sources/Hummingbird/Utils/PrecursorService.swift
+++ b/Sources/Hummingbird/Utils/PrecursorService.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2023 the Hummingbird authors
+// Copyright (c) 2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/Hummingbird/Utils/PreprocessService.swift
+++ b/Sources/Hummingbird/Utils/PreprocessService.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import ServiceLifecycle
+
+/// Wrap another service to run after a preprocess closure has completed
+struct PreprocessService<S: Service>: Service {
+    let preprocess: @Sendable () async throws -> Void
+    let service: S
+
+    init(service: S, preprocess: @escaping @Sendable () async throws -> Void) {
+        self.service = service
+        self.preprocess = preprocess
+    }
+
+    func run() async throws {
+        try await self.preprocess()
+        try await self.service.run()
+    }
+}

--- a/Sources/HummingbirdXCT/TestApplication.swift
+++ b/Sources/HummingbirdXCT/TestApplication.swift
@@ -43,6 +43,7 @@ struct TestApplication<BaseApp: HBApplicationProtocol>: HBApplicationProtocol, S
     var logger: Logger { self.base.logger }
     /// On server running
     @Sendable func onServerRunning(_ channel: Channel) async {
+        await self.base.onServerRunning(channel)
         await self.portPromise.complete(channel.localAddress!.port!)
     }
 

--- a/Sources/HummingbirdXCT/TestApplication.swift
+++ b/Sources/HummingbirdXCT/TestApplication.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2023 the Hummingbird authors
+// Copyright (c) 2023-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -35,19 +35,22 @@ struct TestApplication<BaseApp: HBApplicationProtocol>: HBApplicationProtocol, S
         self.base.server
     }
 
-    /// event loop group used by application
+    /// Event loop group used by application
     var eventLoopGroup: EventLoopGroup { self.base.eventLoopGroup }
     /// Configuration
     var configuration: HBApplicationConfiguration { self.base.configuration.with(address: .hostname("localhost", port: 0)) }
     /// Logger
     var logger: Logger { self.base.logger }
-    /// on server running
+    /// On server running
     @Sendable func onServerRunning(_ channel: Channel) async {
         await self.portPromise.complete(channel.localAddress!.port!)
     }
 
-    /// services attached to the application.
+    /// Services attached to the application.
     var services: [any Service] { self.base.services }
+
+    /// Processes run before server start
+    public var processesRunBeforeServerStart: [@Sendable () async throws -> Void] { self.base.processesRunBeforeServerStart }
 
     let portPromise: Promise<Int> = .init()
 }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2023 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -529,6 +529,22 @@ final class ApplicationTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(10))
         }
         XCTAssertEqual(MyService.shutdown.load(ordering: .relaxed), true)
+    }
+
+    func testRunBeforeServer() async throws {
+        let runBeforeServer = ManagedAtomic(false)
+        let router = HBRouter()
+        var app = HBApplication(
+            responder: router.buildResponder()
+        )
+        app.runBeforeServerStart {
+            runBeforeServer.store(true, ordering: .relaxed)
+        }
+        try await app.test(.live) { _ in
+            // shutting down immediately outputs an error
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(runBeforeServer.load(ordering: .relaxed), true)
     }
 
     /// test we can create out own application type conforming to HBApplicationProtocol


### PR DESCRIPTION
While writing the Todos tutorial I came across an issue with database setup. There are situations where you need to do pre-processing of your database before starting the server eg running migrations. Unfortunately the new PostgresClient requires that you have a background process running, not currently managed by ServiceLifecycle but I assume it will be eventually. So you can't do the database preprocessing before the server has started because it requires the PostgresClient service to be running, which would also kick off the server service. 

This PR adds a way to add processes to be run before the server has started but while all other services are running. 

```swift
let db = DatabaseClient()
let app = HBApplication()
app.addService(db)
add.runBeforeServerStart {
    db.migrate()
}
```