### PR TITLE
Routerbuilder docs

### DIFF
--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -21,7 +21,7 @@ import Tracing
 /// Creates a span for each request, including attributes such as the HTTP method.
 ///
 /// You may opt in to recording a specific subset of HTTP request/response header values by passing
-/// a set of header names to ``init(recordingHeaders:)``.
+/// a set of header names.
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct HBTracingMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProtocol {
     private let headerNamesToRecord: Set<RecordingHeader>

--- a/Sources/HummingbirdCore/Server/ChildChannel.swift
+++ b/Sources/HummingbirdCore/Server/ChildChannel.swift
@@ -19,13 +19,17 @@ import NIOCore
 public protocol HBChildChannel: Sendable {
     associatedtype Value: Sendable
 
-    /// Initialize channel
+    /// Setup child channel
     /// - Parameters:
-    ///   - channel: channel
-    ///   - childHandlers: Channel handlers to add
-    ///   - configuration: server configuration
+    ///   - channel: Child channel
+    ///   - configuration: Server configuration
+    ///   - logger: Logger used during setup
+    /// - Returns: Object to process input/output on child channel
     func setup(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value>
 
-    /// handle async channel
+    /// handle messages being passed down the channel pipeline
+    /// - Parameters:
+    ///   - value: Object to process input/output on child channel
+    ///   - logger: Logger to use while processing messages
     func handle(value: Value, logger: Logger) async
 }

--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -18,9 +18,14 @@ import NIOCore
 import NIOHTTPTypes
 import NIOHTTPTypesHTTP1
 
+/// Child channel for processing HTTP1
 public struct HTTP1Channel: HBChildChannel, HTTPChannelHandler {
     public typealias Value = NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>
 
+    ///  Initialize HTTP1Channel
+    /// - Parameters:
+    ///   - responder: Function returning a HTTP response for a HTTP request
+    ///   - additionalChannelHandlers: Additional channel handlers to add to channel pipeline
     public init(
         responder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse,
         additionalChannelHandlers: @escaping @Sendable () -> [any RemovableChannelHandler] = { [] }
@@ -29,6 +34,12 @@ public struct HTTP1Channel: HBChildChannel, HTTPChannelHandler {
         self.responder = responder
     }
 
+    /// Setup child channel for HTTP1
+    /// - Parameters:
+    ///   - channel: Child channel
+    ///   - configuration: Server configuration
+    ///   - logger: Logger used during setup
+    /// - Returns: Object to process input/output on child channel
     public func setup(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value> {
         let childChannelHandlers: [any ChannelHandler] =
             [HTTP1ToHTTPServerCodec(secure: false)] +
@@ -47,6 +58,10 @@ public struct HTTP1Channel: HBChildChannel, HTTPChannelHandler {
         }
     }
 
+    /// handle HTTP messages being passed down the channel pipeline
+    /// - Parameters:
+    ///   - value: Object to process input/output on child channel
+    ///   - logger: Logger to use while processing messages
     public func handle(value asyncChannel: NIOCore.NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>, logger: Logging.Logger) async {
         await handleHTTP(asyncChannel: asyncChannel, logger: logger)
     }

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelBuilder.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelBuilder.swift
@@ -15,14 +15,32 @@
 import NIOCore
 
 /// Build Channel Setup that takes an HTTP responder
+///
+/// Used when building an ``Hummingbird/HBApplication``. It delays the building
+/// of the ``HBChildChannel`` until the HTTP responder has been built.
 public struct HBHTTPChannelBuilder<ChildChannel: HBChildChannel>: Sendable {
+    /// build child channel from HTTP responder
     public let build: @Sendable (@escaping HTTPChannelHandler.Responder) throws -> ChildChannel
+
+    /// Initialize HBHTTPChannelBuilder
+    /// - Parameter build: closure building child channel from HTTP responder
     public init(_ build: @escaping @Sendable (@escaping HTTPChannelHandler.Responder) throws -> ChildChannel) {
         self.build = build
     }
 }
 
 extension HBHTTPChannelBuilder {
+    ///  Build HTTP1 channel
+    ///
+    /// Use in ``Hummingbird/HBApplication`` initialization.
+    /// ```
+    /// let app = HBApplication(
+    ///     router: router,
+    ///     server: .http1()
+    /// )
+    /// ```
+    /// - Parameter additionalChannelHandlers: Additional channel handlers to add to channel pipeline
+    /// - Returns: HTTPChannelHandler builder
     public static func http1(
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
     ) -> HBHTTPChannelBuilder<HTTP1Channel> {

--- a/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
@@ -17,6 +17,19 @@ import NIOCore
 import NIOSSL
 
 extension HBHTTPChannelBuilder {
+    ///  Build HTTP channel with HTTP2 upgrade
+    ///
+    /// Use in ``Hummingbird/HBApplication`` initialization.
+    /// ```
+    /// let app = HBApplication(
+    ///     router: router,
+    ///     server: .http2(tlsConfiguration: tlsConfiguration)
+    /// )
+    /// ```
+    /// - Parameters:
+    ///   - tlsConfiguration: TLS configuration
+    ///   - additionalChannelHandlers: Additional channel handlers to call before handling HTTP
+    /// - Returns: HTTPChannelHandler builder
     public static func http2(
         tlsConfiguration: TLSConfiguration,
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []

--- a/Sources/HummingbirdRouter/MiddlewareModule/MiddlewareStack.swift
+++ b/Sources/HummingbirdRouter/MiddlewareModule/MiddlewareStack.swift
@@ -13,21 +13,6 @@
 //===----------------------------------------------------------------------===//
 import Hummingbird
 
-public struct MiddlewareClosure<Input, Output, Context>: MiddlewareProtocol {
-    @usableFromInline
-    var closure: Middleware<Input, Output, Context>
-
-    @inlinable
-    public init(_ middleware: @escaping Middleware<Input, Output, Context>) {
-        self.closure = middleware
-    }
-
-    @inlinable
-    public func handle(_ input: Input, context: Context, next: (Input, Context) async throws -> Output) async throws -> Output {
-        try await self.closure(input, context, next)
-    }
-}
-
 public struct _Middleware2<M0: MiddlewareProtocol, M1: MiddlewareProtocol>: MiddlewareProtocol where M0.Input == M1.Input, M0.Context == M1.Context, M0.Output == M1.Output {
     public typealias Input = M0.Input
     public typealias Output = M0.Output
@@ -50,6 +35,10 @@ public struct _Middleware2<M0: MiddlewareProtocol, M1: MiddlewareProtocol>: Midd
     }
 }
 
+/// Result builder used by ``HBRouterBuilder``
+///
+/// Generates a middleware stack from the elements inside the result builder. The input,
+/// context and output types passed through the middleware stack are fixed and cannot be changed.
 @resultBuilder
 public enum MiddlewareFixedTypeBuilder<Input, Output, Context> {
     public static func buildExpression<M0: MiddlewareProtocol>(_ m0: M0) -> M0 where M0.Input == Input, M0.Output == Output, M0.Context == Context {

--- a/Sources/HummingbirdRouter/Route.swift
+++ b/Sources/HummingbirdRouter/Route.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2023 the Hummingbird authors
+// Copyright (c) 2023-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -17,16 +17,20 @@ import Hummingbird
 import ServiceContextModule
 
 /// Route definition
-public struct Route<Handler: RouteHandlerProtocol, Context: HBRouterRequestContext>: HBMiddlewareProtocol where Handler.Context == Context {
+public struct Route<Handler: _RouteHandlerProtocol, Context: HBRouterRequestContext>: HBMiddlewareProtocol where Handler.Context == Context {
+    /// Full URI path to route
     public let fullPath: String
+    /// Route path local to group route is defined in.
     public let routerPath: RouterPath
+    /// Route method
     public let method: HTTPRequest.Method
+    /// Route handler
     public let handler: Handler
 
     /// Initialize Route
     /// - Parameters:
     ///   - method: Route method
-    ///   - routerPath: Route path, relative to Group route is defined in
+    ///   - routerPath: Route path, relative to group route is defined in
     ///   - handler: Route handler
     init(_ method: HTTPRequest.Method, _ routerPath: RouterPath = "", handler: Handler) {
         self.method = method
@@ -38,38 +42,38 @@ public struct Route<Handler: RouteHandlerProtocol, Context: HBRouterRequestConte
     /// Initialize Route with a closure
     /// - Parameters:
     ///   - method: Route method
-    ///   - routerPath: Route path, relative to Group route is defined in
+    ///   - routerPath: Route path, relative to group route is defined in
     ///   - handler: Router handler closure
     public init<RouteOutput: HBResponseGenerator>(
         _ method: HTTPRequest.Method,
         _ routerPath: RouterPath = "",
         handler: @escaping @Sendable (Input, Context) async throws -> RouteOutput
-    ) where Handler == RouteHandlerClosure<RouteOutput, Context> {
+    ) where Handler == _RouteHandlerClosure<RouteOutput, Context> {
         self.init(
             method,
             routerPath,
-            handler: RouteHandlerClosure(closure: handler)
+            handler: _RouteHandlerClosure(closure: handler)
         )
     }
 
-    /// Initialize Route with a MiddlewareProtocol
+    /// Initialize Route using the ``RouteBuilder`` result builder
     /// - Parameters:
     ///   - method: Route method
-    ///   - routerPath: Route path, relative to Group route is defined in
+    ///   - routerPath: Route path, relative to group route is defined in
     ///   - builder: Result builder used to build Route middleware
     public init<M0: MiddlewareProtocol>(
         _ method: HTTPRequest.Method,
         _ routerPath: RouterPath = "",
         @RouteBuilder<Context> builder: () -> M0
-    ) where Handler == RouteHandlerMiddleware<M0>, M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
+    ) where Handler == _RouteHandlerMiddleware<M0>, M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
         self.init(
             method,
             routerPath,
-            handler: RouteHandlerMiddleware(middleware: builder())
+            handler: _RouteHandlerMiddleware(middleware: builder())
         )
     }
 
-    /// Handle route middleware
+    /// Process HTTP request and return an HTTP response
     /// - Parameters:
     ///   - input: Request
     ///   - context: Context for handler
@@ -96,132 +100,132 @@ public struct Route<Handler: RouteHandlerProtocol, Context: HBRouterRequestConte
 
 /// Create a GET Route with a closure
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - handler: Router handler closure
 public func Get<RouteOutput: HBResponseGenerator, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     handler: @escaping @Sendable (HBRequest, Context) async throws -> RouteOutput
-) -> Route<RouteHandlerClosure<RouteOutput, Context>, Context> {
+) -> Route<_RouteHandlerClosure<RouteOutput, Context>, Context> {
     .init(.get, routerPath, handler: handler)
 }
 
-/// Create a GET Route with a MiddlewareProtocol
+/// Create a GET Route using the ``RouteBuilder`` result builder
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - builder: Result builder used to build Route middleware
 public func Get<M0: MiddlewareProtocol, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     @RouteBuilder<Context> builder: () -> M0
-) -> Route<RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
+) -> Route<_RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
     .init(.get, routerPath, builder: builder)
 }
 
 /// Create a HEAD Route with a closure
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - handler: Router handler closure
 public func Head<RouteOutput: HBResponseGenerator, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     handler: @escaping @Sendable (HBRequest, Context) async throws -> RouteOutput
-) -> Route<RouteHandlerClosure<RouteOutput, Context>, Context> {
+) -> Route<_RouteHandlerClosure<RouteOutput, Context>, Context> {
     .init(.head, routerPath, handler: handler)
 }
 
-/// Create a HEAD Route with a MiddlewareProtocol
+/// Create a HEAD Route using the ``RouteBuilder`` result builder
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - builder: Result builder used to build Route middleware
 public func Head<M0: MiddlewareProtocol, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     @RouteBuilder<Context> builder: () -> M0
-) -> Route<RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
+) -> Route<_RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
     .init(.head, routerPath, builder: builder)
 }
 
 /// Create a PUT Route with a closure
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - handler: Router handler closure
 public func Put<RouteOutput: HBResponseGenerator, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     handler: @escaping @Sendable (HBRequest, Context) async throws -> RouteOutput
-) -> Route<RouteHandlerClosure<RouteOutput, Context>, Context> {
+) -> Route<_RouteHandlerClosure<RouteOutput, Context>, Context> {
     .init(.put, routerPath, handler: handler)
 }
 
-/// Create a PUT Route with a MiddlewareProtocol
+/// Create a PUT Route using the ``RouteBuilder`` result builder
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - builder: Result builder used to build Route middleware
 public func Put<M0: MiddlewareProtocol, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     @RouteBuilder<Context> builder: () -> M0
-) -> Route<RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
+) -> Route<_RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
     .init(.put, routerPath, builder: builder)
 }
 
 /// Create a POST Route with a closure
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - handler: Router handler closure
 public func Post<RouteOutput: HBResponseGenerator, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     handler: @escaping @Sendable (HBRequest, Context) async throws -> RouteOutput
