### PR TITLE
Add JobParameters that collates job parameters and id into one

### DIFF
--- a/Sources/HummingbirdJobs/JobDefinition.swift
+++ b/Sources/HummingbirdJobs/JobDefinition.swift
@@ -18,6 +18,11 @@ public struct JobDefinition<Parameters: Codable & Sendable>: Sendable {
     let maxRetryCount: Int
     let _execute: @Sendable (Parameters, JobContext) async throws -> Void
 
+    ///  Initialize JobDefinition
+    /// - Parameters:
+    ///   - id: Job identifier
+    ///   - maxRetryCount: Maxiumum times this job will be retried if it fails
+    ///   - execute: Closure that executes job
     public init(id: JobIdentifier<Parameters>, maxRetryCount: Int = 0, execute: @escaping @Sendable (Parameters, JobContext) async throws -> Void) {
         self.id = id
         self.maxRetryCount = maxRetryCount

--- a/Sources/HummingbirdJobs/JobParameters.swift
+++ b/Sources/HummingbirdJobs/JobParameters.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Defines job parameters and identifier
+public protocol JobParameters: Codable, Sendable {
+    /// Job type identifier
+    static var jobID: String { get }
+}
+
+extension JobQueue {
+    ///  Push Job onto queue
+    /// - Parameters:
+    ///   - parameters: parameters for the job
+    /// - Returns: Identifier of queued job
+    @discardableResult public func push<Parameters: JobParameters>(_ parameters: Parameters) async throws -> Queue.JobID {
+        return try await self.push(id: .init(Parameters.jobID), parameters: parameters)
+    }
+
+    ///  Register job type
+    /// - Parameters:
+    ///   - parameters: Job parameter type
+    ///   - maxRetryCount: Maximum number of times job is retried before being flagged as failed
+    ///   - execute: Job code
+    public func registerJob<Parameters: JobParameters>(
+        parameters: Parameters.Type = Parameters.self,
+        maxRetryCount: Int = 0,
+        execute: @escaping @Sendable (
+            Parameters,
+            JobContext
+        ) async throws -> Void
+    ) {
+        self.registerJob(id: .init(Parameters.jobID), maxRetryCount: maxRetryCount, execute: execute)
+    }
+}
+
+extension JobDefinition where Parameters: JobParameters {
+    ///  Initialize JobDefinition
+    /// - Parameters:
+    ///   - maxRetryCount: Maxiumum times this job will be retried if it fails
+    ///   - execute: Closure that executes job
+    public init(maxRetryCount: Int = 0, execute: @escaping @Sendable (Parameters, JobContext) async throws -> Void) {
+        self.init(id: .init(Parameters.jobID), maxRetryCount: maxRetryCount, execute: execute)
+    }
+}

--- a/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
+++ b/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
@@ -164,6 +164,26 @@ final class HummingbirdJobsTests: XCTestCase {
         }
     }
 
+    func testJobParameters() async throws {
+        struct TestJobParameters: JobParameters {
+            static let id: JobIdentifier<Self> = "TestJobParameters"
+            let id: Int
+            let message: String
+        }
+        let expectation = XCTestExpectation(description: "TestJob.execute was called")
+        let jobQueue = JobQueue(.memory, numWorkers: 1, logger: Logger(label: "HummingbirdJobsTests"))
+        jobQueue.registerJob(parameters: TestJobParameters.self) { parameters, _ in
+            XCTAssertEqual(parameters.id, 23)
+            XCTAssertEqual(parameters.message, "Hello!")
+            expectation.fulfill()
+        }
+        try await self.testJobQueue(jobQueue) {
+            try await jobQueue.push(TestJobParameters(id: 23, message: "Hello!"))
+
+            await self.wait(for: [expectation], timeout: 5)
+        }
+    }
+
     /// Verify test job is cancelled when service group is cancelled
     func testShutdownJob() async throws {
         let jobIdentifer = JobIdentifier<Int>(#function)

--- a/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
+++ b/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
@@ -166,7 +166,7 @@ final class HummingbirdJobsTests: XCTestCase {
 
     func testJobParameters() async throws {
         struct TestJobParameters: JobParameters {
-            static let id: JobIdentifier<Self> = "TestJobParameters"
+            static let jobID: String = "TestJobParameters"
             let id: Int
             let message: String
         }


### PR DESCRIPTION
Instead of having 
```swift
struct EmailJob {
    let to: String
    let subject: String
    let body: String
}
extension JobIdentifier<EmailJob> {
    static let emailJob: Self { "EmailJob" }
}
```
This allows you to collate everything into the one type
```swift
struct EmailJob {
    static jobID: String = "EmailJob"
    let to: String
    let subject: String
    let body: String
}
```