### PR TITLE
Remove `HBRequestChannel.init(allocator:logger:)` protocol requirement

### DIFF
--- a/Benchmarks/Benchmarks/Router/RouterBenchmarks.swift
+++ b/Benchmarks/Benchmarks/Router/RouterBenchmarks.swift
@@ -25,11 +25,8 @@ import NIOPosix
 struct BasicBenchmarkContext: HBRequestContext {
     var coreContext: HBCoreRequestContext
 
-    init(
-        allocator: ByteBufferAllocator,
-        logger: Logger
-    ) {
-        self.coreContext = .init(allocator: allocator, logger: logger)
+    public init(channel: Channel, logger: Logger) {
+        self.coreContext = .init(allocator: channel.allocator, logger: logger)
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -91,6 +91,7 @@ let package = Package(
                 .product(name: "HTTPTypes", package: "swift-http-types"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
                 .product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
                 .product(name: "NIOPosix", package: "swift-nio"),

--- a/Sources/Hummingbird/Server/RequestContext.swift
+++ b/Sources/Hummingbird/Server/RequestContext.swift
@@ -122,21 +122,6 @@ public protocol HBRequestContext: HBBaseRequestContext {
     ///   - channel: Channel that initiated this request
     ///   - logger: Logger used for this request
     init(channel: Channel, logger: Logger)
-    /// initialize an `HBRequestContext`
-    /// - Parameters
-    ///   - allocator: ByteBuffer allocator
-    ///   - logger: Logger used for this request
-    init(allocator: ByteBufferAllocator, logger: Logger)
-}
-
-extension HBRequestContext {
-    ///  Initialize an `HBRequestContext`
-    /// - Parameters:
-    ///   - channel: Channel that initiated this request
-    ///   - logger: Logger used for this request
-    public init(channel: Channel, logger: Logger) {
-        self.init(allocator: channel.allocator, logger: logger)
-    }
 }
 
 /// Implementation of a basic request context that supports everything the Hummingbird library needs
@@ -148,12 +133,9 @@ public struct HBBasicRequestContext: HBRequestContext {
     /// - Parameters:
     ///   - allocator: Allocator
     ///   - logger: Logger
-    public init(
-        allocator: ByteBufferAllocator,
-        logger: Logger
-    ) {
+    public init(channel: Channel, logger: Logger) {
         self.coreContext = .init(
-            allocator: allocator,
+            allocator: channel.allocator,
             logger: logger
         )
     }

--- a/Sources/HummingbirdRouter/RouterBuilderContext.swift
+++ b/Sources/HummingbirdRouter/RouterBuilderContext.swift
@@ -37,8 +37,8 @@ public struct HBBasicRouterRequestContext: HBRequestContext, HBRouterRequestCont
     public var routerContext: HBRouterBuilderContext
     public var coreContext: HBCoreRequestContext
 
-    public init(allocator: ByteBufferAllocator, logger: Logger) {
-        self.coreContext = .init(allocator: allocator, logger: logger)
+    public init(channel: Channel, logger: Logger) {
+        self.coreContext = .init(allocator: channel.allocator, logger: logger)
         self.routerContext = .init()
     }
 }

--- a/Sources/HummingbirdXCT/HBXCTRouter.swift
+++ b/Sources/HummingbirdXCT/HBXCTRouter.swift
@@ -14,6 +14,7 @@
 
 import Atomics
 import HTTPTypes
+import NIOEmbedded
 @_spi(HBXCT) import Hummingbird
 @_spi(HBXCT) import HummingbirdCore
 import Logging
@@ -38,7 +39,7 @@ struct HBXCTRouter<Responder: HBResponder>: HBXCTApplication where Responder.Con
         self.logger = app.logger
         self.makeContext = { logger in
             Responder.Context(
-                allocator: ByteBufferAllocator(),
+                channel: NIOAsyncTestingChannel(),
                 logger: logger
             )
         }

--- a/Tests/HummingbirdRouterTests/RouterTests.swift
+++ b/Tests/HummingbirdRouterTests/RouterTests.swift
@@ -434,9 +434,9 @@ public struct HBTestRouterContext2: HBRouterRequestContext, HBRequestContext {
     /// additional data
     public var string: String
 
-    public init(allocator: ByteBufferAllocator, logger: Logger) {
+    public init(channel: Channel, logger: Logger) {
         self.routerContext = .init()
-        self.coreContext = .init(allocator: allocator, logger: logger)
+        self.coreContext = .init(allocator: channel.allocator, logger: logger)
         self.string = ""
     }
 }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -334,8 +334,8 @@ final class ApplicationTests: XCTestCase {
                 return encoder
             }
 
-            init(allocator: ByteBufferAllocator, logger: Logger) {
-                self.coreContext = .init(allocator: allocator, logger: logger)
+            init(channel: Channel, logger: Logger) {
+                self.coreContext = .init(allocator: channel.allocator, logger: logger)
             }
         }
         struct Name: HBResponseCodable {
@@ -404,8 +404,8 @@ final class ApplicationTests: XCTestCase {
 
     func testMaxUploadSize() async throws {
         struct MaxUploadRequestContext: HBRequestContext {
-            init(allocator: ByteBufferAllocator, logger: Logger) {
-                self.coreContext = .init(allocator: allocator, logger: logger)
+            init(channel: Channel, logger: Logger) {
+                self.coreContext = .init(allocator: channel.allocator, logger: logger)
             }
 
             var coreContext: HBCoreRequestContext

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -448,11 +448,6 @@ final class ApplicationTests: XCTestCase {
                 self.coreContext = .init(allocator: channel.allocator, logger: logger)
                 self.remoteAddress = channel.remoteAddress
             }
-
-            init(allocator: ByteBufferAllocator, logger: Logger) {
-                self.coreContext = .init(allocator: allocator, logger: logger)
-                self.remoteAddress = nil
-            }
         }
         let router = HBRouter(context: HBSocketAddressRequestContext.self)
         router.get("/") { _, context -> String in

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -483,18 +483,15 @@ final class RouterTests: XCTestCase {
     }
 }
 
-public struct HBTestRouterContext2: HBRequestContext {
-    public init(
-        allocator: ByteBufferAllocator,
-        logger: Logger
-    ) {
-        self.coreContext = .init(allocator: allocator, logger: logger)
+struct HBTestRouterContext2: HBRequestContext {
+    init(channel: Channel, logger: Logger) {
+        self.coreContext = .init(allocator: channel.allocator, logger: logger)
         self.string = ""
     }
 
     /// parameters
-    public var coreContext: HBCoreRequestContext
+    var coreContext: HBCoreRequestContext
 
     /// additional data
-    public var string: String
+    var string: String
 }

--- a/Tests/HummingbirdTests/URLEncodedForm/Application+URLEncodedFormTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/Application+URLEncodedFormTests.swift
@@ -29,10 +29,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
         var coreContext: HBCoreRequestContext
 
         init(channel: Channel, logger: Logger) {
-            self.coreContext = .init(
-                allocator: channel.allocator,
-                logger: logger
-            )
+            self.coreContext = .init(allocator: channel.allocator, logger: logger)
         }
 
         var requestDecoder: URLEncodedFormDecoder { .init() }

--- a/Tests/HummingbirdTests/URLEncodedForm/Application+URLEncodedFormTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/Application+URLEncodedFormTests.swift
@@ -15,6 +15,7 @@
 import Hummingbird
 import HummingbirdXCT
 import Logging
+import NIOCore
 import XCTest
 
 class HummingBirdURLEncodedTests: XCTestCase {
@@ -27,9 +28,9 @@ class HummingBirdURLEncodedTests: XCTestCase {
     struct URLEncodedCodingRequestContext: HBRequestContext {
         var coreContext: HBCoreRequestContext
 
-        init(allocator: ByteBufferAllocator, logger: Logger) {
+        init(channel: Channel, logger: Logger) {
             self.coreContext = .init(
-                allocator: allocator,
+                allocator: channel.allocator,
                 logger: logger
             )
         }


### PR DESCRIPTION
Instead users will need to implement `HBRequestChannel.init(channel:logger:)` which previously had a default implementation