-) -> Route<RouteHandlerClosure<RouteOutput, Context>, Context> {
+) -> Route<_RouteHandlerClosure<RouteOutput, Context>, Context> {
     .init(.post, routerPath, handler: handler)
 }
 
-/// Create a POST Route with a MiddlewareProtocol
+/// Create a POST Route using the ``RouteBuilder`` result builder
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - builder: Result builder used to build Route middleware
 public func Post<M0: MiddlewareProtocol, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     @RouteBuilder<Context> builder: () -> M0
-) -> Route<RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
+) -> Route<_RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
     .init(.post, routerPath, builder: builder)
 }
 
 /// Create a PATCH Route with a closure
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - handler: Router handler closure
 public func Patch<RouteOutput: HBResponseGenerator, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     handler: @escaping @Sendable (HBRequest, Context) async throws -> RouteOutput
-) -> Route<RouteHandlerClosure<RouteOutput, Context>, Context> {
+) -> Route<_RouteHandlerClosure<RouteOutput, Context>, Context> {
     .init(.patch, routerPath, handler: handler)
 }
 
-/// Create a PATCH Route with a MiddlewareProtocol
+/// Create a PATCH Route using the ``RouteBuilder`` result builder
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - builder: Result builder used to build Route middleware
 public func Patch<M0: MiddlewareProtocol, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     @RouteBuilder<Context> builder: () -> M0
