### PR TITLE
HTTPResponseStatus -> HTTPResponse.Status

### DIFF
--- a/Sources/Hummingbird/Router/ResponseGenerator.swift
+++ b/Sources/Hummingbird/Router/ResponseGenerator.swift
@@ -54,7 +54,7 @@ extension ByteBuffer: ResponseGenerator {
     }
 }
 
-/// Extend HTTPResponseStatus to conform to ResponseGenerator
+/// Extend HTTPResponse.Status to conform to ResponseGenerator
 extension HTTPResponse.Status: ResponseGenerator {
     /// Generate response with this response status code
     public func response(from request: Request, context: some BaseRequestContext) -> Response {

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -26,7 +26,7 @@ import NIOCore
 /// router.get("string") { _, _ -> String in
 ///     return "string"
 /// }
-/// router.post("status") { _, _ -> HTTPResponseStatus in
+/// router.post("status") { _, _ -> HTTPResponse.Status in
 ///     return .ok
 /// }
 /// router.data("data") { request, context -> ByteBuffer in

--- a/Sources/Hummingbird/Server/Response.swift
+++ b/Sources/Hummingbird/Server/Response.swift
@@ -34,7 +34,7 @@ extension Response {
         /// must be used in the second request.
         case temporary
 
-        /// Associated `HTTPResponseStatus` for this redirect type.
+        /// Associated `HTTPResponse.Status` for this redirect type.
         public var status: HTTPResponse.Status {
             switch self {
             case .permanent: return .movedPermanently


### PR DESCRIPTION
In https://docs.hummingbird.codes/2.0/documentation/hummingbird/router ,

```swift
router.post("status") { _, _ -> HTTPResponseStatus in
    return .ok
}
```


This example code cannot compile because `HTTPResponseStatus` seems to have been renamed to `HTTPResponse.Status`. This PR updates the documentation comments accordingly.