### PR TITLE
Fix minimum swift-nio version to use async/await FileIO APIs.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.1"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.20.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),


### PR DESCRIPTION
2.0.0-beta.2 uses async/await FileIO APIs in NIO.

Package.swift points to 2.62.0 as the minimum version, but this API was introduced in 2.63.0.
INFO: https://github.com/apple/swift-nio/releases/tag/2.63.0