### PR TITLE
FileIO Sendable fixes and minor API changes

### DIFF
--- a/Sources/Hummingbird/Files/FileIO.swift
+++ b/Sources/Hummingbird/Files/FileIO.swift
@@ -66,11 +66,10 @@ public struct FileIO: Sendable {
         }
     }
 
-    /// Write contents of request body to file
+    /// Write contents of AsyncSequence of buffers to file
     ///
-    /// This can be used to save arbitrary ByteBuffers by passing in `.byteBuffer(ByteBuffer)` as contents
     /// - Parameters:
-    ///   - contents: Request body to write.
+    ///   - contents: AsyncSequence of buffers to write.
     ///   - path: Path to write to
     ///   - logger: Logger
     public func writeFile<AS: AsyncSequence>(
@@ -86,11 +85,10 @@ public struct FileIO: Sendable {
         }
     }
 
-    /// Write contents of request body to file
+    /// Write contents of buffer to file
     ///
-    /// This can be used to save arbitrary ByteBuffers by passing in `.byteBuffer(ByteBuffer)` as contents
     /// - Parameters:
-    ///   - contents: Request body to write.
+    ///   - contents: ByteBuffer to write.
     ///   - path: Path to write to
     ///   - logger: Logger
     public func writeFile(

--- a/Sources/Hummingbird/Files/FileMiddleware.swift
+++ b/Sources/Hummingbird/Files/FileMiddleware.swift
@@ -201,7 +201,7 @@ public struct FileMiddleware<Context: BaseRequestContext>: RouterMiddleware {
                 switch request.method {
                 case .get:
                     if let range {
-                        let (body, _) = try await self.fileIO.loadFile(path: fullPath, range: range, context: context)
+                        let body = try await self.fileIO.loadFile(path: fullPath, range: range, context: context)
                         return Response(status: .partialContent, headers: headers, body: body)
                     }
 

--- a/Sources/Hummingbird/Files/FileMiddleware.swift
+++ b/Sources/Hummingbird/Files/FileMiddleware.swift
@@ -235,7 +235,7 @@ extension FileMiddleware {
 
         if groups[1] == "" {
             guard let upperBound = Int(groups[2]) else { return nil }
-            return Int.min...upperBound
+            return 0...upperBound
         } else if groups[2] == "" {
             guard let lowerBound = Int(groups[1]) else { return nil }
             return lowerBound...Int.max

--- a/Tests/HummingbirdTests/FileMiddlewareTests.swift
+++ b/Tests/HummingbirdTests/FileMiddlewareTests.swift
@@ -18,7 +18,7 @@ import Hummingbird
 import HummingbirdTesting
 import XCTest
 
-class HummingbirdFilesTests: XCTestCase {
+class FileMiddlewareTests: XCTestCase {
     func randomBuffer(size: Int) -> ByteBuffer {
         var data = [UInt8](repeating: 0, count: size)
         data = data.map { _ in UInt8.random(in: 0...255) }
@@ -89,6 +89,7 @@ class HummingbirdFilesTests: XCTestCase {
                 let slice = buffer.getSlice(at: 100, length: 3900)
                 XCTAssertEqual(response.body, slice)
                 XCTAssertEqual(response.headers[.contentRange], "bytes 100-3999/326000")
+                XCTAssertEqual(response.headers[.contentLength], "3900")
                 XCTAssertEqual(response.headers[.contentType], "text/plain")
             }
 
@@ -96,6 +97,7 @@ class HummingbirdFilesTests: XCTestCase {
                 let slice = buffer.getSlice(at: 0, length: 1)
                 XCTAssertEqual(response.body, slice)
                 XCTAssertEqual(response.headers[.contentRange], "bytes 0-0/326000")
+                XCTAssertEqual(response.headers[.contentLength], "1")
                 XCTAssertEqual(response.headers[.contentType], "text/plain")
             }
 
@@ -109,6 +111,7 @@ class HummingbirdFilesTests: XCTestCase {
             try await client.execute(uri: filename, method: .get, headers: [.range: "bytes=6000-"]) { response in
                 let slice = buffer.getSlice(at: 6000, length: 320_000)
                 XCTAssertEqual(response.body, slice)
+                XCTAssertEqual(response.headers[.contentLength], "320000")
                 XCTAssertEqual(response.headers[.contentRange], "bytes 6000-325999/326000")
             }
         }


### PR DESCRIPTION
- Don't pass around unsendable FileHandler.
- Use ClosedRanges instead of FileRegions which are also unsendable
- `FileIO.writeFile` can write a generic AsyncSequence instead of just a RequestBody
- Remove usage of EventLoops in FileIO