### PR TITLE
Add HBResponderBuilder

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -232,14 +232,14 @@ public struct HBApplication<Responder: HBResponder, ChildChannel: HBChildChannel
     ///   - onServerRunning: Function called once the server is running
     ///   - eventLoopGroupProvider: Where to get our EventLoopGroup
     ///   - logger: Logger application uses
-    public init<Context>(
-        router: HBRouter<Context>,
+    public init<ResponderBuilder: HBResponderBuilder>(
+        router: ResponderBuilder,
         server: HBHTTPChannelBuilder<ChildChannel> = .http1(),
         configuration: HBApplicationConfiguration = HBApplicationConfiguration(),
         onServerRunning: @escaping @Sendable (Channel) async -> Void = { _ in },
         eventLoopGroupProvider: EventLoopGroupProvider = .singleton,
         logger: Logger? = nil
-    ) where Responder == HBRouterResponder<Context> {
+    ) where Responder == ResponderBuilder.Responder {
         if let logger {
             self.logger = logger
         } else {

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -43,7 +43,7 @@ import NIOCore
 /// Both of these match routes which start with "/user" and the next path segment being anything.
 /// The second version extracts the path segment out and adds it to `HBRequest.parameters` with the
 /// key "id".
-public final class HBRouter<Context: HBBaseRequestContext>: HBRouterMethods {
+public final class HBRouter<Context: HBBaseRequestContext>: HBRouterMethods, HBResponderBuilder {
     var trie: RouterPathTrieBuilder<HBEndpointResponders<Context>>
     public let middlewares: HBMiddlewareGroup<Context>
 
@@ -94,4 +94,11 @@ struct NotFoundResponder<Context: HBBaseRequestContext>: HBResponder {
     func respond(to request: HBRequest, context: Context) throws -> HBResponse {
         throw HBHTTPError(.notFound)
     }
+}
+
+/// A type that has a single method to build a responder
+public protocol HBResponderBuilder {
+    associatedtype Responder: HBResponder
+    /// build a responder
+    func buildResponder() -> Responder
 }

--- a/Sources/HummingbirdRouter/RouterBuilder.swift
+++ b/Sources/HummingbirdRouter/RouterBuilder.swift
@@ -67,10 +67,14 @@ public struct HBRouterBuilder<Context: HBRouterRequestContext, Handler: Middlewa
 }
 
 /// extend Router to conform to HBResponder so we can use it to process `HBRequest``
-extension HBRouterBuilder: HBResponder {
+extension HBRouterBuilder: HBResponder, HBResponderBuilder {
     public func respond(to request: Input, context: Context) async throws -> Output {
         try await self.handle(request, context: context) { _, _ in
             throw HBHTTPError(.notFound)
         }
+    }
+
+    public func buildResponder() -> Self {
+        return self
     }
 }

--- a/Tests/HummingbirdRouterTests/RouterTests.swift
+++ b/Tests/HummingbirdRouterTests/RouterTests.swift
@@ -407,6 +407,20 @@ final class RouterTests: XCTestCase {
             }
         }
     }
+
+    func testResponderBuilder() async throws {
+        let router = HBRouterBuilder(context: HBBasicRouterRequestContext.self) {
+            Get("hello") { _, _ in
+                return "hello"
+            }
+        }
+        let app = HBApplication(router: router)
+        try await app.test(.router) { client in
+            try await client.XCTExecute(uri: "/hello", method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), "hello")
+            }
+        }
+    }
 }
 
 public struct HBTestRouterContext2: HBRouterRequestContext, HBRequestContext {


### PR DESCRIPTION
Added this to fix a weird API thing where HBRouterBuilder could not be used as a paramter to `HBApplication(router:...)`

All routers should conform to this `protocol` and provide a `buildResponder` method