### PR TITLE
2.x.x http2 idle state (version 1)

### DIFF
--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2023 the Hummingbird authors
+// Copyright (c) 2023-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -29,22 +29,26 @@ public struct HTTP2UpgradeChannel: HTTPChannelHandler {
 
     private let sslContext: NIOSSLContext
     private let http1: HTTP1Channel
+    private let idleTimeout: TimeAmount
     private let additionalChannelHandlers: @Sendable () -> [any RemovableChannelHandler]
     public var responder: @Sendable (HBRequest, Channel) async throws -> HBResponse { http1.responder }
 
     ///  Initialize HTTP1Channel
     /// - Parameters:
     ///   - tlsConfiguration: TLS configuration
+    ///   - idleTimeout: Time before closing an idle HTTP2 connection pipeline
     ///   - additionalChannelHandlers: Additional channel handlers to add to channel pipeline
     ///   - responder: Function returning a HTTP response for a HTTP request
     public init(
         tlsConfiguration: TLSConfiguration,
+        idleTimeout: Duration = .seconds(30),
         additionalChannelHandlers: @escaping @Sendable () -> [any RemovableChannelHandler] = { [] },
         responder: @escaping @Sendable (HBRequest, Channel) async throws -> HBResponse = { _, _ in throw HBHTTPError(.notImplemented) }
     ) throws {
         var tlsConfiguration = tlsConfiguration
         tlsConfiguration.applicationProtocols = NIOHTTP2SupportedALPNProtocols
         self.sslContext = try NIOSSLContext(configuration: tlsConfiguration)
+        self.idleTimeout = .init(idleTimeout)
         self.additionalChannelHandlers = additionalChannelHandlers
         self.http1 = HTTP1Channel(responder: responder, additionalChannelHandlers: additionalChannelHandlers)
     }
@@ -75,22 +79,20 @@ public struct HTTP2UpgradeChannel: HTTPChannelHandler {
                 }
         } http2ConnectionInitializer: { http2Channel -> EventLoopFuture<NIOAsyncChannel<HTTP2Frame, HTTP2Frame>> in
             http2Channel.eventLoop.makeCompletedFuture {
-                try NIOAsyncChannel<HTTP2Frame, HTTP2Frame>(wrappingChannelSynchronously: http2Channel)
+                try http2Channel.pipeline.syncOperations.addHandler(IdleStateHandler(readTimeout: self.idleTimeout))
+                try http2Channel.pipeline.syncOperations.addHandler(HTTP2UserEventHandler())
+                return try NIOAsyncChannel<HTTP2Frame, HTTP2Frame>(wrappingChannelSynchronously: http2Channel)
             }
         } http2StreamInitializer: { http2ChildChannel -> EventLoopFuture<HTTP1Channel.Value> in
             let childChannelHandlers: [ChannelHandler] =
                 self.additionalChannelHandlers() + [
                     HBHTTPUserEventHandler(logger: logger),
                 ]
-
-            return http2ChildChannel
-                .pipeline
-                .addHandler(HTTP2FramePayloadToHTTPServerCodec())
-                .flatMap {
-                    http2ChildChannel.pipeline.addHandlers(childChannelHandlers)
-                }.flatMapThrowing {
-                    try HTTP1Channel.Value(wrappingChannelSynchronously: http2ChildChannel)
-                }
+            return http2ChildChannel.eventLoop.makeCompletedFuture {
+                try http2ChildChannel.pipeline.syncOperations.addHandler(HTTP2FramePayloadToHTTPServerCodec())
+                try http2ChildChannel.pipeline.syncOperations.addHandlers(childChannelHandlers)
+                return try HTTP1Channel.Value(wrappingChannelSynchronously: http2ChildChannel)
+            }
         }
     }
 
@@ -116,8 +118,7 @@ public struct HTTP2UpgradeChannel: HTTPChannelHandler {
                 } catch {
                     logger.error("Error handling inbound connection for HTTP2 handler: \(error)")
                 }