-) -> Route<RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
+) -> Route<_RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
     .init(.patch, routerPath, builder: builder)
 }
 
 /// Create a DELETE Route with a closure
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - handler: Router handler closure
 public func Delete<RouteOutput: HBResponseGenerator, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     handler: @escaping @Sendable (HBRequest, Context) async throws -> RouteOutput
-) -> Route<RouteHandlerClosure<RouteOutput, Context>, Context> {
+) -> Route<_RouteHandlerClosure<RouteOutput, Context>, Context> {
     .init(.delete, routerPath, handler: handler)
 }
 
-/// Create a DELETE Route with a MiddlewareProtocol
+/// Create a DELETE Route using the ``RouteBuilder`` result builder
 /// - Parameters:
-///   - routerPath: Route path, relative to Group route is defined in
+///   - routerPath: Route path, relative to group route is defined in
 ///   - builder: Result builder used to build Route middleware
 public func Delete<M0: MiddlewareProtocol, Context: HBRouterRequestContext>(
     _ routerPath: RouterPath = "",
     @RouteBuilder<Context> builder: () -> M0
-) -> Route<RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
+) -> Route<_RouteHandlerMiddleware<M0>, Context> where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context == Context {
     .init(.delete, routerPath, builder: builder)
 }

--- a/Sources/HummingbirdRouter/RouteBuilder.swift
+++ b/Sources/HummingbirdRouter/RouteBuilder.swift
@@ -16,8 +16,8 @@ import Hummingbird
 
 /// Route Handler Middleware.
 ///
