### PR TITLE
2.x.x - Add support for creating a streamed HBRequestBody

### DIFF
--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -257,7 +257,7 @@ extension HBStreamedRequestBody {
 
     ///  Make a new ``HBStreamedRequestBody``
     /// - Returns: The new `HBStreamedRequestBody` and a source to yield ByteBuffers to the `HBStreamedRequestBody`.
-    public static func makeStream() -> (HBStreamedRequestBody, Source) {
+    static func makeStream() -> (HBStreamedRequestBody, Source) {
         let delegate = Delegate()
         let newSequence = Producer.makeSequence(
             backPressureStrategy: .init(lowWatermark: 2, highWatermark: 4),

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -250,9 +250,7 @@ extension HBStreamedRequestBody {
             finishOnDeinit: false,
             delegate: delegate
         )
-        let result = newSequence.source.yield(byteBuffer)
-        // we are only pushing one ByteBuffer onto the source so yield will be fine
-        assert(result == .produceMore)
+        _ = newSequence.source.yield(byteBuffer)
         newSequence.source.finish()
         self.init(producer: newSequence.sequence)
     }

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -46,6 +46,13 @@ public enum HBRequestBody: Sendable, AsyncSequence {
             return try await collect(upTo: maxSize)
         }
     }
+
+    ///  Make a new ``HBStreamedRequestBody``
+    /// - Returns: The new `HBStreamedRequestBody` and a source to yield ByteBuffers to the `HBStreamedRequestBody`.
+    static public func makeRequestBodyStream() -> (HBRequestBody, HBStreamedRequestBody.Source) {
+        let (stream, source) = HBStreamedRequestBody.makeStream()
+        return (.stream(stream), source)
+    }
 }
 
 /// Request body that is a stream of ByteBuffers.
@@ -251,7 +258,7 @@ extension HBStreamedRequestBody {
 
     ///  Make a new ``HBStreamedRequestBody``
     /// - Returns: The new `HBStreamedRequestBody` and a source to yield ByteBuffers to the `HBStreamedRequestBody`.
-    static public func makeRequestBodyStream() -> (HBStreamedRequestBody, Source) {
+    static public func makeStream() -> (HBStreamedRequestBody, Source) {
         let delegate = Delegate()
         let newSequence = Producer.makeSequence(
             backPressureStrategy: .init(lowWatermark: 2, highWatermark: 4), 

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -55,7 +55,7 @@ extension HTTPChannelHandler {
 
                     while true {
                         // set to processing unless it is cancelled then exit
-                        guard processingRequest.exchange(.processing, ordering: .relaxed) == .idle else { break }
+                        guard processingRequest.exchange(.processing, ordering: .releasing) == .idle else { break }
 
                         let bodyStream = HBStreamedRequestBody(iterator: iterator)
                         let request = HBRequest(head: head, body: .stream(bodyStream))
@@ -76,7 +76,7 @@ extension HTTPChannelHandler {
                             throw HTTPChannelError.closeConnection
                         }
                         // set to idle unless it is cancelled then exit
-                        guard processingRequest.exchange(.idle, ordering: .relaxed) == .processing else { break }
+                        guard processingRequest.exchange(.idle, ordering: .releasing) == .processing else { break }
 
                         // Flush current request
                         // read until we don't have a body part
@@ -102,7 +102,7 @@ extension HTTPChannelHandler {
                 }
             } onGracefulShutdown: {
                 // set to cancelled
-                if processingRequest.exchange(.cancelled, ordering: .relaxed) == .idle {
+                if processingRequest.exchange(.cancelled, ordering: .acquiring) == .idle {
                     // only close the channel input if it is idle
                     asyncChannel.channel.close(mode: .input, promise: nil)
                 }

--- a/Sources/HummingbirdXCT/HBXCTRouter.swift
+++ b/Sources/HummingbirdXCT/HBXCTRouter.swift
@@ -91,10 +91,10 @@ struct HBXCTRouter<Responder: HBResponder>: HBXCTApplication where Responder.Con
 
         func execute(uri: String, method: HTTPRequest.Method, headers: HTTPFields, body: ByteBuffer?) async throws -> HBXCTResponse {
             return try await withThrowingTaskGroup(of: HBXCTResponse.self) { group in
-                let (streamer, source) = HBStreamedRequestBody.makeRequestBodyStream()
+                let (stream, source) = HBRequestBody.makeRequestBodyStream()
                 let request = HBRequest(
                     head: .init(method: method, scheme: "http", authority: "localhost", path: uri, headerFields: headers),
-                    body: .stream(streamer)
+                    body: stream
                 )
                 let logger = self.logger.with(metadataKey: "hb_id", value: .stringConvertible(RequestID()))
                 let context = self.makeContext(logger)

--- a/Sources/HummingbirdXCT/HBXCTRouter.swift
+++ b/Sources/HummingbirdXCT/HBXCTRouter.swift
@@ -91,7 +91,7 @@ struct HBXCTRouter<Responder: HBResponder>: HBXCTApplication where Responder.Con
 
         func execute(uri: String, method: HTTPRequest.Method, headers: HTTPFields, body: ByteBuffer?) async throws -> HBXCTResponse {
             return try await withThrowingTaskGroup(of: HBXCTResponse.self) { group in
-                let (stream, source) = HBRequestBody.makeRequestBodyStream()
+                let (stream, source) = HBRequestBody.makeStream()
                 let request = HBRequest(
                     head: .init(method: method, scheme: "http", authority: "localhost", path: uri, headerFields: headers),
                     body: stream

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -650,38 +650,6 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    /// test we can edit request body in middleware
-    func testMiddlewareEditingRequestBody() async throws {
-        struct RequestEditingMiddleware<Context: HBRequestContext>: HBMiddlewareProtocol {
-            func handle(_ request: Input, context: Context, next: (Input, Context) async throws -> Output) async throws -> Output {
-                try await withThrowingTaskGroup(of: Void.self) { group in
-                    let (requestBody, source) = HBStreamedRequestBody.makeRequestBodyStream()
-                    var newRequest = request
-                    newRequest.body = .stream(requestBody)
-                    group.addTask {
-                        for try await buffer in request.body {
-                            try await source.yield(ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 0xFF }))
-                        }
-                        source.finish()
-                    }
-                    return try await next(newRequest, context)
-                }
-            }
-        }
-        let buffer = self.randomBuffer(size: 1024 * 1024)
-        let router = HBRouter()
-        router.middlewares.add(RequestEditingMiddleware())
-        router.post("/") { request, context -> HTTPResponse.Status in
-            let body = try await request.body.collate(maxSize: .max)
-            XCTAssertEqual(body, ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 0xFF }))
-            return .ok
-        }
-        let app = HBApplication(router: router)
-        try await app.test(.live) { client in
-            _ = try await client.XCTExecute(uri: "/", method: .post, body: buffer)
-        }
-    }
-
     // MARK: Helper functions
 
     func getServerTLSConfiguration() throws -> TLSConfiguration {

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -177,9 +177,9 @@ final class MiddlewareTests: XCTestCase {
         struct RequestEditingMiddleware<Context: HBRequestContext>: HBMiddlewareProtocol {
             func handle(_ request: Input, context: Context, next: (Input, Context) async throws -> Output) async throws -> Output {
                 try await withThrowingTaskGroup(of: Void.self) { group in
-                    let (requestBody, source) = HBStreamedRequestBody.makeRequestBodyStream()
+                    let (requestBody, source) = HBRequestBody.makeRequestBodyStream()
                     var newRequest = request
-                    newRequest.body = .stream(requestBody)
+                    newRequest.body = requestBody
                     group.addTask {
                         for try await buffer in request.body {
                             try await source.yield(ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 0xFF }))

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Hummingbird
+import HummingbirdCore
 import HummingbirdXCT
 import XCTest
 
@@ -168,6 +169,38 @@ final class MiddlewareTests: XCTestCase {
                 let expectedOutput = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
                 XCTAssertEqual(expectedOutput, response.body)
             }
+        }
+    }
+
+    /// test we can edit request body in middleware
+    func testMiddlewareEditingRequestBody() async throws {
+        struct RequestEditingMiddleware<Context: HBRequestContext>: HBMiddlewareProtocol {
+            func handle(_ request: Input, context: Context, next: (Input, Context) async throws -> Output) async throws -> Output {
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    let (requestBody, source) = HBStreamedRequestBody.makeRequestBodyStream()
+                    var newRequest = request
+                    newRequest.body = .stream(requestBody)
+                    group.addTask {
+                        for try await buffer in request.body {
+                            try await source.yield(ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 0xFF }))
+                        }
+                        source.finish()
+                    }
+                    return try await next(newRequest, context)
+                }
+            }
+        }
+        let buffer = self.randomBuffer(size: 1024 * 1024)
+        let router = HBRouter()
+        router.middlewares.add(RequestEditingMiddleware())
+        router.post("/") { request, context -> HTTPResponse.Status in
+            let body = try await request.body.collate(maxSize: .max)
+            XCTAssertEqual(body, ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 0xFF }))
+            return .ok
+        }
+        let app = HBApplication(router: router)
+        try await app.test(.live) { client in
+            _ = try await client.XCTExecute(uri: "/", method: .post, body: buffer)
         }
     }
 

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Hummingbird
-import HummingbirdCore
 import HummingbirdXCT
 import XCTest
 


### PR DESCRIPTION
One of the problems with moving to wrapping the NIOAsyncChannelInboundStream iterator in the HBRequestBody, is it provided no method for creating a streamed `HBRequestBody` outside of the HTTP request handler. This PR addresses this by internal storing an enum which switches between a `NIOAsyncChannelInboundStream.AsyncIterator` and a `NIOThrowingAsyncSequenceProducer`.

You can now create a new streamed request body as follows
```swift
let (stream, source) = HBRequestBody.makeStream()
```