### PR TITLE
Jobs Refactor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,6 +74,8 @@ let package = Package(
                 .product(name: "Collections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
             ],
             swiftSettings: swiftSettings

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
@@ -70,8 +71,10 @@ let package = Package(
         .target(
             name: "HummingbirdJobs",
             dependencies: [
-                .byName(name: "Hummingbird"),
+                .product(name: "Collections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
             ],
             swiftSettings: swiftSettings
         ),
@@ -138,6 +141,7 @@ let package = Package(
         .testTarget(name: "HummingbirdJobsTests", dependencies: [
             .byName(name: "HummingbirdJobs"),
             .byName(name: "HummingbirdXCT"),
+            .product(name: "Atomics", package: "swift-atomics"),
         ]),
         .testTarget(name: "HummingbirdRouterTests", dependencies: [
             .byName(name: "HummingbirdRouter"),

--- a/Sources/HummingbirdJobs/Job.swift
+++ b/Sources/HummingbirdJobs/Job.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2023 the Hummingbird authors
+// Copyright (c) 2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,83 +12,38 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-import Logging
-import NIOConcurrencyHelpers
-import NIOCore
-
-/// Protocol for job description
-///
-/// For a job to be decodable, it has to be registered. Call `MyJob.register()` to register a job.
-public protocol HBJob: Codable, Sendable {
-    /// Unique Job name
-    static var name: String { get }
-
-    /// Maximum times this job should be retried if it fails
-    static var maxRetryCount: Int { get }
-
-    /// Execute job
-    /// - Returns: EventLoopFuture that is fulfulled when job is done
-    func execute(logger: Logger) async throws
+/// Protocol for a Job
+public protocol HBJob: Sendable {
+    /// Parameters job requries
+    associatedtype Parameters: Codable & Sendable
+    /// Job Type identifier
+    var id: HBJobIdentifier<Parameters> { get }
+    /// Maximum number of times a job will be retried before being classed as failed
+    var maxRetryCount: Int { get }
+    /// Function to execute the job
+    func execute(context: HBJobContext) async throws
 }
 
 extension HBJob {
-    /// maximum times this job should be retried
-    public static var maxRetryCount: Int { return 0 }
-
-    /// register job
-    public static func register() {
-        HBJobRegister.register(job: Self.self)
+    /// name of job type
+    public var name: String {
+        id.name
     }
 }
 
-/// Register Jobs, for decoding and encoding
-enum HBJobRegister {
-    static func decode(from decoder: Decoder) throws -> HBJob {
-        let container = try decoder.container(keyedBy: _HBJobCodingKey.self)
-        let key = container.allKeys.first!
-        let childDecoder = try container.superDecoder(forKey: key)
-        let jobType = try HBJobRegister.nameTypeMap.withLockedValue {
-            guard let job = $0[key.stringValue] else { throw JobQueueError.decodeJobFailed }
-            return job
-        }
-        return try jobType.init(from: childDecoder)
+/// Type used internally by job queue implementations to encode a job request
+public struct _HBJobRequest<Parameters: Codable & Sendable>: Encodable, Sendable {
+    let id: HBJobIdentifier<Parameters>
+    let parameters: Parameters
+
+    public init(id: HBJobIdentifier<Parameters>, parameters: Parameters) {
+        self.id = id
+        self.parameters = parameters
     }
 
-    static func encode(job: HBJob, to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: _HBJobCodingKey.self)
-        let childEncoder = container.superEncoder(forKey: .init(stringValue: type(of: job).name, intValue: nil))
-        try job.encode(to: childEncoder)
-    }
-
-    static func register(job: HBJob.Type) {
-        self.nameTypeMap.withLockedValue { $0[job.name] = job }
-    }
-
-    static let nameTypeMap: NIOLockedValueBox<[String: HBJob.Type]> = .init([:])
-}
-
-internal struct _HBJobCodingKey: CodingKey {
-    public var stringValue: String
-    public var intValue: Int?
-
-    public init?(stringValue: String) {
-        self.stringValue = stringValue
-        self.intValue = nil
-    }
-
-    public init?(intValue: Int) {
-        self.stringValue = "\(intValue)"
-        self.intValue = intValue
-    }
-
-    public init(stringValue: String, intValue: Int?) {
-        self.stringValue = stringValue
-        self.intValue = intValue
-    }
-
-    internal init(index: Int) {
-        self.stringValue = "Index \(index)"
-        self.intValue = index
+        let childEncoder = container.superEncoder(forKey: .init(stringValue: self.id.name, intValue: nil))
+        try self.parameters.encode(to: childEncoder)
     }
 }

--- a/Sources/HummingbirdJobs/Job.swift
+++ b/Sources/HummingbirdJobs/Job.swift
@@ -30,20 +30,3 @@ extension HBJob {
         id.name
     }
 }
-
-/// Type used internally by job queue implementations to encode a job request
-public struct _HBJobRequest<Parameters: Codable & Sendable>: Encodable, Sendable {
-    let id: HBJobIdentifier<Parameters>
-    let parameters: Parameters
-
-    public init(id: HBJobIdentifier<Parameters>, parameters: Parameters) {
-        self.id = id
-        self.parameters = parameters
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: _HBJobCodingKey.self)
-        let childEncoder = container.superEncoder(forKey: .init(stringValue: self.id.name, intValue: nil))
-        try self.parameters.encode(to: childEncoder)
-    }
-}

--- a/Sources/HummingbirdJobs/JobContext.swift
+++ b/Sources/HummingbirdJobs/JobContext.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,4 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_exported @_documentation(visibility: internal) import struct Logging.Logger
+import Logging
+
+public struct HBJobContext {
+    public let logger: Logger
+}

--- a/Sources/HummingbirdJobs/JobDefinition.swift
+++ b/Sources/HummingbirdJobs/JobDefinition.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Job definition type
+public struct HBJobDefinition<Parameters: Codable & Sendable> {
+    let id: HBJobIdentifier<Parameters>
+    let maxRetryCount: Int
+    let _execute: @Sendable (Parameters, HBJobContext) async throws -> Void
+
+    public init(id: HBJobIdentifier<Parameters>, maxRetryCount: Int = 0, execute: @escaping @Sendable (Parameters, HBJobContext) async throws -> Void) {
+        self.id = id
+        self.maxRetryCount = maxRetryCount
+        self._execute = execute
+    }
+
+    func execute(_ parameters: Parameters, context: HBJobContext) async throws {
+        try await self._execute(parameters, context)
+    }
+}

--- a/Sources/HummingbirdJobs/JobDefinition.swift
+++ b/Sources/HummingbirdJobs/JobDefinition.swift
@@ -14,7 +14,7 @@
 
 /// Job definition type
 public struct HBJobDefinition<Parameters: Codable & Sendable>: Sendable {
-    let id: HBJobIdentifier<Parameters>
+    public let id: HBJobIdentifier<Parameters>
     let maxRetryCount: Int
     let _execute: @Sendable (Parameters, HBJobContext) async throws -> Void
 

--- a/Sources/HummingbirdJobs/JobDefinition.swift
+++ b/Sources/HummingbirdJobs/JobDefinition.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Job definition type
-public struct HBJobDefinition<Parameters: Codable & Sendable> {
+public struct HBJobDefinition<Parameters: Codable & Sendable>: Sendable {
     let id: HBJobIdentifier<Parameters>
     let maxRetryCount: Int
     let _execute: @Sendable (Parameters, HBJobContext) async throws -> Void

--- a/Sources/HummingbirdJobs/JobIdentifier.swift
+++ b/Sources/HummingbirdJobs/JobIdentifier.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Identifier for a Job type
+///
+/// The identifier includes the type of the parameters required by the job to ensure
+/// the wrong parameters are not passed to this job
+///
+/// Extend this type to include your own job identifiers
+/// ```
+/// extension HBJobIdentifier<String> {
+///     static var myJob: Self { .init("my-job") }
+/// }
+/// ```
+public struct HBJobIdentifier<Parameters>: Sendable, Hashable {
+    let name: String
+    public init(_ name: String, parameters: Parameters.Type = Parameters.self) { self.name = name }
+}

--- a/Sources/HummingbirdJobs/JobIdentifier.swift
+++ b/Sources/HummingbirdJobs/JobIdentifier.swift
@@ -23,7 +23,20 @@
 ///     static var myJob: Self { .init("my-job") }
 /// }
 /// ```
-public struct HBJobIdentifier<Parameters>: Sendable, Hashable {
+public struct HBJobIdentifier<Parameters>: Sendable, Hashable, ExpressibleByStringLiteral {
     let name: String
+    /// Initialize a HBJobIdentifier
+    ///
+    /// - Parameters:
+    ///   - name: Unique name for identifier
+    ///   - parameters: Parameter type associated with Job
     public init(_ name: String, parameters: Parameters.Type = Parameters.self) { self.name = name }
+
+    /// Initialize a HBJobIdentifier from a string literal
+    ///
+    /// This can only be used in a situation where the Parameter type is defined elsewhere
+    /// - Parameter string:
+    public init(stringLiteral string: String) {
+        self.name = string
+    }
 }

--- a/Sources/HummingbirdJobs/JobQueue.swift
+++ b/Sources/HummingbirdJobs/JobQueue.swift
@@ -23,7 +23,8 @@ import ServiceLifecycle
 /// with the queue via either ``HBJobQueue.registerJob(id:maxRetryCount:execute:)`` or
 /// ``HBJobQueue.registerJob(_:)``.
 public struct HBJobQueue<Queue: HBJobQueueDriver>: Service {
-    let queue: Queue
+    /// underlying driver for queue
+    public let queue: Queue
     let handler: HBJobQueueHandler<Queue>
 
     public init(_ queue: Queue, numWorkers: Int = 1, logger: Logger) {
@@ -62,7 +63,7 @@ public struct HBJobQueue<Queue: HBJobQueueDriver>: Service {
     ///  Register job type
     /// - Parameters:
     ///   - job: Job definition
-    public func registerJob<Parameters: Codable & Sendable>(_ job: HBJobDefinition<Parameters>) {
+    public func registerJob(_ job: HBJobDefinition<some Codable & Sendable>) {
         self.handler.registerJob(job)
     }
 

--- a/Sources/HummingbirdJobs/JobQueue.swift
+++ b/Sources/HummingbirdJobs/JobQueue.swift
@@ -26,7 +26,7 @@ public protocol HBJobQueue: AsyncSequence, Sendable where Element == HBQueuedJob
     func onInit() async throws
     /// Push Job onto queue
     /// - Returns: Identifier of queued job
-    @discardableResult func push(_ job: HBJob) async throws -> JobID
+    @discardableResult func push<Parameters: Codable & Sendable>(id: HBJobIdentifier<Parameters>, parameters: Parameters) async throws -> JobID
     /// This is called to say job has finished processing and it can be deleted
     func finished(jobId: JobID) async throws
     /// This is called to say job has failed to run and should be put aside

--- a/Sources/HummingbirdJobs/JobQueue.swift
+++ b/Sources/HummingbirdJobs/JobQueue.swift
@@ -32,7 +32,10 @@ public struct HBJobQueue<Queue: HBJobQueueDriver>: Service {
         self.handler = .init(queue: queue, numWorkers: numWorkers, logger: logger)
     }
 
-    /// Push Job onto queue
+    ///  Push Job onto queue
+    /// - Parameters:
+    ///   - id: Job identifier
+    ///   - parameters: parameters for the job
     /// - Returns: Identifier of queued job
     @discardableResult public func push<Parameters: Codable & Sendable>(id: HBJobIdentifier<Parameters>, parameters: Parameters) async throws -> Queue.JobID {
         let jobRequest = HBJobRequest(id: id, parameters: parameters)

--- a/Sources/HummingbirdJobs/JobQueue.swift
+++ b/Sources/HummingbirdJobs/JobQueue.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import Hummingbird
 import Logging
 import ServiceLifecycle
 
@@ -43,7 +42,7 @@ public struct HBJobQueue<Queue: HBJobQueueDriver>: Service {
         return try await self.queue.push(data: data)
     }
 
-    ///  Register job
+    ///  Register job type
     /// - Parameters:
     ///   - id: Job Identifier
     ///   - maxRetryCount: Maximum number of times job is retried before being flagged as failed
@@ -57,15 +56,13 @@ public struct HBJobQueue<Queue: HBJobQueueDriver>: Service {
         ) async throws -> Void
     ) {
         let job = HBJobDefinition<Parameters>(id: id, maxRetryCount: maxRetryCount, execute: execute)
-        self.handler.registerJob(job)
+        self.registerJob(job)
     }
 
-    ///  Register job
+    ///  Register job type
     /// - Parameters:
-    ///   - id: Job Identifier
-    ///   - maxRetryCount: Maximum number of times job is retried before being flagged as failed
-    ///   - execute: Job code
-    public func registerJob(_ job: HBJobDefinition<some Codable & Sendable>) {
+    ///   - job: Job definition
+    public func registerJob<Parameters: Codable & Sendable>(_ job: HBJobDefinition<Parameters>) {
         self.handler.registerJob(job)
     }
 

--- a/Sources/HummingbirdJobs/JobQueue.swift
+++ b/Sources/HummingbirdJobs/JobQueue.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2023 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/HummingbirdJobs/JobQueueDriver.swift
+++ b/Sources/HummingbirdJobs/JobQueueDriver.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import Logging
+import NIOCore
 
 /// Job queue protocol.
 ///
@@ -25,7 +26,7 @@ public protocol HBJobQueueDriver: AsyncSequence, Sendable where Element == HBQue
     func onInit() async throws
     /// Push Job onto queue
     /// - Returns: Identifier of queued job
-    func push(data: Data) async throws -> JobID
+    func push(_ buffer: ByteBuffer) async throws -> JobID
     /// This is called to say job has finished processing and it can be deleted
     func finished(jobId: JobID) async throws
     /// This is called to say job has failed to run and should be put aside

--- a/Sources/HummingbirdJobs/JobQueueDriver.swift
+++ b/Sources/HummingbirdJobs/JobQueueDriver.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Hummingbird
+import Logging
+
+/// Job queue protocol.
+///
+/// Defines how to push and pop job data off a queue
+public protocol HBJobQueueDriver: AsyncSequence, Sendable where Element == HBQueuedJob<JobID> {
+    associatedtype JobID: CustomStringConvertible & Sendable
+
+    /// Called when JobQueueHandler is initialised with this queue
+    func onInit() async throws
+    /// Push Job onto queue
+    /// - Returns: Identifier of queued job
+    func push(data: Data) async throws -> JobID
+    /// This is called to say job has finished processing and it can be deleted
+    func finished(jobId: JobID) async throws
+    /// This is called to say job has failed to run and should be put aside
+    func failed(jobId: JobID, error: any Error) async throws
+    /// stop serving jobs
+    func stop() async
+    /// shutdown queue
+    func shutdownGracefully() async
+}
+
+extension HBJobQueueDriver {
+    // default version of onInit doing nothing
+    public func onInit() async throws {}
+}

--- a/Sources/HummingbirdJobs/JobQueueDriver.swift
+++ b/Sources/HummingbirdJobs/JobQueueDriver.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import Hummingbird
 import Logging
 
 /// Job queue protocol.

--- a/Sources/HummingbirdJobs/JobQueueDriver.swift
+++ b/Sources/HummingbirdJobs/JobQueueDriver.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2023 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/HummingbirdJobs/JobQueueError.swift
+++ b/Sources/HummingbirdJobs/JobQueueError.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/HummingbirdJobs/JobQueueError.swift
+++ b/Sources/HummingbirdJobs/JobQueueError.swift
@@ -17,11 +17,14 @@ public struct JobQueueError: Error, Equatable {
     /// failed to decode job. Possibly because it hasn't been registered or data that was expected
     /// is not available
     public static var decodeJobFailed: Self { .init(.decodeJobFailed) }
+    /// failed to decode job as the job id is not recognised
+    public static var unrecognisedJobId: Self { .init(.unrecognisedJobId) }
     /// failed to get job from queue
     public static var dequeueError: Self { .init(.dequeueError) }
 
     private enum QueueError {
         case decodeJobFailed
+        case unrecognisedJobId
         case dequeueError
     }
 

--- a/Sources/HummingbirdJobs/JobQueueHandler.swift
+++ b/Sources/HummingbirdJobs/JobQueueHandler.swift
@@ -23,7 +23,7 @@ final class HBJobQueueHandler<Queue: HBJobQueueDriver>: Service {
         self.queue = queue
         self.numWorkers = numWorkers
         self.logger = logger
-        self.jobRegister = .init()
+        self.jobRegistry = .init()
     }
 
     ///  Register job
@@ -32,7 +32,7 @@ final class HBJobQueueHandler<Queue: HBJobQueueDriver>: Service {
     ///   - maxRetryCount: Maximum number of times job is retried before being flagged as failed
     ///   - execute: Job code
     func registerJob(_ job: HBJobDefinition<some Codable & Sendable>) {
-        self.jobRegister.registerJob(job: job)
+        self.jobRegistry.registerJob(job: job)
     }
 
     func run() async throws {
@@ -69,7 +69,7 @@ final class HBJobQueueHandler<Queue: HBJobQueueDriver>: Service {
         logger[metadataKey: "hb_job_id"] = .stringConvertible(queuedJob.id)
         let job: any HBJob
         do {
-            job = try self.jobRegister.decode(data: queuedJob.jobData)
+            job = try self.jobRegistry.decode(data: queuedJob.jobData)
         } catch let error as JobQueueError where error == .unrecognisedJobId {
             logger.debug("Failed to find Job with ID while decoding")
             try await self.queue.failed(jobId: queuedJob.id, error: error)
@@ -113,7 +113,7 @@ final class HBJobQueueHandler<Queue: HBJobQueueDriver>: Service {
         }
     }
 
-    private let jobRegister: HBJobRegister
+    private let jobRegistry: HBJobRegistry
     private let queue: Queue
     private let numWorkers: Int
     let logger: Logger

--- a/Sources/HummingbirdJobs/JobQueueHandler.swift
+++ b/Sources/HummingbirdJobs/JobQueueHandler.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import AsyncAlgorithms
-import Hummingbird
 import Logging
 import ServiceLifecycle
 

--- a/Sources/HummingbirdJobs/JobQueueHandler.swift
+++ b/Sources/HummingbirdJobs/JobQueueHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/HummingbirdJobs/JobQueueHandler.swift
+++ b/Sources/HummingbirdJobs/JobQueueHandler.swift
@@ -68,16 +68,16 @@ public final class HBJobQueueHandler<Queue: HBJobQueue>: Service {
     func runJob(_ queuedJob: HBQueuedJob<Queue.JobID>) async {
         var logger = logger
         logger[metadataKey: "hb_job_id"] = .stringConvertible(queuedJob.id)
-        logger[metadataKey: "hb_job_type"] = .string(String(describing: type(of: queuedJob.job)))
+        logger[metadataKey: "hb_job_type"] = .string(queuedJob.job.name)
 
         let job = queuedJob.job
-        var count = type(of: job).maxRetryCount
+        var count = job.maxRetryCount
         logger.debug("Starting Job")
 
         do {
             while true {
                 do {
-                    try await job.execute(logger: self.logger)
+                    try await job.execute(context: .init(logger: logger))
                     break
                 } catch let error as CancellationError {
                     logger.debug("Job cancelled")

--- a/Sources/HummingbirdJobs/JobQueueHandler.swift
+++ b/Sources/HummingbirdJobs/JobQueueHandler.swift
@@ -67,7 +67,7 @@ final class HBJobQueueHandler<Queue: HBJobQueueDriver>: Service {
         logger[metadataKey: "hb_job_id"] = .stringConvertible(queuedJob.id)
         let job: any HBJob
         do {
-            job = try self.jobRegistry.decode(data: queuedJob.jobData)
+            job = try self.jobRegistry.decode(queuedJob.jobBuffer)
         } catch let error as JobQueueError where error == .unrecognisedJobId {
             logger.debug("Failed to find Job with ID while decoding")
             try await self.queue.failed(jobId: queuedJob.id, error: error)

--- a/Sources/HummingbirdJobs/JobRegister.swift
+++ b/Sources/HummingbirdJobs/JobRegister.swift
@@ -34,7 +34,10 @@ public enum HBJobRegister {
             let parameters = try Parameters(from: decoder)
             return try HBJobInstance(job: definition, parameters: parameters)
         }
-        self.idTypeMap.withLockedValue { $0[id.name] = builder }
+        self.idTypeMap.withLockedValue {
+            precondition($0[id.name] == nil, "There is a job already registered under id \"\(id.name)\"")
+            $0[id.name] = builder
+        }
     }
 
     static func decode(from decoder: Decoder) throws -> any HBJob {

--- a/Sources/HummingbirdJobs/JobRegister.swift
+++ b/Sources/HummingbirdJobs/JobRegister.swift
@@ -36,7 +36,7 @@ struct HBJobRegister: Sendable {
     }
 
     func decode(data: Data) throws -> any HBJob {
-        return try JSONDecoder().decode(HBAnyCodableJob.self, from: data, configuration: self).job
+        return try JSONDecoder().decode(HBAnyCodableJob.self, from: data, userInfoConfiguration: self).job
     }
 
     func decode(from decoder: Decoder) throws -> any HBJob {
@@ -75,7 +75,7 @@ internal struct HBJobInstance<Parameters: Codable & Sendable>: HBJob {
 }
 
 /// Add codable support for decoding/encoding any HBJob
-internal struct HBAnyCodableJob: DecodableWithConfiguration, Sendable {
+internal struct HBAnyCodableJob: DecodableWithUserInfoConfiguration, Sendable {
     typealias DecodingConfiguration = HBJobRegister
 
     init(from decoder: Decoder, configuration register: DecodingConfiguration) throws {

--- a/Sources/HummingbirdJobs/JobRegister.swift
+++ b/Sources/HummingbirdJobs/JobRegister.swift
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOConcurrencyHelpers
+
+/// Registry for job types
+public enum HBJobRegister {
+    ///  Register job
+    /// - Parameters:
+    ///   - id: Job Identifier
+    ///   - maxRetryCount: Maximum number of times job is retried before being flagged as failed
+    ///   - execute: Job code
+    public static func registerJob<Parameters: Codable & Sendable>(
+        _ id: HBJobIdentifier<Parameters>,
+        maxRetryCount: Int = 0,
+        execute: @escaping @Sendable (
+            Parameters,
+            HBJobContext
+        ) async throws -> Void
+    ) {
+        let definition = HBJobInstance<Parameters>.Definition(id: id, maxRetryCount: maxRetryCount, execute: execute)
+        let builder = { (decoder: Decoder) in
+            let parameters = try Parameters(from: decoder)
+            return try HBJobInstance(job: definition, parameters: parameters)
+        }
+        self.idTypeMap.withLockedValue { $0[id.name] = builder }
+    }
+
+    static func decode(from decoder: Decoder) throws -> any HBJob {
+        let container = try decoder.container(keyedBy: _HBJobCodingKey.self)
+        let key = container.allKeys.first!
+        let childDecoder = try container.superDecoder(forKey: key)
+        let jobDefinitionBuilder = try Self.idTypeMap.withLockedValue {
+            guard let job = $0[key.stringValue] else { throw JobQueueError.decodeJobFailed }
+            return job
+        }
+        return try jobDefinitionBuilder(childDecoder)
+    }
+
+    static let idTypeMap: NIOLockedValueBox < [String: (Decoder) throws -> any HBJob]> = .init([:])
+}
+
+/// Internal job instance type
+struct HBJobInstance<Parameters: Codable & Sendable>: HBJob {
+    /// Job definition type
+    struct Definition {
+        let id: HBJobIdentifier<Parameters>
+        let maxRetryCount: Int
+        let _execute: @Sendable (Parameters, HBJobContext) async throws -> Void
+
+        init(id: HBJobIdentifier<Parameters>, maxRetryCount: Int, execute: @escaping @Sendable (Parameters, HBJobContext) async throws -> Void) {
+            self.id = id
+            self.maxRetryCount = maxRetryCount
+            self._execute = execute
+        }
+
+        public func execute(_ parameters: Parameters, context: HBJobContext) async throws {
+            try await self._execute(parameters, context)
+        }
+    }
+
+    /// job definition
+    let job: Definition
+    /// job parameters
+    let parameters: Parameters
+
+    /// get i
+    var id: HBJobIdentifier<Parameters> { self.job.id }
+    var maxRetryCount: Int { self.job.maxRetryCount }
+
+    func execute(context: HBJobContext) async throws {
+        try await self.job.execute(self.parameters, context: context)
+    }
+
+    init(job: Definition, parameters: Parameters) throws {
+        self.job = job
+        self.parameters = parameters
+    }
+}
+
+internal struct _HBJobCodingKey: CodingKey {
+    public var stringValue: String
+    public var intValue: Int?
+
+    public init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    public init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+
+    public init(stringValue: String, intValue: Int?) {
+        self.stringValue = stringValue
+        self.intValue = intValue
+    }
+
+    internal init(index: Int) {
+        self.stringValue = "Index \(index)"
+        self.intValue = index
+    }
+}

--- a/Sources/HummingbirdJobs/JobRegister.swift
+++ b/Sources/HummingbirdJobs/JobRegister.swift
@@ -25,7 +25,7 @@ struct HBJobRegister: Sendable {
     public func registerJob<Parameters: Codable & Sendable>(
         job: HBJobDefinition<Parameters>
     ) {
-        let builder = { (decoder: Decoder) in
+        let builder: @Sendable (Decoder) throws -> any HBJob = { decoder in
             let parameters = try Parameters(from: decoder)
             return try HBJobInstance<Parameters>(job: job, parameters: parameters)
         }

--- a/Sources/HummingbirdJobs/JobRegistry.swift
+++ b/Sources/HummingbirdJobs/JobRegistry.swift
@@ -16,7 +16,7 @@ import Foundation
 import NIOConcurrencyHelpers
 
 /// Registry for job types
-struct HBJobRegister: Sendable {
+struct HBJobRegistry: Sendable {
     ///  Register job
     /// - Parameters:
     ///   - id: Job Identifier
@@ -76,7 +76,7 @@ internal struct HBJobInstance<Parameters: Codable & Sendable>: HBJob {
 
 /// Add codable support for decoding/encoding any HBJob
 internal struct HBAnyCodableJob: DecodableWithUserInfoConfiguration, Sendable {
-    typealias DecodingConfiguration = HBJobRegister
+    typealias DecodingConfiguration = HBJobRegistry
 
     init(from decoder: Decoder, configuration register: DecodingConfiguration) throws {
         self.job = try register.decode(from: decoder)

--- a/Sources/HummingbirdJobs/JobRegistry.swift
+++ b/Sources/HummingbirdJobs/JobRegistry.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import NIOConcurrencyHelpers
+import NIOCore
 
 /// Registry for job types
 struct HBJobRegistry: Sendable {
@@ -35,8 +36,8 @@ struct HBJobRegistry: Sendable {
         }
     }
 
-    func decode(data: Data) throws -> any HBJob {
-        return try JSONDecoder().decode(HBAnyCodableJob.self, from: data, userInfoConfiguration: self).job
+    func decode(_ buffer: ByteBuffer) throws -> any HBJob {
+        return try JSONDecoder().decode(HBAnyCodableJob.self, from: buffer, userInfoConfiguration: self).job
     }
 
     func decode(from decoder: Decoder) throws -> any HBJob {

--- a/Sources/HummingbirdJobs/MemoryJobQueue.swift
+++ b/Sources/HummingbirdJobs/MemoryJobQueue.swift
@@ -16,7 +16,7 @@ import Collections
 import Foundation
 
 /// In memory implementation of job queue driver. Stores jobs in a circular buffer
-public final class HBMemoryJobQueue: HBJobQueue {
+public final class HBMemoryJobQueue: HBJobQueueDriver {
     public typealias Element = HBQueuedJob<JobID>
     public typealias JobID = UUID
 
@@ -45,7 +45,7 @@ public final class HBMemoryJobQueue: HBJobQueue {
     ///   - job: Job
     ///   - eventLoop: Eventloop to run process on (ignored in this case)
     /// - Returns: Queued job
-    @discardableResult public func _push(data: Data) async throws -> JobID {
+    @discardableResult public func push(data: Data) async throws -> JobID {
         return try await self.queue.push(data)
     }
 
@@ -93,12 +93,8 @@ public final class HBMemoryJobQueue: HBJobQueue {
                     return nil
                 }
                 if let request = queue.popFirst() {
-                    do {
-                        self.pendingJobs[request.id] = request.jobData
-                        return request
-                    } catch {
-                        throw JobQueueError.decodeJobFailed
-                    }
+                    self.pendingJobs[request.id] = request.jobData
+                    return request
                 }
                 try await Task.sleep(for: .milliseconds(100))
             }

--- a/Sources/HummingbirdJobs/MemoryJobQueue.swift
+++ b/Sources/HummingbirdJobs/MemoryJobQueue.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/HummingbirdJobs/MemoryJobQueue.swift
+++ b/Sources/HummingbirdJobs/MemoryJobQueue.swift
@@ -15,8 +15,8 @@
 import Collections
 import Foundation
 
-/// In memory implementation of job queue driver. Stores jobs in a circular buffer
-public final class HBMemoryJobQueue: HBJobQueueDriver {
+/// In memory implementation of job queue driver. Stores job data in a circular buffer
+public final class HBMemoryQueue: HBJobQueueDriver {
     public typealias Element = HBQueuedJob<JobID>
     public typealias JobID = UUID
 
@@ -111,7 +111,7 @@ public final class HBMemoryJobQueue: HBJobQueueDriver {
     }
 }
 
-extension HBMemoryJobQueue {
+extension HBMemoryQueue {
     public struct AsyncIterator: AsyncIteratorProtocol {
         fileprivate let queue: Internal
 
@@ -122,5 +122,14 @@ extension HBMemoryJobQueue {
 
     public func makeAsyncIterator() -> AsyncIterator {
         .init(queue: self.queue)
+    }
+}
+
+extension HBJobQueueDriver where Self == HBMemoryQueue {
+    /// Return In memory driver for Job Queue
+    /// - Parameters:
+    ///   - onFailedJob: Closure called when a job fails
+    public static var memory: HBMemoryQueue {
+        .init()
     }
 }

--- a/Sources/HummingbirdJobs/QueuedJob.swift
+++ b/Sources/HummingbirdJobs/QueuedJob.swift
@@ -13,17 +13,18 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import NIOCore
 
 /// Queued job. Includes job data, plus the id for the job
 public struct HBQueuedJob<JobID: Sendable>: Sendable {
     /// Job instance id
     public let id: JobID
     /// Job data
-    public let jobData: Data
+    public let jobBuffer: ByteBuffer
 
     /// Initialize a queue job
-    public init(id: JobID, jobData: Data) {
-        self.jobData = jobData
+    public init(id: JobID, jobBuffer: ByteBuffer) {
+        self.jobBuffer = jobBuffer
         self.id = id
     }
 }

--- a/Sources/HummingbirdJobs/QueuedJob.swift
+++ b/Sources/HummingbirdJobs/QueuedJob.swift
@@ -14,35 +14,16 @@
 
 import Foundation
 
-/// Add codable support for decoding/encoding any HBJob
-public struct HBAnyCodableJob: Decodable, Sendable {
-    /// Job data
-    public let job: any HBJob
-
-    /// Initialize a queue job
-    public init(_ job: any HBJob) {
-        self.job = job
-    }
-
-    public init(from decoder: Decoder) throws {
-        self.job = try HBJobRegister.decode(from: decoder)
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case job
-    }
-}
-
-/// Queued job. Includes job, plus the id for the job
+/// Queued job. Includes job data, plus the id for the job
 public struct HBQueuedJob<JobID: Sendable>: Sendable {
     /// Job instance id
     public let id: JobID
     /// Job data
-    public let job: any HBJob
+    public let jobData: Data
 
     /// Initialize a queue job
-    public init(id: JobID, job: any HBJob) {
-        self.job = job
+    public init(id: JobID, jobData: Data) {
+        self.jobData = jobData
         self.id = id
     }
 }

--- a/Sources/HummingbirdJobs/QueuedJob.swift
+++ b/Sources/HummingbirdJobs/QueuedJob.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2023 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/HummingbirdJobs/QueuedJob.swift
+++ b/Sources/HummingbirdJobs/QueuedJob.swift
@@ -15,25 +15,17 @@
 import Foundation
 
 /// Add codable support for decoding/encoding any HBJob
-public struct HBAnyCodableJob: Codable, Sendable {
+public struct HBAnyCodableJob: Decodable, Sendable {
     /// Job data
-    public let job: HBJob
+    public let job: any HBJob
 
     /// Initialize a queue job
-    public init(_ job: HBJob) {
+    public init(_ job: any HBJob) {
         self.job = job
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let jobDecoder = try container.superDecoder(forKey: .job)
-        self.job = try HBJobRegister.decode(from: jobDecoder)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        let jobEncoder = container.superEncoder(forKey: .job)
-        try HBJobRegister.encode(job: self.job, to: jobEncoder)
+        self.job = try HBJobRegister.decode(from: decoder)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -43,20 +35,14 @@ public struct HBAnyCodableJob: Codable, Sendable {
 
 /// Queued job. Includes job, plus the id for the job
 public struct HBQueuedJob<JobID: Sendable>: Sendable {
-    /// Job id
+    /// Job instance id
     public let id: JobID
     /// Job data
-    private let _job: HBAnyCodableJob
-    /// Job data
-    public var job: HBJob { self._job.job }
-    /// Job data in a codable form
-    public var anyCodableJob: HBAnyCodableJob { self._job }
+    public let job: any HBJob
 
     /// Initialize a queue job
-    public init(id: JobID, job: HBJob) {
-        self._job = .init(job)
+    public init(id: JobID, job: any HBJob) {
+        self.job = job
         self.id = id
     }
 }
-
-extension HBQueuedJob: Codable where JobID: Codable {}

--- a/Sources/HummingbirdJobs/Utils/DecodableWithUserInfoConfiguration.swift
+++ b/Sources/HummingbirdJobs/Utils/DecodableWithUserInfoConfiguration.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Implementation of DecodableWithConfiguration which extracts the configuration from the userInfo array
+///
+/// This is necessary as Linux Foundation does not have support for setting DecodableWithConfiguration
+/// configuration from the JSONDecoder
+protocol DecodableWithUserInfoConfiguration: Decodable, DecodableWithConfiguration {}
+
+/// Implement `init(from: Decoder)`` by extracting configuration from the userInfo dictionary.
+extension DecodableWithUserInfoConfiguration {
+    init(from decoder: Decoder) throws {
+        guard let configuration = decoder.userInfo[.configuration] as? DecodingConfiguration else {
+            throw DecodingError.valueNotFound(DecodingConfiguration.self, .init(codingPath: decoder.codingPath, debugDescription: "Failed to find Decoding configuration"))
+        }
+        try self.init(from: decoder, configuration: configuration)
+    }
+}
+
+extension CodingUserInfoKey {
+    /// Coding UserInfo key used to store DecodableWithUserInfoConfiguration configuration
+    static var configuration: Self { return .init(rawValue: "_configuration_")! }
+}
+
+extension JSONDecoder {
+    /// Version of JSONDecoder that sets up configuration userInfo for the DecodableWithUserInfoConfiguration
+    /// protocol
+    func decode<T>(
+        _ type: T.Type,
+        from data: Data,
+        userInfoConfiguration: T.DecodingConfiguration
+    ) throws -> T where T: DecodableWithUserInfoConfiguration {
+        self.userInfo[.configuration] = userInfoConfiguration
+        return try self.decode(type, from: data)
+    }
+}

--- a/Sources/HummingbirdJobs/Utils/DecodableWithUserInfoConfiguration.swift
+++ b/Sources/HummingbirdJobs/Utils/DecodableWithUserInfoConfiguration.swift
@@ -13,6 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import NIOCore
+import NIOFoundationCompat
 
 /// Implementation of DecodableWithConfiguration which extracts the configuration from the userInfo array
 ///
@@ -40,10 +42,10 @@ extension JSONDecoder {
     /// protocol
     func decode<T>(
         _ type: T.Type,
-        from data: Data,
+        from buffer: ByteBuffer,
         userInfoConfiguration: T.DecodingConfiguration
     ) throws -> T where T: DecodableWithUserInfoConfiguration {
         self.userInfo[.configuration] = userInfoConfiguration
-        return try self.decode(type, from: data)
+        return try self.decode(type, from: buffer)
     }
 }

--- a/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
+++ b/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
@@ -29,7 +29,7 @@ extension XCTestExpectation {
 
 final class HummingbirdJobsTests: XCTestCase {
     func wait(for expectations: [XCTestExpectation], timeout: TimeInterval) async {
-        #if (os(Linux) && swift(<5.10)) || swift(<5.8)
+        #if (os(Linux) && swift(<5.9)) || swift(<5.8)
         super.wait(for: expectations, timeout: timeout)
         #else
         await fulfillment(of: expectations, timeout: timeout)

--- a/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
+++ b/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -15,6 +15,8 @@
 import Atomics
 import HummingbirdJobs
 import HummingbirdXCT
+import Logging
+import NIOConcurrencyHelpers
 import ServiceLifecycle
 import XCTest
 
@@ -59,18 +61,13 @@ final class HummingbirdJobsTests: XCTestCase {
     }
 
     func testBasic() async throws {
-        struct TestJob: HBJob {
-            static let name = "testBasic"
-            static let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 10)
-
-            let value: Int
-            func execute(logger: Logger) async throws {
-                print(self.value)
-                try await Task.sleep(for: .milliseconds(Int.random(in: 10..<50)))
-                Self.expectation.fulfill()
-            }
+        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 10)
+        let jobIdentifer = HBJobIdentifier<Int>(#function)
+        HBJobRegister.registerJob(jobIdentifer) { parameters, context in
+            context.logger.info("Parameters=\(parameters)")
+            try await Task.sleep(for: .milliseconds(Int.random(in: 10..<50)))
+            expectation.fulfill()
         }
-        TestJob.register()
         let jobQueue = HBMemoryJobQueue()
         let jobQueueHandler = HBJobQueueHandler(
             queue: jobQueue,
@@ -78,41 +75,36 @@ final class HummingbirdJobsTests: XCTestCase {
             logger: Logger(label: "HummingbirdJobsTests")
         )
         try await testJobQueue(jobQueueHandler) {
-            try await jobQueue.push(TestJob(value: 1))
-            try await jobQueue.push(TestJob(value: 2))
-            try await jobQueue.push(TestJob(value: 3))
-            try await jobQueue.push(TestJob(value: 4))
-            try await jobQueue.push(TestJob(value: 5))
-            try await jobQueue.push(TestJob(value: 6))
-            try await jobQueue.push(TestJob(value: 7))
-            try await jobQueue.push(TestJob(value: 8))
-            try await jobQueue.push(TestJob(value: 9))
-            try await jobQueue.push(TestJob(value: 10))
+            try await jobQueue.push(id: jobIdentifer, parameters: 1)
+            try await jobQueue.push(id: jobIdentifer, parameters: 2)
+            try await jobQueue.push(id: jobIdentifer, parameters: 3)
+            try await jobQueue.push(id: jobIdentifer, parameters: 4)
+            try await jobQueue.push(id: jobIdentifer, parameters: 5)
+            try await jobQueue.push(id: jobIdentifer, parameters: 6)
+            try await jobQueue.push(id: jobIdentifer, parameters: 7)
+            try await jobQueue.push(id: jobIdentifer, parameters: 8)
+            try await jobQueue.push(id: jobIdentifer, parameters: 9)
+            try await jobQueue.push(id: jobIdentifer, parameters: 10)
 
-            await self.wait(for: [TestJob.expectation], timeout: 5)
+            await self.wait(for: [expectation], timeout: 5)
         }
     }
 
     func testMultipleWorkers() async throws {
-        struct TestJob: HBJob {
-            static let name = "testBasic"
-            static let runningJobCounter = ManagedAtomic(0)
-            static let maxRunningJobCounter = ManagedAtomic(0)
-            static let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 10)
-
-            let value: Int
-            func execute(logger: Logger) async throws {
-                let runningJobs = Self.runningJobCounter.wrappingIncrementThenLoad(by: 1, ordering: .relaxed)
-                if runningJobs > Self.maxRunningJobCounter.load(ordering: .relaxed) {
-                    Self.maxRunningJobCounter.store(runningJobs, ordering: .relaxed)
-                }
-                try await Task.sleep(for: .milliseconds(Int.random(in: 10..<50)))
-                print(self.value)
-                Self.expectation.fulfill()
-                Self.runningJobCounter.wrappingDecrement(by: 1, ordering: .relaxed)
+        let jobIdentifer = HBJobIdentifier<Int>(#function)
+        let runningJobCounter = ManagedAtomic(0)
+        let maxRunningJobCounter = ManagedAtomic(0)
+        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 10)
+        HBJobRegister.registerJob(jobIdentifer) { parameters, context in
+            let runningJobs = runningJobCounter.wrappingIncrementThenLoad(by: 1, ordering: .relaxed)
+            if runningJobs > maxRunningJobCounter.load(ordering: .relaxed) {
+                maxRunningJobCounter.store(runningJobs, ordering: .relaxed)
             }
+            try await Task.sleep(for: .milliseconds(Int.random(in: 10..<50)))
+            context.logger.info("Parameters=\(parameters)")
+            expectation.fulfill()
+            runningJobCounter.wrappingDecrement(by: 1, ordering: .relaxed)
         }
-        TestJob.register()
 
         let jobQueue = HBMemoryJobQueue()
         let jobQueueHandler = HBJobQueueHandler(
@@ -121,38 +113,33 @@ final class HummingbirdJobsTests: XCTestCase {
             logger: Logger(label: "HummingbirdJobsTests")
         )
         try await testJobQueue(jobQueueHandler) {
-            try await jobQueue.push(TestJob(value: 1))
-            try await jobQueue.push(TestJob(value: 2))
-            try await jobQueue.push(TestJob(value: 3))
-            try await jobQueue.push(TestJob(value: 4))
-            try await jobQueue.push(TestJob(value: 5))
-            try await jobQueue.push(TestJob(value: 6))
-            try await jobQueue.push(TestJob(value: 7))
-            try await jobQueue.push(TestJob(value: 8))
-            try await jobQueue.push(TestJob(value: 9))
-            try await jobQueue.push(TestJob(value: 10))
+            try await jobQueue.push(id: jobIdentifer, parameters: 1)
+            try await jobQueue.push(id: jobIdentifer, parameters: 2)
+            try await jobQueue.push(id: jobIdentifer, parameters: 3)
+            try await jobQueue.push(id: jobIdentifer, parameters: 4)
+            try await jobQueue.push(id: jobIdentifer, parameters: 5)
+            try await jobQueue.push(id: jobIdentifer, parameters: 6)
+            try await jobQueue.push(id: jobIdentifer, parameters: 7)
+            try await jobQueue.push(id: jobIdentifer, parameters: 8)
+            try await jobQueue.push(id: jobIdentifer, parameters: 9)
+            try await jobQueue.push(id: jobIdentifer, parameters: 10)
 
-            await self.wait(for: [TestJob.expectation], timeout: 5)
+            await self.wait(for: [expectation], timeout: 5)
 
-            XCTAssertGreaterThan(TestJob.maxRunningJobCounter.load(ordering: .relaxed), 1)
-            XCTAssertLessThanOrEqual(TestJob.maxRunningJobCounter.load(ordering: .relaxed), 4)
+            XCTAssertGreaterThan(maxRunningJobCounter.load(ordering: .relaxed), 1)
+            XCTAssertLessThanOrEqual(maxRunningJobCounter.load(ordering: .relaxed), 4)
         }
     }
 
     func testErrorRetryCount() async throws {
+        let jobIdentifer = HBJobIdentifier<Int>(#function)
+        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 4)
         let failedJobCount = ManagedAtomic(0)
         struct FailedError: Error {}
-
-        struct TestJob: HBJob {
-            static let name = "testErrorRetryCount"
-            static let maxRetryCount = 3
-            static let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 4)
-            func execute(logger: Logger) async throws {
-                Self.expectation.fulfill()
-                throw FailedError()
-            }
+        HBJobRegister.registerJob(jobIdentifer, maxRetryCount: 3) { _, _ in
+            expectation.fulfill()
+            throw FailedError()
         }
-        TestJob.register()
         var logger = Logger(label: "HummingbirdJobsTests")
         logger.logLevel = .trace
         let jobQueue = HBMemoryJobQueue { _, _ in failedJobCount.wrappingIncrement(by: 1, ordering: .relaxed) }
@@ -162,38 +149,46 @@ final class HummingbirdJobsTests: XCTestCase {
             logger: logger
         )
         try await testJobQueue(jobQueueHandler) {
-            try await jobQueue.push(TestJob())
+            try await jobQueue.push(id: jobIdentifer, parameters: 0)
 
-            await self.wait(for: [TestJob.expectation], timeout: 5)
+            await self.wait(for: [expectation], timeout: 5)
         }
         XCTAssertEqual(failedJobCount.load(ordering: .relaxed), 1)
     }
 
-    func testJobSerialization() throws {
-        struct TestJob: HBJob, Equatable {
-            static let name = "testJobSerialization"
-            let value: Int
-            func execute(logger: Logger) async throws {}
+    func testJobSerialization() async throws {
+        struct TestJobParameters: Codable {
+            let id: Int
+            let message: String
         }
-        TestJob.register()
-        let job = TestJob(value: 2)
-        let codableJob = HBAnyCodableJob(job)
-        let data = try JSONEncoder().encode(codableJob)
-        let codableJob2 = try JSONDecoder().decode(HBAnyCodableJob.self, from: data)
-        XCTAssertEqual(codableJob2.job as? TestJob, job)
+        let expectation = XCTestExpectation(description: "TestJob.execute was called")
+        let jobIdentifer = HBJobIdentifier<TestJobParameters>(#function)
+        HBJobRegister.registerJob(jobIdentifer) { parameters, _ in
+            XCTAssertEqual(parameters.id, 23)
+            XCTAssertEqual(parameters.message, "Hello!")
+            expectation.fulfill()
+        }
+        let jobQueue = HBMemoryJobQueue()
+        let jobQueueHandler = HBJobQueueHandler(
+            queue: jobQueue,
+            numWorkers: 1,
+            logger: Logger(label: "HummingbirdJobsTests")
+        )
+        try await testJobQueue(jobQueueHandler) {
+            try await jobQueue.push(id: jobIdentifer, parameters: .init(id: 23, message: "Hello!"))
+
+            await self.wait(for: [expectation], timeout: 5)
+        }
     }
 
     /// Test job is cancelled on shutdown
     func testShutdownJob() async throws {
-        struct TestJob: HBJob {
-            static let name = "testShutdownJob"
-            static let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 1)
-            func execute(logger: Logger) async throws {
-                Self.expectation.fulfill()
-                try await Task.sleep(for: .milliseconds(1000))
-            }
+        let jobIdentifer = HBJobIdentifier<Int>(#function)
+        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 1)
+        HBJobRegister.registerJob(jobIdentifer) { _, _ in
+            expectation.fulfill()
+            try await Task.sleep(for: .milliseconds(1000))
         }
-        TestJob.register()
 
         let cancelledJobCount = ManagedAtomic(0)
         var logger = Logger(label: "HummingbirdJobsTests")
@@ -209,8 +204,8 @@ final class HummingbirdJobsTests: XCTestCase {
             logger: logger
         )
         try await testJobQueue(jobQueueHandler) {
-            try await jobQueue.push(TestJob())
-            await self.wait(for: [TestJob.expectation], timeout: 5)
+            try await jobQueue.push(id: jobIdentifer, parameters: 0)
+            await self.wait(for: [expectation], timeout: 5)
         }
 
         XCTAssertEqual(cancelledJobCount.load(ordering: .relaxed), 1)
@@ -218,19 +213,14 @@ final class HummingbirdJobsTests: XCTestCase {
 
     /// test job fails to decode but queue continues to process
     func testFailToDecode() async throws {
-        struct TestJob1: HBJob {
-            static let name = "testFailToDecode"
-            func execute(logger: Logger) async throws {}
+        let string: NIOLockedValueBox<String> = .init("")
+        let jobIdentifer1 = HBJobIdentifier<Int>(#function)
+        let jobIdentifer2 = HBJobIdentifier<String>(#function)
+        let expectation = XCTestExpectation(description: "job was called", expectedFulfillmentCount: 1)
+        HBJobRegister.registerJob(jobIdentifer2) { parameters, _ in
+            string.withLockedValue { $0 = parameters }
+            expectation.fulfill()
         }
-        struct TestJob2: HBJob {
-            static let name = "testFailToDecode"
-            static var value: String?
-            let value: String
-            func execute(logger: Logger) async throws {
-                Self.value = self.value
-            }
-        }
-        TestJob2.register()
 
         let jobQueue = HBMemoryJobQueue()
         let jobQueueHandler = HBJobQueueHandler(
@@ -239,12 +229,63 @@ final class HummingbirdJobsTests: XCTestCase {
             logger: Logger(label: "HummingbirdJobsTests")
         )
         try await testJobQueue(jobQueueHandler) {
-            try await jobQueue.push(TestJob1())
-            try await jobQueue.push(TestJob2(value: "test"))
-            // stall to give job chance to start running
-            try await Task.sleep(for: .milliseconds(500))
+            try await jobQueue.push(id: jobIdentifer1, parameters: 2)
+            try await jobQueue.push(id: jobIdentifer2, parameters: "test")
+            await self.wait(for: [expectation], timeout: 5)
         }
+        string.withLockedValue {
+            XCTAssertEqual($0, "test")
+        }
+    }
 
-        XCTAssertEqual(TestJob2.value, "test")
+    func testMultipleJobQueueHandlers() async throws {
+        let jobIdentifer = HBJobIdentifier<Int>(#function)
+        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 200)
+        HBJobRegister.registerJob(jobIdentifer) { parameters, context in
+            context.logger.info("Parameters=\(parameters)")
+            try await Task.sleep(for: .milliseconds(Int.random(in: 10..<50)))
+            expectation.fulfill()
+        }
+        let logger = {
+            var logger = Logger(label: "HummingbirdJobsTests")
+            logger.logLevel = .debug
+            return logger
+        }()
+        let jobQueue = HBMemoryJobQueue()
+        let jobQueueHandler = HBJobQueueHandler(
+            queue: jobQueue,
+            numWorkers: 2,
+            logger: logger
+        )
+        let jobQueue2 = HBMemoryJobQueue()
+        let jobQueueHandler2 = HBJobQueueHandler(
+            queue: jobQueue2,
+            numWorkers: 2,
+            logger: logger
+        )
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            let serviceGroup = ServiceGroup(
+                configuration: .init(
+                    services: [jobQueueHandler, jobQueueHandler2],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: logger
+                )
+            )
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            do {
+                for i in 0..<200 {
+                    try await jobQueue.push(id: jobIdentifer, parameters: i)
+                }
+                await self.wait(for: [expectation], timeout: 5)
+                await serviceGroup.triggerGracefulShutdown()
+            } catch {
+                XCTFail("\(String(reflecting: error))")
+                await serviceGroup.triggerGracefulShutdown()
+                throw error
+            }
+        }
     }
 }

--- a/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
+++ b/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
@@ -62,24 +62,24 @@ final class HummingbirdJobsTests: XCTestCase {
 
     func testBasic() async throws {
         let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 10)
-        let jobIdentifer = HBJobIdentifier<Int>(#function)
         let jobQueue = HBJobQueue(HBMemoryJobQueue(), numWorkers: 1, logger: Logger(label: "HummingbirdJobsTests"))
-        jobQueue.registerJob(jobIdentifer) { parameters, context in
+        let job = HBJobDefinition(id: "testBasic") { (parameters: Int, context) in
             context.logger.info("Parameters=\(parameters)")
             try await Task.sleep(for: .milliseconds(Int.random(in: 10..<50)))
             expectation.fulfill()
         }
+        jobQueue.registerJob(job)
         try await self.testJobQueue(jobQueue) {
-            try await jobQueue.push(id: jobIdentifer, parameters: 1)
-            try await jobQueue.push(id: jobIdentifer, parameters: 2)
-            try await jobQueue.push(id: jobIdentifer, parameters: 3)
-            try await jobQueue.push(id: jobIdentifer, parameters: 4)
-            try await jobQueue.push(id: jobIdentifer, parameters: 5)
-            try await jobQueue.push(id: jobIdentifer, parameters: 6)
-            try await jobQueue.push(id: jobIdentifer, parameters: 7)
-            try await jobQueue.push(id: jobIdentifer, parameters: 8)
-            try await jobQueue.push(id: jobIdentifer, parameters: 9)
-            try await jobQueue.push(id: jobIdentifer, parameters: 10)
+            try await jobQueue.push(id: job.id, parameters: 1)
+            try await jobQueue.push(id: job.id, parameters: 2)
+            try await jobQueue.push(id: job.id, parameters: 3)
+            try await jobQueue.push(id: job.id, parameters: 4)
+            try await jobQueue.push(id: job.id, parameters: 5)
+            try await jobQueue.push(id: job.id, parameters: 6)
+            try await jobQueue.push(id: job.id, parameters: 7)
+            try await jobQueue.push(id: job.id, parameters: 8)
+            try await jobQueue.push(id: job.id, parameters: 9)
+            try await jobQueue.push(id: job.id, parameters: 10)
 
             await self.wait(for: [expectation], timeout: 5)
         }


### PR DESCRIPTION
This refactor is required as it has been pointed out accessing services from a job is quite hard with the current structure. The changes include a breaking up of what defines a job and an actual job instance with parameters. I've also added a JobIdentifier which also includes a reference to the parameter type used by the job to ensure we don't pass bad parameters to a job.

```swift
// define email job parameters
struct EmailJobParameters: Codable {
    let recipient: String
    let subject: String
    let message: String
}

// add identifier for email job and associate with EmailJobParameters type
extension HBJobIdentifier<EmailJobParameters> {
    static var email: Self { .init(name: "email-job") }
}

// Create job queue
let jobQueue = HBJobQueue(.redis(...), maxWorkers: 4, logger: logger)

let ses = SES()

// register email job, with job functionality
jobQueue.registerJob(.email) { parameters, context in
    try await ses.sendEmail(to: parameters.recipient, subject: parameters.subject, body: parameters.message)
}

//  Push email job to queue. Because we have the association between
// the identifier and the required parameters we can ensure the correct parameter type
// is passed in
jobQueue.push(
    id: .email, 
    parameters: .init(recipient: "adam@gmail.com", subject:"Test", message: "Testing, testing, 123")
)
```