-/// Requires that the return value of handler conforms to ``HBResponseGenerator`` so
-/// that the `handle` function can return an `HBResponse`
+/// Requires that the return value of handler conforms to ``Hummingbird/HBResponseGenerator`` so
+/// that the `handle` function can return an ``HummingbirdCore/HBResponse``
 public struct Handle<HandlerOutput: HBResponseGenerator, Context: HBRouterRequestContext>: Sendable, MiddlewareProtocol {
     public typealias Input = HBRequest
     public typealias Output = HBResponse
@@ -36,8 +36,8 @@ public struct Handle<HandlerOutput: HBResponseGenerator, Context: HBRouterReques
 
 /// Result builder for a Route.
 ///
-/// This is very similar to the ``MiddlewareStack`` reult builder except it requires the
-/// last entry of the builder to be a ``Handle`` so we are guaranteed a Response. It also
+/// This is very similar to the ``MiddlewareFixedTypeBuilder`` result builder except it requires
+/// the last entry of the builder to be a ``Handle`` so we are guaranteed a Response. It also
 /// adds the ability to pass in a closure instead of ``Handle`` type.
 @resultBuilder
 public enum RouteBuilder<Context: HBRouterRequestContext> {

--- a/Sources/HummingbirdRouter/RouteBuilder.swift
+++ b/Sources/HummingbirdRouter/RouteBuilder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2023 the Hummingbird authors
+// Copyright (c) 2023-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -25,10 +25,18 @@ public struct Handle<HandlerOutput: HBResponseGenerator, Context: HBRouterReques
 
     let handler: Handler
 
+    ///  Initialize a Handle route middleware
+    /// - Parameter handler: Handler function used to process HTTP request
     public init(_ handler: @escaping Handler) {
         self.handler = handler
     }
 
+    /// Process HTTP request and return an HTTP response
+    /// - Parameters:
+    ///   - input: Request
+    ///   - context: Request context
+    ///   - next: Next middleware to run, if no route handler is found
+    /// - Returns: Response
     public func handle(_ input: Input, context: Context, next: (Input, Context) async throws -> Output) async throws -> Output {
         return try await self.handler(input, context).response(from: input, context: context)
     }

--- a/Sources/HummingbirdRouter/RouteGroup.swift
+++ b/Sources/HummingbirdRouter/RouteGroup.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2023 the Hummingbird authors
+// Copyright (c) 2023-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -32,18 +32,24 @@ extension ServiceContext {
     }
 }
 
