### PR TITLE
HBFileIO changes

### DIFF
--- a/Sources/Hummingbird/Files/FileMiddleware.swift
+++ b/Sources/Hummingbird/Files/FileMiddleware.swift
@@ -197,7 +197,7 @@ public struct HBFileMiddleware<Context: HBBaseRequestContext>: HBMiddlewareProto
                 switch request.method {
                 case .get:
                     if let range {
-                        let (body, _) = try await self.fileIO.loadFile(path: fullPath, range: range, context: context)
+                        let body = try await self.fileIO.loadFile(path: fullPath, range: range, context: context)
                         return HBResponse(status: .partialContent, headers: headers, body: body)
                     }
 

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -112,7 +112,7 @@ extension HTTPChannelHandler {
             // channel is being closed because we received a connection: close header
         } catch {
             // we got here because we failed to either read or write to the channel
-            logger.trace("Failed to read/write to Channel. Error: \(error)")
+            logger.debug("Failed to read/write to Channel. Error: \(error)")
         }
     }
 

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -112,7 +112,7 @@ extension HTTPChannelHandler {
             // channel is being closed because we received a connection: close header
         } catch {
             // we got here because we failed to either read or write to the channel
-            logger.debug("Failed to read/write to Channel. Error: \(error)")
+            logger.trace("Failed to read/write to Channel. Error: \(error)")
         }
     }
 


### PR DESCRIPTION
- Added `makeDirectory`
- `writeFile` can be used to write arbitrary buffers, or sequences of buffers
- Don't return size from `loadFile` as it is already available in returned response body