### PR TITLE
Changes based off comments...

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -100,7 +100,7 @@ extension HBApplicationProtocol {
         @Sendable func respond(to request: HBRequest, channel: Channel) async throws -> HBResponse {
             let context = Self.Responder.Context(
                 channel: channel,
-                logger: loggerWithRequestId(self.logger)
+                logger: self.logger.with(metadataKey: "hb_id", value: .stringConvertible(RequestID()))
             )
             // respond to request
             var response = try await responder.respond(to: request, context: context)
@@ -145,10 +145,6 @@ extension HBApplicationProtocol {
         )
         try await serviceGroup.run()
     }
-}
-
-public func loggerWithRequestId(_ logger: Logger) -> Logger {
-    return logger.with(metadataKey: "hb_id", value: .stringConvertible(RequestID()))
 }
 
 /// Application class. Brings together all the components of Hummingbird together

--- a/Sources/Hummingbird/Configuration.swift
+++ b/Sources/Hummingbird/Configuration.swift
@@ -26,20 +26,17 @@ public struct HBApplicationConfiguration: Sendable {
     // MARK: Member variables
 
     /// Bind address for server
-    public let address: HBBindAddress
+    public var address: HBBindAddress
     /// Server name to return in "server" header
-    public let serverName: String?
+    public var serverName: String?
     /// Defines the maximum length for the queue of pending connections
-    public let backlog: Int
+    public var backlog: Int
     /// Allows socket to be bound to an address that is already in use.
-    public let reuseAddress: Bool
+    public var reuseAddress: Bool
     #if canImport(Network)
     /// TLS options for NIO Transport services
-    public let tlsOptions: TSTLSOptions
+    public var tlsOptions: TSTLSOptions
     #endif
-
-    /// don't run the HTTP server
-    public let noHTTPServer: Bool
 
     // MARK: Initialization
 
@@ -51,14 +48,12 @@ public struct HBApplicationConfiguration: Sendable {
     ///   - backlog: the maximum length for the queue of pending connections.  If a connection request arrives with the queue full,
     ///         the client may receive an error with an indication of ECONNREFUSE
     ///   - reuseAddress: Allows socket to be bound to an address that is already in use.
-    ///   - noHTTPServer: Don't start up the HTTP server.
     public init(
         address: HBBindAddress = .hostname(),
         serverName: String? = nil,
         backlog: Int = 256,
         reuseAddress: Bool = true,
-        threadPoolSize: Int = 2,
-        noHTTPServer: Bool = false
+        threadPoolSize: Int = 2
     ) {
         self.address = address
         self.serverName = serverName
@@ -67,8 +62,6 @@ public struct HBApplicationConfiguration: Sendable {
         #if canImport(Network)
         self.tlsOptions = .none
         #endif
-
-        self.noHTTPServer = noHTTPServer
     }
 
     #if canImport(Network)
@@ -78,13 +71,11 @@ public struct HBApplicationConfiguration: Sendable {
     ///   - address: Bind address for server
     ///   - serverName: Server name to return in "server" header
     ///   - reuseAddress: Allows socket to be bound to an address that is already in use.
-    ///   - noHTTPServer: Don't start up the HTTP server.
     ///   - tlsOptions: TLS options for when you are using NIOTransportServices
     public init(
         address: HBBindAddress = .hostname(),
         serverName: String? = nil,
         reuseAddress: Bool = true,
-        noHTTPServer: Bool = false,
         tlsOptions: TSTLSOptions
     ) {
         self.address = address
@@ -92,8 +83,6 @@ public struct HBApplicationConfiguration: Sendable {
         self.backlog = 256 // not used by Network framework
         self.reuseAddress = reuseAddress
         self.tlsOptions = tlsOptions
-
-        self.noHTTPServer = noHTTPServer
     }
 
     #endif

--- a/Sources/Hummingbird/Configuration.swift
+++ b/Sources/Hummingbird/Configuration.swift
@@ -52,8 +52,7 @@ public struct HBApplicationConfiguration: Sendable {
         address: HBBindAddress = .hostname(),
         serverName: String? = nil,
         backlog: Int = 256,
-        reuseAddress: Bool = true,
-        threadPoolSize: Int = 2
+        reuseAddress: Bool = true
     ) {
         self.address = address
         self.serverName = serverName

--- a/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
@@ -17,14 +17,7 @@ public final class HBMiddlewareGroup<Context> {
     var middlewares: [any HBMiddlewareProtocol<Context>]
 
     /// Initialize `HBMiddlewareGroup`
-    ///
-    /// Set middleware array to be empty
-    public init() {
-        // this is set by WebSocketRouterGroup so this needs to be kept public
-        self.middlewares = []
-    }
-
-    init(middlewares: [any HBMiddlewareProtocol<Context>]) {
+    init(middlewares: [any HBMiddlewareProtocol<Context>] = []) {
         self.middlewares = middlewares
     }
 

--- a/Sources/Hummingbird/Server/RequestID.swift
+++ b/Sources/Hummingbird/Server/RequestID.swift
@@ -15,15 +15,14 @@
 import Atomics
 
 /// Generate Unique ID for each request
-@_spi(HBXCT)
-public struct RequestID: CustomStringConvertible {
+package struct RequestID: CustomStringConvertible {
     let low: UInt64
 
-    public init() {
+    package init() {
         self.low = Self.globalRequestID.loadThenWrappingIncrement(by: 1, ordering: .relaxed)
     }
 
-    public var description: String {
+    package var description: String {
         Self.high + self.formatAsHexWithLeadingZeros(self.low)
     }
 

--- a/Sources/Hummingbird/Server/RequestID.swift
+++ b/Sources/Hummingbird/Server/RequestID.swift
@@ -15,14 +15,15 @@
 import Atomics
 
 /// Generate Unique ID for each request
-struct RequestID: CustomStringConvertible {
+@_spi(HBXCT)
+public struct RequestID: CustomStringConvertible {
     let low: UInt64
 
-    init() {
+    public init() {
         self.low = Self.globalRequestID.loadThenWrappingIncrement(by: 1, ordering: .relaxed)
     }
 
-    var description: String {
+    public var description: String {
         Self.high + self.formatAsHexWithLeadingZeros(self.low)
     }
 

--- a/Sources/HummingbirdCore/Server/Server.swift
+++ b/Sources/HummingbirdCore/Server/Server.swift
@@ -175,7 +175,7 @@ public actor HBServer<ChildChannel: HBChildChannel>: Service {
     /// Start server
     /// - Parameter responder: Object that provides responses to requests sent to the server
     /// - Returns: EventLoopFuture that is fulfilled when server has started
-    public func makeServer(childChannelSetup: ChildChannel, configuration: HBServerConfiguration) async throws -> AsyncServerChannel {
+    func makeServer(childChannelSetup: ChildChannel, configuration: HBServerConfiguration) async throws -> AsyncServerChannel {
         let bootstrap: ServerBootstrapProtocol
         #if canImport(Network)
         if let tsBootstrap = self.createTSBootstrap(configuration: configuration) {

--- a/Sources/HummingbirdXCT/HBXCTRouter.swift
+++ b/Sources/HummingbirdXCT/HBXCTRouter.swift
@@ -95,7 +95,7 @@ struct HBXCTRouter<Responder: HBResponder>: HBXCTApplication where Responder.Con
                     head: .init(method: method, scheme: "http", authority: "localhost", path: uri, headerFields: headers),
                     body: .stream(streamer)
                 )
-                let logger = loggerWithRequestId(self.logger)
+                let logger = self.logger.with(metadataKey: "hb_id", value: .stringConvertible(RequestID()))
                 let context = self.makeContext(logger)
 
                 group.addTask {

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -606,6 +606,29 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
+    /// test we can create out own application type conforming to HBApplicationProtocol
+    func testBidirectionalStreaming() async throws {
+        let buffer = randomBuffer(size: 1024 * 1024)
+        let router = HBRouter()
+        router.post("/") { request, context -> HBResponse in
+            .init(
+                status: .ok,
+                body: .init { writer in
+                    for try await buffer in request.body {
+                        let processed = context.allocator.buffer(bytes: buffer.readableBytesView.map {$0 ^ 0xff })
+                        try await writer.write(processed)
+                    }
+                }
+            )
+        }
+        let app = HBApplication(router: router)
+        try await app.test(.live) { client in
+            try await client.XCTExecute(uri: "/", method: .post, body: buffer) { response in
+                XCTAssertEqual(response.body, ByteBuffer(bytes: buffer.readableBytesView.map {$0 ^ 0xff }))
+            }
+        }
+    }
+
     // MARK: Helper functions
 
     func getServerTLSConfiguration() throws -> TLSConfiguration {


### PR DESCRIPTION
From @FranzBusch

- Removed `loggerWithRequestId` global function. It is a one liner and used in two places. This did mean I had to make `RequestID` public but it is hidden behind `@_spi(HBXCT)` for HB internal symbols used in HBXCT.
- `HBApplicationConfiguration` members are all `var`
- Removed `noHTTPServer` as we are not using it
- Removed `threadPoolSize` parameter I missed previously
-  `HBServer. makeServer` is no longer public

The changes to `HBApplicationConfiguration` mean it is now basically just the server configuration parameters so I'll probably merge these two in a later PR.