### PR TITLE
Re-instate "hb" prefix on logger, metrics ids

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -100,7 +100,7 @@ extension ApplicationProtocol {
         @Sendable func respond(to request: Request, channel: Channel) async throws -> Response {
             let context = Self.Responder.Context(
                 channel: channel,
-                logger: self.logger.with(metadataKey: "_id", value: .stringConvertible(RequestID()))
+                logger: self.logger.with(metadataKey: "hb_id", value: .stringConvertible(RequestID()))
             )
             // respond to request
             var response = try await responder.respond(to: request, context: context)

--- a/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
@@ -29,13 +29,13 @@ public struct LogRequestsMiddleware<Context: BaseRequestContext>: RouterMiddlewa
             context.logger.log(
                 level: self.logLevel,
                 "\(request.headers)",
-                metadata: ["_uri": .stringConvertible(request.uri), "_method": .string(request.method.rawValue)]
+                metadata: ["hb_uri": .stringConvertible(request.uri), "hb_method": .string(request.method.rawValue)]
             )
         } else {
             context.logger.log(
                 level: self.logLevel,
                 "",
-                metadata: ["_uri": .stringConvertible(request.uri), "_method": .string(request.method.rawValue)]
+                metadata: ["hb_uri": .stringConvertible(request.uri), "hb_method": .string(request.method.rawValue)]
             )
         }
         return try await next(request, context)

--- a/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
@@ -30,12 +30,12 @@ public struct MetricsMiddleware<Context: BaseRequestContext>: RouterMiddleware {
             // need to create dimensions once request has been responded to ensure
             // we have the correct endpoint path
             let dimensions: [(String, String)] = [
-                ("_uri", context.endpointPath ?? request.uri.path),
-                ("_method", request.method.rawValue),
+                ("hb_uri", context.endpointPath ?? request.uri.path),
+                ("hb_method", request.method.rawValue),
             ]
-            Counter(label: "_requests", dimensions: dimensions).increment()
+            Counter(label: "hb_requests", dimensions: dimensions).increment()
             Metrics.Timer(
-                label: "_request_duration",
+                label: "hb_request_duration",
                 dimensions: dimensions,
                 preferredDisplayUnit: .seconds
             ).recordNanoseconds(DispatchTime.now().uptimeNanoseconds - startTime)
@@ -47,16 +47,16 @@ public struct MetricsMiddleware<Context: BaseRequestContext>: RouterMiddleware {
             // Don't record uri in 404 errors, to avoid spamming of metrics
             if let endpointPath = context.endpointPath {
                 dimensions = [
-                    ("_uri", endpointPath),
-                    ("_method", request.method.rawValue),
+                    ("hb_uri", endpointPath),
+                    ("hb_method", request.method.rawValue),
                 ]
-                Counter(label: "_requests", dimensions: dimensions).increment()
+                Counter(label: "hb_requests", dimensions: dimensions).increment()
             } else {
                 dimensions = [
-                    ("_method", request.method.rawValue),
+                    ("hb_method", request.method.rawValue),
                 ]
             }
-            Counter(label: "_errors", dimensions: dimensions).increment()
+            Counter(label: "hb_errors", dimensions: dimensions).increment()
             throw error
         }
     }

--- a/Sources/Hummingbird/Server/RequestContext.swift
+++ b/Sources/Hummingbird/Server/RequestContext.swift
@@ -96,7 +96,7 @@ extension BaseRequestContext {
     public var parameters: Parameters { coreContext.parameters }
     /// Request ID, extracted from Logger
     @inlinable
-    public var id: String { self.logger[metadataKey: "_id"]!.description }
+    public var id: String { self.logger[metadataKey: "hb_id"]!.description }
 }
 
 extension BaseRequestContext where Decoder == JSONDecoder {

--- a/Sources/HummingbirdTesting/RouterTestFramework.swift
+++ b/Sources/HummingbirdTesting/RouterTestFramework.swift
@@ -102,7 +102,7 @@ struct RouterTestFramework<Responder: HTTPResponder>: ApplicationTestFramework w
                     head: .init(method: method, scheme: "http", authority: "localhost", path: uri, headerFields: headers),
                     body: stream
                 )
-                let logger = self.logger.with(metadataKey: "_id", value: .stringConvertible(RequestID()))
+                let logger = self.logger.with(metadataKey: "hb_id", value: .stringConvertible(RequestID()))
                 let context = self.makeContext(logger)
 
                 group.addTask {

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -194,11 +194,11 @@ final class MetricsTests: XCTestCase {
             try await client.execute(uri: "/hello", method: .get) { _ in }
         }
 
-        let counter = try XCTUnwrap(Self.testMetrics.counters["_requests"] as? TestCounter)
+        let counter = try XCTUnwrap(Self.testMetrics.counters["hb_requests"] as? TestCounter)
         XCTAssertEqual(counter.values[0].1, 1)
-        XCTAssertEqual(counter.dimensions[0].0, "_uri")
+        XCTAssertEqual(counter.dimensions[0].0, "hb_uri")
         XCTAssertEqual(counter.dimensions[0].1, "/hello")
-        XCTAssertEqual(counter.dimensions[1].0, "_method")
+        XCTAssertEqual(counter.dimensions[1].0, "hb_method")
         XCTAssertEqual(counter.dimensions[1].1, "GET")
     }
 
@@ -213,12 +213,12 @@ final class MetricsTests: XCTestCase {
             try await client.execute(uri: "/hello", method: .get) { _ in }
         }
 
-        let counter = try XCTUnwrap(Self.testMetrics.counters["_errors"] as? TestCounter)
+        let counter = try XCTUnwrap(Self.testMetrics.counters["hb_errors"] as? TestCounter)
         XCTAssertEqual(counter.values.count, 1)
         XCTAssertEqual(counter.values[0].1, 1)
-        XCTAssertEqual(counter.dimensions[0].0, "_uri")
+        XCTAssertEqual(counter.dimensions[0].0, "hb_uri")
         XCTAssertEqual(counter.dimensions[0].1, "/hello")
-        XCTAssertEqual(counter.dimensions[1].0, "_method")
+        XCTAssertEqual(counter.dimensions[1].0, "hb_method")
         XCTAssertEqual(counter.dimensions[1].1, "GET")
     }
 
