### PR TITLE
2.x.x http2 idle state (version 2)

### DIFF
--- a/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
@@ -32,11 +32,13 @@ extension HBHTTPChannelBuilder {
     /// - Returns: HTTPChannelHandler builder
     public static func http2Upgrade(
         tlsConfiguration: TLSConfiguration,
+        idleTimeout: Duration = .seconds(30),
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
     ) throws -> HBHTTPChannelBuilder<HTTP2UpgradeChannel> {
         return .init { responder in
             return try HTTP2UpgradeChannel(
                 tlsConfiguration: tlsConfiguration,
+                idleTimeout: idleTimeout,
                 additionalChannelHandlers: additionalChannelHandlers,
                 responder: responder
             )

--- a/Tests/HummingbirdCoreTests/HTTP2Tests.swift
+++ b/Tests/HummingbirdCoreTests/HTTP2Tests.swift
@@ -51,4 +51,33 @@ class HummingBirdHTTP2Tests: XCTestCase {
             XCTAssertEqual(response.status, .ok)
         }
     }
+
+    // test timeout doesn't kill long running task
+    func testTimeout() async throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        try await testServer(
+            responder: { _, _ in
+                try await Task.sleep(for: .seconds(2))
+                return .init(status: .ok, body: .init(byteBuffer: .init(string: "Hello")))
+            },
+            httpChannelSetup: .http2Upgrade(tlsConfiguration: getServerTLSConfiguration(), idleTimeout: .seconds(0.5)),
+            configuration: .init(address: .hostname(port: 0), serverName: testServerName),
+            eventLoopGroup: eventLoopGroup,
+            logger: Logger(label: "HB")
+        ) { _, port in
+            var tlsConfiguration = try getClientTLSConfiguration()
+            // no way to override the SSL server name with AsyncHTTPClient so need to set
+            // hostname verification off
+            tlsConfiguration.certificateVerification = .noHostnameVerification
+            let httpClient = HTTPClient(
+                eventLoopGroupProvider: .shared(eventLoopGroup),
+                configuration: .init(tlsConfiguration: tlsConfiguration)
+            )
+            defer { try? httpClient.syncShutdown() }
+
+            let response = try await httpClient.get(url: "https://localhost:\(port)/").get()
+            XCTAssertEqual(response.status, .ok)
+        }
+    }
 }


### PR DESCRIPTION
This is an alternative to #370 

Idle state is all done in the async handler. I merge the multiplexer inbound sequence and a async timer sequence together. I iterate over the elements of this merged sequence. For a stream event I start a a handle task for that stream, if a timer event occurs it checks how many streams are open and if the last stream to close was long enough ago. If so then it exits the loop and the channel is closed.

I also merge a gracefulShutdown AsyncStream with the two sequences above to implement graceful shutdown