### PR TITLE
align doccomment indentation in RouterBuilder.swift

### DIFF
--- a/Sources/HummingbirdRouter/RouterBuilder.swift
+++ b/Sources/HummingbirdRouter/RouterBuilder.swift
@@ -22,7 +22,7 @@ public struct RouterBuilder<Context: RouterRequestContext, Handler: MiddlewarePr
 
     let handler: Handler
 
-    ///  Initialize RouterBuilder with contents of result builder
+    /// Initialize RouterBuilder with contents of result builder
     /// - Parameters:
     ///   - context: Request context used by router
     ///   - builder: Result builder for router


### PR DESCRIPTION
this is preventing the parameters list from parsing as a markdown list