### PR TITLE
Fix metrics timers

### DIFF
--- a/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
@@ -26,19 +26,24 @@ public struct MetricsMiddleware<Context: BaseRequestContext>: RouterMiddleware {
         let startTime = DispatchTime.now().uptimeNanoseconds
 
         do {
-            let response = try await next(request, context)
-            // need to create dimensions once request has been responded to ensure
-            // we have the correct endpoint path
-            let dimensions: [(String, String)] = [
-                ("hb_uri", context.endpointPath ?? request.uri.path),
-                ("hb_method", request.method.rawValue),
-            ]
-            Counter(label: "hb_requests", dimensions: dimensions).increment()
-            Metrics.Timer(
-                label: "hb_request_duration",
-                dimensions: dimensions,
-                preferredDisplayUnit: .seconds
-            ).recordNanoseconds(DispatchTime.now().uptimeNanoseconds - startTime)
+            var response = try await next(request, context)
+            let originalBody = response.body
+            response.body = .withTrailingHeaders { writer in
+                let headers = try await originalBody.write(writer)
+                // need to create dimensions once request has been responded to ensure
+                // we have the correct endpoint path
+                let dimensions: [(String, String)] = [
+                    ("hb_uri", context.endpointPath ?? request.uri.path),
+                    ("hb_method", request.method.rawValue),
+                ]
+                Counter(label: "hb_requests", dimensions: dimensions).increment()
+                Metrics.Timer(
+                    label: "hb_request_duration",
+                    dimensions: dimensions,
+                    preferredDisplayUnit: .seconds
+                ).recordNanoseconds(DispatchTime.now().uptimeNanoseconds - startTime)
+                return headers
+            }
             return response
         } catch {
             // need to create dimensions once request has been responded to ensure

--- a/Sources/HummingbirdCore/Response/ResponseBody.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBody.swift
@@ -78,7 +78,7 @@ public struct ResponseBody: Sendable {
     /// response was written. This functions provides you a method for catching the point when the
     /// response has been fully written. If you drop the response in a middleware run after this
     /// point the post write closure will not get run.
-    public func withPostWriteClosure(_ postWrite: @escaping @Sendable () async -> Void) -> Self {
+    package func withPostWriteClosure(_ postWrite: @escaping @Sendable () async -> Void) -> Self {
         return .init(contentLength: self.contentLength) { writer in
             do {
                 let result = try await self.write(writer)

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -263,14 +263,14 @@ final class MetricsTests: XCTestCase {
     }
 
     func testRecordingBodyWriteTime() async throws {
-        let router = HBRouter()
-        router.middlewares.add(HBMetricsMiddleware())
-        router.get("/hello") { _, _ -> HBResponse in
-            return HBResponse(status: .ok, body: .init { _ in
+        let router = Router()
+        router.middlewares.add(MetricsMiddleware())
+        router.get("/hello") { _, _ -> Response in
+            return Response(status: .ok, body: .init { _ in
                 try await Task.sleep(for: .milliseconds(5))
             })
         }
-        let app = HBApplication(responder: router.buildResponder())
+        let app = Application(responder: router.buildResponder())
         try await app.test(.router) { client in
             try await client.execute(uri: "/hello", method: .get) { _ in }
         }

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -261,4 +261,21 @@ final class MetricsTests: XCTestCase {
         XCTAssertEqual(counter.dimensions[1].0, "hb_method")
         XCTAssertEqual(counter.dimensions[1].1, "GET")
     }
+
+    func testRecordingBodyWriteTime() async throws {
+        let router = HBRouter()
+        router.middlewares.add(HBMetricsMiddleware())
+        router.get("/hello") { _, _ -> HBResponse in
+            return HBResponse(status: .ok, body: .init { _ in
+                try await Task.sleep(for: .milliseconds(5))
+            })
+        }
+        let app = HBApplication(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/hello", method: .get) { _ in }
+        }
+
+        let timer = try XCTUnwrap(Self.testMetrics.timers["hb_request_duration"] as? TestTimer)
+        XCTAssertGreaterThan(timer.values[0].1, 5_000_000)
+    }
 }


### PR DESCRIPTION
Metrics timers were stopping when we returned a response but that is not when the response has been written. The response is written later by the response writer. This moves the recording of metrics to once the response has been written.