@@ -233,11 +233,11 @@ final class MetricsTests: XCTestCase {
             try await client.execute(uri: "/hello2", method: .get) { _ in }
         }
 
-        let counter = try XCTUnwrap(Self.testMetrics.counters["_errors"] as? TestCounter)
+        let counter = try XCTUnwrap(Self.testMetrics.counters["hb_errors"] as? TestCounter)
         XCTAssertEqual(counter.values.count, 1)
         XCTAssertEqual(counter.values[0].1, 1)
         XCTAssertEqual(counter.dimensions.count, 1)
-        XCTAssertEqual(counter.dimensions[0].0, "_method")
+        XCTAssertEqual(counter.dimensions[0].0, "hb_method")
         XCTAssertEqual(counter.dimensions[0].1, "GET")
     }
 
@@ -252,13 +252,13 @@ final class MetricsTests: XCTestCase {
             try await client.execute(uri: "/user/765", method: .get) { _ in }
         }
 
-        let counter = try XCTUnwrap(Self.testMetrics.counters["_errors"] as? TestCounter)
+        let counter = try XCTUnwrap(Self.testMetrics.counters["hb_errors"] as? TestCounter)
         XCTAssertEqual(counter.values.count, 1)
         XCTAssertEqual(counter.values[0].1, 1)
         XCTAssertEqual(counter.dimensions.count, 2)
-        XCTAssertEqual(counter.dimensions[0].0, "_uri")
+        XCTAssertEqual(counter.dimensions[0].0, "hb_uri")
         XCTAssertEqual(counter.dimensions[0].1, "/user/:id")
-        XCTAssertEqual(counter.dimensions[1].0, "_method")
+        XCTAssertEqual(counter.dimensions[1].0, "hb_method")
         XCTAssertEqual(counter.dimensions[1].1, "GET")
     }
 }


### PR DESCRIPTION
Somehow I removed all the "hb" prefixes from the logger and metrics ids. This PR reinstates them