### PR TITLE
Use generic for file loading in FileMiddleware

### DIFF
--- a/Sources/Hummingbird/Files/FileMiddleware.swift
+++ b/Sources/Hummingbird/Files/FileMiddleware.swift
@@ -12,11 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
-@preconcurrency import Foundation
-#else
 import Foundation
-#endif
 import HTTPTypes
 import Logging
 import NIOCore

--- a/Sources/Hummingbird/Files/FileMiddleware.swift
+++ b/Sources/Hummingbird/Files/FileMiddleware.swift
@@ -231,7 +231,7 @@ extension FileMiddleware {
     /// Also supports open ended ranges
     private func getRangeFromHeaderValue(_ header: String) -> ClosedRange<Int>? {
         do {
-        var parser = Parser(header)
+            var parser = Parser(header)
             guard try parser.read("bytes=") else { return nil }
             let lower = parser.read { $0.properties.numericType == .decimal }.string
             guard try parser.read("-") else { return nil }
@@ -245,7 +245,7 @@ extension FileMiddleware {
                 return lowerBound...Int.max
             } else {
                 guard let lowerBound = Int(lower),
-                    let upperBound = Int(upper) else { return nil }
+                      let upperBound = Int(upper) else { return nil }
                 return lowerBound...upperBound
             }
         } catch {

--- a/Sources/Hummingbird/Files/FileProvider.swift
+++ b/Sources/Hummingbird/Files/FileProvider.swift
@@ -23,6 +23,13 @@ public struct FileAttributes: Sendable {
     public let size: Int
     /// Last time file was modified
     public let modificationDate: Date
+
+    /// Initialize FileAttributes
+    public init(isFolder: Bool, size: Int, modificationDate: Date) {
+        self.isFolder = isFolder
+        self.size = size
+        self.modificationDate = modificationDate
+    }
 }
 
 /// Protocol for file provider type used by ``FileMiddleware``

--- a/Sources/Hummingbird/Files/FileProvider.swift
+++ b/Sources/Hummingbird/Files/FileProvider.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIOPosix
+
+/// File attributes required by ``FileMiddleware``
+public struct FileAttributes: Sendable {
+    /// Is file a folder
+    public let isFolder: Bool
+    /// Size of file
+    public let size: Int
+    /// Last time file was modified
+    public let modificationDate: Date
+}
+
+/// Protocol for file provider type used by ``FileMiddleware``
+public protocol FileProvider: Sendable {
+    /// Get full path name
+    /// - Parameter path: path from URI
+    /// - Returns: Full path
+    func getFullPath(_ path: String) -> String
+
+    /// Get file attributes
+    /// - Parameter path: Full path to file
+    /// - Returns: File attributes
+    func getAttributes(path: String) async throws -> FileAttributes?
+
+    /// Return a reponse body that will write the file body
+    /// - Parameters:
+    ///   - path: Full path to file
+    ///   - context: Request context
+    /// - Returns: Response body
+    func loadFile(path: String, context: some BaseRequestContext) async throws -> ResponseBody
+
+    /// Return a reponse body that will write a partial file body
+    /// - Parameters:
+    ///   - path: Full path to file
+    ///   - range: Part of file to return
+    ///   - context: Request context
+    /// - Returns: Response body
+    func loadFile(path: String, range: ClosedRange<Int>, context: some BaseRequestContext) async throws -> ResponseBody
+}

--- a/Sources/Hummingbird/Files/FileProvider.swift
+++ b/Sources/Hummingbird/Files/FileProvider.swift
@@ -15,25 +15,11 @@
 import Foundation
 import NIOPosix
 
-/// File attributes required by ``FileMiddleware``
-public struct FileAttributes: Sendable {
-    /// Is file a folder
-    public let isFolder: Bool
-    /// Size of file
-    public let size: Int
-    /// Last time file was modified
-    public let modificationDate: Date
-
-    /// Initialize FileAttributes
-    public init(isFolder: Bool, size: Int, modificationDate: Date) {
-        self.isFolder = isFolder
-        self.size = size
-        self.modificationDate = modificationDate
-    }
-}
-
 /// Protocol for file provider type used by ``FileMiddleware``
 public protocol FileProvider: Sendable {
+    /// File attributes type
+    associatedtype FileAttributes
+
     /// Get full path name
     /// - Parameter path: path from URI
     /// - Returns: Full path

--- a/Sources/Hummingbird/Files/LocalFileSystem.swift
+++ b/Sources/Hummingbird/Files/LocalFileSystem.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import NIOPosix
+
+/// Local file system file provider. All file accesses are relative to a root folder
+public struct LocalFileSystem: FileProvider {
+    let rootFolder: String
+    let fileIO: FileIO
+
+    /// Initialize LocalFileSystem FileProvider
+    /// - Parameters:
+    ///   - rootFolder: Root folder to serve files from
+    ///   - threadPool: Thread pool used when loading files
+    ///   - logger: Logger to output root folder information
+    init(rootFolder: String, threadPool: NIOThreadPool, logger: Logger) {
+        if rootFolder.last != "/" {
+            self.rootFolder = "\(rootFolder)/"
+        } else {
+            self.rootFolder = rootFolder
+        }
+        self.fileIO = .init(threadPool: threadPool)
+
+        let workingFolder: String
+        if rootFolder.first == "/" {
+            workingFolder = ""
+        } else {
+            if let cwd = getcwd(nil, Int(PATH_MAX)) {
+                workingFolder = String(cString: cwd) + "/"
+                free(cwd)
+            } else {
+                workingFolder = "./"
+            }
+        }
+        logger.info("Serving files from \(workingFolder)\(rootFolder)")
+    }
+
+    /// Get full path name with local file system root prefixed
+    /// - Parameter path: path from URI
+    /// - Returns: Full path
+    public func getFullPath(_ path: String) -> String {
+        if path.first == "/" {
+            return "\(self.rootFolder)\(path.dropFirst())"
+        } else {
+            return "\(self.rootFolder)\(path)"
+        }
+    }
+
+    /// Get file attributes
+    /// - Parameter path: Full path to file
+    /// - Returns: File attributes
+    public func getAttributes(path: String) async throws -> FileAttributes? {
+        do {
+            let lstat = try await self.fileIO.fileIO.lstat(path: path)
+            let isFolder = (lstat.st_mode & S_IFMT) == S_IFDIR
+            let modificationDate = Double(lstat.st_mtimespec.tv_sec) + (Double(lstat.st_mtimespec.tv_nsec) / 1_000_000_000.0)
+            return .init(
+                isFolder: isFolder,
+                size: numericCast(lstat.st_size),
+                modificationDate: Date(timeIntervalSince1970: modificationDate)
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    /// Return a reponse body that will write the file body
+    /// - Parameters:
+    ///   - path: Full path to file
+    ///   - context: Request context
+    /// - Returns: Response body
+    public func loadFile(path: String, context: some BaseRequestContext) async throws -> ResponseBody {
+        try await self.fileIO.loadFile(path: path, context: context)
+    }
+
+    /// Return a reponse body that will write a partial file body
+    /// - Parameters:
+    ///   - path: Full path to file
+    ///   - range: Part of file to return
+    ///   - context: Request context
+    /// - Returns: Response body
+    public func loadFile(path: String, range: ClosedRange<Int>, context: some BaseRequestContext) async throws -> ResponseBody {
+        try await self.fileIO.loadFile(path: path, range: range, context: context)
+    }
+}

--- a/Sources/Hummingbird/Files/LocalFileSystem.swift
+++ b/Sources/Hummingbird/Files/LocalFileSystem.swift
@@ -66,7 +66,11 @@ public struct LocalFileSystem: FileProvider {
         do {
             let lstat = try await self.fileIO.fileIO.lstat(path: path)
             let isFolder = (lstat.st_mode & S_IFMT) == S_IFDIR
+            #if os(Linux)
+            let modificationDate = Double(lstat.st_mtim.tv_sec) + (Double(lstat.st_mtim.tv_nsec) / 1_000_000_000.0)
+            #else
             let modificationDate = Double(lstat.st_mtimespec.tv_sec) + (Double(lstat.st_mtimespec.tv_nsec) / 1_000_000_000.0)
+            #endif
             return .init(
                 isFolder: isFolder,
                 size: numericCast(lstat.st_size),

--- a/Sources/Hummingbird/Files/LocalFileSystem.swift
+++ b/Sources/Hummingbird/Files/LocalFileSystem.swift
@@ -16,8 +16,25 @@ import Foundation
 import Logging
 import NIOPosix
 
-/// Local file system file provider. All file accesses are relative to a root folder
+/// Local file system file provider used by FileMiddleware. All file accesses are relative to a root folder
 public struct LocalFileSystem: FileProvider {
+    /// File attributes required by ``FileMiddleware``
+    public struct FileAttributes: Sendable, FileMiddlewareFileAttributes {
+        /// Is file a folder
+        public let isFolder: Bool
+        /// Size of file
+        public let size: Int
+        /// Last time file was modified
+        public let modificationDate: Date
+
+        /// Initialize FileAttributes
+        public init(isFolder: Bool, size: Int, modificationDate: Date) {
+            self.isFolder = isFolder
+            self.size = size
+            self.modificationDate = modificationDate
+        }
+    }
+
     let rootFolder: String
     let fileIO: FileIO
 

--- a/Sources/Hummingbird/Files/LocalFileSystem.swift
+++ b/Sources/Hummingbird/Files/LocalFileSystem.swift
@@ -28,7 +28,7 @@ public struct LocalFileSystem: FileProvider {
         public let modificationDate: Date
 
         /// Initialize FileAttributes
-        public init(isFolder: Bool, size: Int, modificationDate: Date) {
+        init(isFolder: Bool, size: Int, modificationDate: Date) {
             self.isFolder = isFolder
             self.size = size
             self.modificationDate = modificationDate

--- a/Tests/HummingbirdTests/FileMiddlewareTests.swift
+++ b/Tests/HummingbirdTests/FileMiddlewareTests.swift
@@ -53,6 +53,18 @@ class FileMiddlewareTests: XCTestCase {
         }
     }
 
+    func testNotAFile() async throws {
+        let router = Router()
+        router.middlewares.add(FileMiddleware("."))
+        let app = Application(responder: router.buildResponder())
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "missed.jpg", method: .get) { response in
+                XCTAssertEqual(response.status, .notFound)
+            }
+        }
+    }
+
     func testReadLargeFile() async throws {
         let router = Router()
         router.middlewares.add(FileMiddleware("."))


### PR DESCRIPTION
This will allow for writing custom file loaders that cache file contents or use another source than the local file system for files