-                // have to run this to ensure http2 channel outbound writer is closed
-                try await http2.executeThenClose { _,_ in}
+                try await http2.executeThenClose { _, _ in }
             }
         } catch {
             logger.error("Error getting HTTP2 upgrade negotiated value: \(error)")

--- a/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
@@ -32,11 +32,13 @@ extension HBHTTPChannelBuilder {
     /// - Returns: HTTPChannelHandler builder
     public static func http2Upgrade(
         tlsConfiguration: TLSConfiguration,
+        idleTimeout: Duration = .seconds(30),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
     ) throws -> HBHTTPChannelBuilder<HTTP2UpgradeChannel> {
         return .init { responder in
             return try HTTP2UpgradeChannel(
                 tlsConfiguration: tlsConfiguration,
+                idleTimeout: idleTimeout,
                 additionalChannelHandlers: additionalChannelHandlers,
                 responder: responder
             )

--- a/Sources/HummingbirdHTTP2/HTTP2UserEventHandler.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2UserEventHandler.swift
@@ -15,11 +15,9 @@
 import NIOCore
 import NIOHTTP2
 
-final class HTTP2UserEventHandler: ChannelDuplexHandler, RemovableChannelHandler {
+final class HTTP2UserEventHandler: ChannelInboundHandler, RemovableChannelHandler {
     typealias InboundIn = HTTP2Frame
     typealias InboundOut = HTTP2Frame
-    typealias OutboundIn = HTTP2Frame
-    typealias OutboundOut = HTTP2Frame
 
     enum State {
         case active(numberOpenStreams: Int)

--- a/Sources/HummingbirdHTTP2/HTTP2UserEventHandler.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2UserEventHandler.swift
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023-2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOHTTP2
+
+final class HTTP2UserEventHandler: ChannelDuplexHandler, RemovableChannelHandler {
+    typealias InboundIn = HTTP2Frame
+    typealias InboundOut = HTTP2Frame
+    typealias OutboundIn = HTTP2Frame
+    typealias OutboundOut = HTTP2Frame
+
+    enum State {
+        case active(numberOpenStreams: Int)
+        case quiescing(numberOpenStreams: Int)
+        case closing
+    }
+
+    var state: State = .active(numberOpenStreams: 0)
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        context.fireChannelRead(data)
+    }
+
+    public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        switch event {
+        case is NIOHTTP2StreamCreatedEvent:
+            self.streamOpened()
+
+        case is StreamClosedEvent:
+            self.streamClosed(context: context)
+
+        case is ChannelShouldQuiesceEvent:
+            self.quiesce(context: context)
+
+        case let evt as IdleStateHandler.IdleStateEvent where evt == .read:
+            self.processIdleReadState(context: context)
+
+        default:
+            break
+        }
+        context.fireUserInboundEventTriggered(event)
+    }
+
+    func streamOpened() {
+        switch self.state {
+        case .active(let numberOpenStreams):
+            self.state = .active(numberOpenStreams: numberOpenStreams + 1)
+        case .quiescing(let numberOpenStreams):
+            self.state = .quiescing(numberOpenStreams: numberOpenStreams + 1)
+        case .closing:
+            assertionFailure("If we have initiated a close, then we should not be opening new streams.")
+        }
+    }
+
+    func streamClosed(context: ChannelHandlerContext) {
+        switch self.state {
+        case .active(let numberOpenStreams):
+            self.state = .active(numberOpenStreams: numberOpenStreams - 1)
+        case .quiescing(let numberOpenStreams):
+            if numberOpenStreams > 1 {
+                self.state = .quiescing(numberOpenStreams: numberOpenStreams - 1)
+            } else {
+                self.close(context: context)
+            }
+        case .closing:
+            assertionFailure("If we have initiated a close, there should be no streams to close.")
+        }
+    }
+
+    func quiesce(context: ChannelHandlerContext) {
+        switch self.state {
+        case .active(let numberOpenStreams):
+            if numberOpenStreams > 0 {
+                self.state = .quiescing(numberOpenStreams: numberOpenStreams)
+            } else {
+                self.close(context: context)
+            }
+        case .quiescing, .closing:
+            break
+        }
+    }
+
+    func processIdleReadState(context: ChannelHandlerContext) {
+        switch self.state {
+        case .active(let numberOpenStreams):
+            // if we get a read idle state and there are streams open
+            if numberOpenStreams == 0 {
+                self.close(context: context)
+            }
+        case .quiescing(let numberOpenStreams):
+            // if we get a read idle state and there are streams open
+            if numberOpenStreams == 0 {
+                self.close(context: context)
+            }
+        default:
+            break
+        }
+    }
+
+    func close(context: ChannelHandlerContext) {
+        switch self.state {
+        case .active, .quiescing:
+            self.state = .closing
+            context.close(promise: nil)
+        case .closing:
+            break
+        }
+    }
+}

--- a/Sources/HummingbirdHTTP2/HTTP2UserEventHandler.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2UserEventHandler.swift
@@ -93,12 +93,12 @@ final class HTTP2UserEventHandler: ChannelInboundHandler, RemovableChannelHandle
     func processIdleReadState(context: ChannelHandlerContext) {
         switch self.state {
         case .active(let numberOpenStreams):
-            // if we get a read idle state and there are streams open
+            // if we get a read idle state and there are no streams open
             if numberOpenStreams == 0 {
                 self.close(context: context)
             }
         case .quiescing(let numberOpenStreams):
-            // if we get a read idle state and there are streams open
+            // if we get a read idle state and there are no streams open
             if numberOpenStreams == 0 {
                 self.close(context: context)
             }

--- a/Tests/HummingbirdCoreTests/HTTP2Tests.swift
+++ b/Tests/HummingbirdCoreTests/HTTP2Tests.swift
@@ -51,4 +51,33 @@ class HummingBirdHTTP2Tests: XCTestCase {
             XCTAssertEqual(response.status, .ok)
         }
     }
+
+    // test timeout doesn't kill long running task
+    func testTimeout() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        try await testServer(
+            responder: { _, _ in
+                try await Task.sleep(for: .seconds(2))
+                return .init(status: .ok, body: .init(byteBuffer: .init(string: "Hello")))
+            },
+            httpChannelSetup: .http2Upgrade(tlsConfiguration: getServerTLSConfiguration(), idleTimeout: .seconds(1)),
+            configuration: .init(address: .hostname(port: 0), serverName: testServerName),
+            eventLoopGroup: eventLoopGroup,
+            logger: Logger(label: "HB")
+        ) { _, port in
+            var tlsConfiguration = try getClientTLSConfiguration()
+            // no way to override the SSL server name with AsyncHTTPClient so need to set
+            // hostname verification off
+            tlsConfiguration.certificateVerification = .noHostnameVerification
+            let httpClient = HTTPClient(
+                eventLoopGroupProvider: .shared(eventLoopGroup),
+                configuration: .init(tlsConfiguration: tlsConfiguration)
+            )
+            defer { try? httpClient.syncShutdown() }
+
+            let response = try await httpClient.get(url: "https://localhost:\(port)/").get()
+            XCTAssertEqual(response.status, .ok)
+        }
+    }
 }


### PR DESCRIPTION
I've implemented HTTP2 idle state using the IdleStateHandler and custom HTTP2 stream open and close events. 
The idea being you shutdown when there are no open streams (it is up to the open streams to handle idle state) and an read idle event has been triggered.
The standard HTTP2 events are not generated by the channel handlers created by `configureAsyncHTTPServerPipeline` so I have to create custom events and pass them back to the channel as outbound events to say when streams open and close..

An alternative method can be found in #371 