### PR TITLE
Add request task cancellation, and improve handling of graceful shutdown

### DIFF
--- a/Sources/HummingbirdCore/Server/Server.swift
+++ b/Sources/HummingbirdCore/Server/Server.swift
@@ -114,7 +114,7 @@ public actor HBServer<ChildChannel: HBChildChannel>: Service {
                         await withDiscardingTaskGroup { group in
                             do {
                                 try await asyncChannel.executeThenClose { inbound in
-                                    for try await childChannel in inbound {
+                                    for try await childChannel in inbound.cancelOnGracefulShutdown() {
                                         group.addTask {
                                             await childChannelSetup.handle(value: childChannel, logger: logger)
                                         }


### PR DESCRIPTION
Should solve a typical dilemma I've had in systems that get under heavy load:
1. A user connects to download a huge dataset (CSV or XLSX)
2. Server does some heavy queries, and starts outputting CSV/XLSX
3. User gets impatient and refreshes browser, cancelling the request
4. Server is still generating the request that was cancelled
5. Successive attempts by the user become futile and take forever