### PR TITLE
Rename http2 to http2Upgrade

### DIFF
--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -24,7 +24,7 @@ import NIOPosix
 import NIOSSL
 
 /// Child channel for processing HTTP1 with the option of upgrading to HTTP2
-public struct HTTP2Channel: HTTPChannelHandler {
+public struct HTTP2UpgradeChannel: HTTPChannelHandler {
     public typealias Value = EventLoopFuture<NIONegotiatedHTTPVersion<HTTP1Channel.Value, (NIOAsyncChannel<HTTP2Frame, HTTP2Frame>, NIOHTTP2Handler.AsyncStreamMultiplexer<HTTP1Channel.Value>)>>
 
     private let sslContext: NIOSSLContext

--- a/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
@@ -23,19 +23,19 @@ extension HBHTTPChannelBuilder {
     /// ```
     /// let app = HBApplication(
     ///     router: router,
-    ///     server: .http2(tlsConfiguration: tlsConfiguration)
+    ///     server: .http2Upgrade(tlsConfiguration: tlsConfiguration)
     /// )
     /// ```
     /// - Parameters:
     ///   - tlsConfiguration: TLS configuration
     ///   - additionalChannelHandlers: Additional channel handlers to call before handling HTTP
     /// - Returns: HTTPChannelHandler builder
-    public static func http2(
+    public static func http2Upgrade(
         tlsConfiguration: TLSConfiguration,
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
-    ) throws -> HBHTTPChannelBuilder<HTTP2Channel> {
+    ) throws -> HBHTTPChannelBuilder<HTTP2UpgradeChannel> {
         return .init { responder in
-            return try HTTP2Channel(
+            return try HTTP2UpgradeChannel(
                 tlsConfiguration: tlsConfiguration,
                 additionalChannelHandlers: additionalChannelHandlers,
                 responder: responder

--- a/Tests/HummingbirdCoreTests/HTTP2Tests.swift
+++ b/Tests/HummingbirdCoreTests/HTTP2Tests.swift
@@ -14,8 +14,8 @@
 
 import AsyncHTTPClient
 import HummingbirdCore
-import HummingbirdXCT
 import HummingbirdHTTP2
+import HummingbirdXCT
 import Logging
 import NIOCore
 import NIOHTTP1
@@ -32,7 +32,7 @@ class HummingBirdHTTP2Tests: XCTestCase {
             responder: { _, _ in
                 .init(status: .ok)
             },
-            httpChannelSetup: .http2(tlsConfiguration: self.getServerTLSConfiguration()),
+            httpChannelSetup: .http2Upgrade(tlsConfiguration: self.getServerTLSConfiguration()),
             configuration: .init(address: .hostname(port: 0), serverName: testServerName),
             eventLoopGroup: eventLoopGroup,
             logger: Logger(label: "HB")

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -579,7 +579,7 @@ final class ApplicationTests: XCTestCase {
         }
         let app = try HBApplication(
             responder: router.buildResponder(),
-            server: .http2(tlsConfiguration: self.getServerTLSConfiguration())
+            server: .http2Upgrade(tlsConfiguration: self.getServerTLSConfiguration())
         )
         try await app.test(.ahc(.https)) { client in
             try await client.XCTExecute(uri: "/", method: .get) { response in


### PR DESCRIPTION
It is more explicit as what the channel does and leaves the space open for a HTTP2 only channel