### PR TITLE
Minor changes to HTTP channel lhandler

### DIFF
--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -46,8 +46,9 @@ public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
             [HTTPUserEventHandler(logger: logger)]
         return channel.eventLoop.makeCompletedFuture {
             try channel.pipeline.syncOperations.configureHTTPServerPipeline(
-                withPipeliningAssistance: false,
-                withErrorHandling: true
+                withPipeliningAssistance: false, // HTTP is pipelined by NIOAsyncChannel
+                withErrorHandling: true,
+                withOutboundHeaderValidation: false // Swift HTTP Types are already doing this validation
             )
             try channel.pipeline.syncOperations.addHandlers(childChannelHandlers)
             return try NIOAsyncChannel(

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -30,7 +30,6 @@ public protocol HTTPChannelHandler: ServerChildChannel {
 @usableFromInline
 enum HTTPChannelError: Error {
     case unexpectedHTTPPart(HTTPRequestPart)
-    case closeConnection
 }
 
 enum HTTPState: Int, Sendable {
@@ -75,7 +74,7 @@ extension HTTPChannelHandler {
                                 throw error
                             }
                             if request.headers[.connection] == "close" {
-                                throw HTTPChannelError.closeConnection
+                                return
                             }
                             // set to idle unless it is cancelled then exit
                             guard processingRequest.exchange(.idle) == .processing else { break }
@@ -112,8 +111,6 @@ extension HTTPChannelHandler {
             } onCancel: {
                 asyncChannel.channel.close(mode: .input, promise: nil)
             }
-        } catch HTTPChannelError.closeConnection {
-            // channel is being closed because we received a connection: close header
         } catch {
             // we got here because we failed to either read or write to the channel
             logger.trace("Failed to read/write to Channel. Error: \(error)")


### PR DESCRIPTION
- Don't throw connection close error, instead just return from function (it is clearer what is going on)
- Disable outbound header validation. This is already done by swift http types