+/// Router middleware that applies a middleware chain to URIs with a specified prefix
 public struct RouteGroup<Context: HBRouterRequestContext, Handler: MiddlewareProtocol>: HBMiddlewareProtocol where Handler.Input == HBRequest, Handler.Output == HBResponse, Handler.Context == Context {
     public typealias Input = HBRequest
     public typealias Output = HBResponse
 
+    /// Path local to group route this group is defined in.
     @usableFromInline
     var routerPath: RouterPath
+    /// Group handler
     @usableFromInline
     var handler: Handler
 
+    /// Create RouteGroup from result builder
+    /// - Parameters:
+    ///   - routerPath: Path local to group route this group is defined in
+    ///   - builder: RouteGroup builder
     public init(
-        _ routerPath: RouterPath = "",
-        context: Context.Type = Context.self,
+        _ routerPath: RouterPath,
         @MiddlewareFixedTypeBuilder<HBRequest, HBResponse, Context> builder: () -> Handler
     ) {
         self.routerPath = routerPath
@@ -55,6 +61,12 @@ public struct RouteGroup<Context: HBRouterRequestContext, Handler: MiddlewarePro
         }
     }
 
+    /// Process HTTP request and return an HTTP response
+    /// - Parameters:
+    ///   - input: Request
+    ///   - context: Request context
+    ///   - next: Next middleware to run, if no route handler is found
+    /// - Returns: Response
     @inlinable
     public func handle(_ input: Input, context: Context, next: (Input, Context) async throws -> Output) async throws -> Output {
         if let updatedContext = self.routerPath.matchPrefix(context) {

--- a/Sources/HummingbirdRouter/RouteHandler.swift
+++ b/Sources/HummingbirdRouter/RouteHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2023 the Hummingbird authors
+// Copyright (c) 2023-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -16,14 +16,18 @@ import Hummingbird
 
 /// Protocol for route handler object.
 ///
-/// Requires a function that returns a response from a request and context
-public protocol RouteHandlerProtocol<Context>: Sendable {
+/// Requires a function that returns a HTTP response from a HTTP request and context.
+@_documentation(visibility: internal)
+public protocol _RouteHandlerProtocol<Context>: Sendable {
     associatedtype Context: HBRouterRequestContext
     func handle(_ request: HBRequest, context: Context) async throws -> HBResponse
 }
 
-/// Implementatinon of RouteHandleProtocol that uses a closure to produce a response
-public struct RouteHandlerClosure<RouteOutput: HBResponseGenerator, Context: HBRouterRequestContext>: RouteHandlerProtocol {
+/// Implementatinon of ``_RouteHandlerProtocol`` that uses a closure to produce a response.
+///
+/// This is used internally to implement `Route` when it is initialized with a closure.
+@_documentation(visibility: internal)
+public struct _RouteHandlerClosure<RouteOutput: HBResponseGenerator, Context: HBRouterRequestContext>: _RouteHandlerProtocol {
     @usableFromInline
     let closure: @Sendable (HBRequest, Context) async throws -> RouteOutput
 
@@ -33,8 +37,12 @@ public struct RouteHandlerClosure<RouteOutput: HBResponseGenerator, Context: HBR
     }
 }
 
-/// Implementatinon of RouteHandleProtocol that uses a MiddlewareStack to produce a resposne
-public struct RouteHandlerMiddleware<M0: MiddlewareProtocol>: RouteHandlerProtocol where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context: HBRouterRequestContext {
+/// Implementatinon of ``_RouteHandlerProtocol`` that uses a MiddlewareStack to produce a resposne
+///
+/// This is used internally to implement `Route` when it is initialized with a middleware built
+/// from the ``RouteBuilder`` result builder.
+@_documentation(visibility: internal)
+public struct _RouteHandlerMiddleware<M0: MiddlewareProtocol>: _RouteHandlerProtocol where M0.Input == HBRequest, M0.Output == HBResponse, M0.Context: HBRouterRequestContext {
     public typealias Context = M0.Context
 
     /// Dummy function passed to middleware handle

--- a/Sources/HummingbirdRouter/RouterBuilderContext.swift
+++ b/Sources/HummingbirdRouter/RouterBuilderContext.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+import Logging
+import NIOCore
+
+/// Context data required by `HBRouterBuilder`
+public struct HBRouterBuilderContext: Sendable {
+    /// remaining path components to match
+    @usableFromInline
+    var remainingPathComponents: ArraySlice<Substring>
+
+    public init() {
+        self.remainingPathComponents = []
+    }
+}
+
+/// Protocol that all request contexts used with HBRouterBuilder should conform to.
+public protocol HBRouterRequestContext: HBBaseRequestContext {
+    var routerContext: HBRouterBuilderContext { get set }
+}
+
+/// Basic implementation of a context that can be used with `HBRouterBuilder``
+public struct HBBasicRouterRequestContext: HBRequestContext, HBRouterRequestContext {
+    public var routerContext: HBRouterBuilderContext
+    public var coreContext: HBCoreRequestContext
+
+    public init(allocator: ByteBufferAllocator, logger: Logger) {
+        self.coreContext = .init(allocator: allocator, logger: logger)
+        self.routerContext = .init()
+    }
+}

--- a/Sources/HummingbirdTLS/TLSChannel.swift
+++ b/Sources/HummingbirdTLS/TLSChannel.swift
@@ -7,11 +7,21 @@ import NIOSSL
 public struct TLSChannel<BaseChannel: HBChildChannel>: HBChildChannel {
     public typealias Value = BaseChannel.Value
 
+    ///  Initialize TLSChannel
+    /// - Parameters:
+    ///   - baseChannel: Base child channel wrap
+    ///   - tlsConfiguration: TLS configuration
     public init(_ baseChannel: BaseChannel, tlsConfiguration: TLSConfiguration) throws {
         self.sslContext = try NIOSSLContext(configuration: tlsConfiguration)
         self.baseChannel = baseChannel
     }
 
+    /// Setup child channel with TLS and the base channel setup
+    /// - Parameters:
+    ///   - channel: Child channel
+    ///   - configuration: Server configuration
+    ///   - logger: Logger used during setup
+    /// - Returns: Object to process input/output on child channel
     @inlinable
     public func setup(channel: Channel, configuration: HBServerConfiguration, logger: Logger) -> EventLoopFuture<Value> {
         return channel.pipeline.addHandler(NIOSSLServerHandler(context: self.sslContext)).flatMap {
@@ -20,6 +30,10 @@ public struct TLSChannel<BaseChannel: HBChildChannel>: HBChildChannel {
     }
 
     @inlinable
+    /// handle messages being passed down the channel pipeline
+    /// - Parameters:
+    ///   - value: Object to process input/output on child channel
+    ///   - logger: Logger to use while processing messages
     public func handle(value: BaseChannel.Value, logger: Logging.Logger) async {
         await self.baseChannel.handle(value: value, logger: logger)
     }

--- a/Sources/HummingbirdTLS/TLSChannelBuilder.swift
+++ b/Sources/HummingbirdTLS/TLSChannelBuilder.swift
@@ -16,6 +16,19 @@ import HummingbirdCore
 import NIOSSL
 
 extension HBHTTPChannelBuilder {
+    ///  Build child channel supporting HTTP with TLS
+    ///
+    /// Use in ``Hummingbird/HBApplication`` initialization.
+    /// ```
+    /// let app = HBApplication(
+    ///     router: router,
+    ///     server: .tls(.http1(), tlsConfiguration: tlsConfiguration)
+    /// )
+    /// ```
+    /// - Parameters:
+    ///   - base: Base child channel to wrap with TLS
+    ///   - tlsConfiguration: TLS configuration
+    /// - Returns: HTTPChannelHandler builder
     public static func tls<BaseChannel: HBChildChannel>(
         _ base: HBHTTPChannelBuilder<BaseChannel> = .http1(),
         tlsConfiguration: TLSConfiguration

--- a/Tests/HummingbirdRouterTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdRouterTests/MiddlewareTests.swift
@@ -143,7 +143,7 @@ final class MiddlewareTests: XCTestCase {
             }
         }
         let router = HBRouterBuilder(context: HBBasicRouterRequestContext.self) {
-            RouteGroup {
+            RouteGroup("") {
                 TransformMiddleware()
                 Get("test") { request, _ in
                     return HBResponse(status: .ok, body: .init(asyncSequence: request.body))

--- a/Tests/HummingbirdRouterTests/RouterTests.swift
+++ b/Tests/HummingbirdRouterTests/RouterTests.swift
@@ -341,7 +341,7 @@ final class RouterTests: XCTestCase {
 
     func testPartialCapture() async throws {
         let router = HBRouterBuilder(context: HBBasicRouterRequestContext.self) {
-            Get("/files/file.{ext}/{name}.jpg") { _, context -> String in
+            Route(.get, "/files/file.{ext}/{name}.jpg") { _, context -> String in
                 XCTAssertEqual(context.parameters.count, 2)
                 let ext = try context.parameters.require("ext")
                 let name = try context.parameters.require("name")


### PR DESCRIPTION
- Added documentation for HummingbirdRouter.
- Removed unused symbols
- Hid internal (but public) symbols
- Moved some code around to clean up module

Minor change to `RouteGroup.init`. I found I don't need the context parameter (compiler is clever enough to work it out) and I removed the default value for the path.