### PR TITLE
Add primary associated type to HBRouterMethods

### DIFF
--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -16,7 +16,7 @@ import HTTPTypes
 import NIOCore
 
 /// Conform to `HBRouterMethods` to add standard router verb (get, post ...) methods
-public protocol HBRouterMethods {
+public protocol HBRouterMethods<Context> {
     associatedtype Context: HBBaseRequestContext
 
     /// Add path for async closure


### PR DESCRIPTION
I want to use it like Vapor's `RouteCollection`, so I need the primary associated type to be able to write the following

```swift
struct MyController {
    func boot(routes: some HBRouterMethods<MyRequestContext>) {
        routes.get("foo", use: getFoo)
        routes.post("foo", use: postFoo)
    }
```