### PR TITLE
2.x.x: guard for index overflow

### DIFF
--- a/Sources/HummingbirdCore/Utils/HBParser.swift
+++ b/Sources/HummingbirdCore/Utils/HBParser.swift
@@ -596,13 +596,9 @@ extension Parser {
         func _percentDecode(_ original: ArraySlice<UInt8>, _ bytes: UnsafeMutableBufferPointer<UInt8>) throws -> Int {
             var newIndex = 0
             var index = original.startIndex
-
-            while index < original.endIndex {
+            while index < (original.endIndex - 2) {
                 // if we have found a percent sign
                 if original[index] == 0x25 {
-                    guard original.endIndex - index >= 2 else {
-                        throw DecodeError()
-                    }
                     let high = Self.asciiHexValues[Int(original[index + 1])]
                     let low = Self.asciiHexValues[Int(original[index + 2])]
                     index += 3
@@ -617,9 +613,13 @@ extension Parser {
                     index += 1
                 }
             }
+            while index < original.endIndex {
+                bytes[newIndex] = original[index]
+                newIndex += 1
+                index += 1
+            }
             return newIndex
         }
-
         guard self.index != self.range.endIndex else { return "" }
         do {
             if #available(macOS 11, macCatalyst 14.0, iOS 14.0, tvOS 14.0, *) {

--- a/Sources/HummingbirdCore/Utils/HBParser.swift
+++ b/Sources/HummingbirdCore/Utils/HBParser.swift
@@ -600,6 +600,9 @@ extension Parser {
             while index < original.endIndex {
                 // if we have found a percent sign
                 if original[index] == 0x25 {
+                    guard original.endIndex - index >= 2 else {
+                        throw DecodeError()
+                    }
                     let high = Self.asciiHexValues[Int(original[index + 1])]
                     let low = Self.asciiHexValues[Int(original[index + 2])]
                     index += 3

--- a/Tests/HummingbirdRouterTests/RouterTests.swift
+++ b/Tests/HummingbirdRouterTests/RouterTests.swift
@@ -309,7 +309,7 @@ final class RouterTests: XCTestCase {
             }
         }
     }
-    
+
     /// Test the hummingbird core parser against possible overflows of the percent encoder. this issue was introduced in pr #404 in the context of query parameters but I've thrown in some other random overflow scenarios in here too for good measure. if it doesn't crash, its a win.
     func testQueryParameterOverflow() async throws {
         let router = RouterBuilder(context: BasicRouterRequestContext.self) {
@@ -318,7 +318,7 @@ final class RouterTests: XCTestCase {
                 return String("\(currentQP ?? "")")
             }
         }
-        let app = Application(router:router)
+        let app = Application(router: router)
         try await app.test(.router) { client in
             try await client.execute(uri: "/overflow?query=value%", method: .get) { response in
                 XCTAssertEqual(String(buffer: response.body), "value%")
@@ -327,7 +327,7 @@ final class RouterTests: XCTestCase {
                 XCTAssertEqual(String(buffer: response.body), "")
             }
             try await client.execute(uri: "/overflow?%&", method: .get) { response in
-            	XCTAssertEqual(String(buffer: response.body), "")
+                XCTAssertEqual(String(buffer: response.body), "")
             }
         }
     }

--- a/Tests/HummingbirdRouterTests/RouterTests.swift
+++ b/Tests/HummingbirdRouterTests/RouterTests.swift
@@ -309,6 +309,28 @@ final class RouterTests: XCTestCase {
             }
         }
     }
+    
+    /// Test the hummingbird core parser against possible overflows of the percent encoder. this issue was introduced in pr #404 in the context of query parameters but I've thrown in some other random overflow scenarios in here too for good measure. if it doesn't crash, its a win.
+    func testQueryParameterOverflow() async throws {
+        let router = RouterBuilder(context: BasicRouterRequestContext.self) {
+            Get("overflow") { req, _ in
+                let currentQP = req.uri.queryParameters["query"]
+                return String("\(currentQP ?? "")")
+            }
+        }
+        let app = Application(router:router)
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/overflow?query=value%", method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), "value%")
+            }
+            try await client.execute(uri: "/overflow?query%=value%", method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), "")
+            }
+            try await client.execute(uri: "/overflow?%&", method: .get) { response in
+            	XCTAssertEqual(String(buffer: response.body), "")
+            }
+        }
+    }
 
     func testParameters() async throws {
         let router = RouterBuilder(context: BasicRouterRequestContext.self) {


### PR DESCRIPTION
hello,

I have been using the hummingbird 2.x.x alphas (and now beta) in production (like a madman) and have been super impressed with how well it has been running. thank you for all your work on this project - its fantastic.

as I expose this socket to more of the wild, I am beginning to pick up on traffic that is causing `2.x.x beta1` and priors to crash.

here is a stack trace of what that looks like (from Ubuntu Linux):

```
Swift/SliceBuffer.swift:287: Fatal error: Index out of bounds

💣 Program crashed: Illegal instruction at 0x00007f27f34f219e

Thread 1 crashed:

 0 0x00007f27f34f219e closure #1 in closure #1 in closure #1 in _assertionFailure(_:_:file:line:flags:) + 318 in libswiftCore.so
 1 0x00007f27f34f1f4e closure #1 in closure #1 in _assertionFailure(_:_:file:line:flags:) + 269 in libswiftCore.so
 2 0x00007f27f34f1dfd closure #1 in _assertionFailure(_:_:file:line:flags:) + 380 in libswiftCore.so
 3 0x00007f27f34f1986 _assertionFailure(_:_:file:line:flags:) + 229 in libswiftCore.so
 4 0x00007f27f34e7fad ArraySlice.subscript.getter + 108 in libswiftCore.so
 5 _percentDecode #1 (_:_:) in Parser.percentDecode() + 509 in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Utils/HBParser.swift:603:64
 6 closure #1 in Parser.percentDecode() + 409 in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Utils/HBParser.swift:624:32
 7 0x00007f27f37459eb specialized static __StringStorage.create(uninitializedCodeUnitCapacity:initializingUncheckedUTF8With:) + 122 in libswiftCore.so
 8 0x00007f27f3745a80 specialized static String._fromLargeUTF8Repairing(uninitializedCapacity:initializingWith:) + 15 in libswiftCore.so
 9 Parser.percentDecode() + 322 in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Utils/HBParser.swift:623:28
10 closure #1 in URI.queryParameters.getter + 1096 in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Request/URI.swift:60:64
11 0x00007f27f34d84f0 Collection.map<A>(_:) + 463 in libswiftCore.so
12 URI.queryParameters.getter + 314 in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Request/URI.swift:51:38
13 static APIv2.parseAPIKey(from:) + 107 in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/Sources/webservice/APIv2/APIv2.swift:19:34
14 APIv2.Rates.respond(to:context:) + 1354 in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/Sources/webservice/APIv2/RatesEndpoint.swift:20:17
15 RouterResponder.respond(to:context:) in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/Hummingbird/Router/RouterResponder.swift:57
16 respond #1 <A>@Sendable (to:channel:) in ApplicationProtocol.run() in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/Hummingbird/Application.swift:106
17 closure #1 in closure #1 in closure #1 in HTTPChannelHandler.handleHTTP(asyncChannel:logger:) in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift:66
18 NIOAsyncChannel.executeThenClose<A>(_:) in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/swift-nio/Sources/NIOCore/AsyncChannel/AsyncChannel.swift:271
19 closure #1 in closure #1 in HTTPChannelHandler.handleHTTP(asyncChannel:logger:) in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift:48
20 withGracefulShutdownHandler<A>(operation:onGracefulShutdown:) in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/swift-service-lifecycle/Sources/ServiceLifecycle/GracefulShutdown.swift:55
21 closure #1 in HTTPChannelHandler.handleHTTP(asyncChannel:logger:) in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift:47
22 0x00007f27f333cce0 withTaskCancellationHandler<A>(operation:onCancel:) in libswift_Concurrency.so
23 HTTPChannelHandler.handleHTTP(asyncChannel:logger:) in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift:46
24 HTTP1Channel.handle(value:logger:) in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift:65
25 closure #1 in closure #1 in closure #1 in closure #1 in Server.run() in <PROJ_NAME_REDACTED> at <PROJ_ROOT_REDACTED>/.build/checkouts/hummingbird/Sources/HummingbirdCore/Server/Server.swift:119

Backtrace took 36.46s

Illegal instruction (core dumped)
```

Problem: Looks like I am getting some traffic with bad query params that are causing the HBParser code to overflow.

Solution: I simply guard against this potential overflow before it happens.

Result: My production service no longer reproduces the above stacktrace when I deploy using the commit proposed here.