### PR TITLE
Route collections

### DIFF
--- a/Sources/Hummingbird/Router/RouteCollection.swift
+++ b/Sources/Hummingbird/Router/RouteCollection.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPTypes
+
+/// Collection of routes
+public final class RouteCollection<Context: BaseRequestContext>: RouterMethods {
+    /// Initialize RouteCollection
+    public init() {
+        self.routes = .init()
+        self.middlewares = .init()
+    }
+
+    /// Add responder to call when path and method are matched
+    ///
+    /// - Parameters:
+    ///   - path: Path to match
+    ///   - method: Request method to match
+    ///   - responder: Responder to call if match is made
+    /// - Returns: self
+    public func on<Responder: HTTPResponder>(
+        _ path: String,
+        method: HTTPRequest.Method,
+        responder: Responder
+    ) -> Self where Responder.Context == Context {
+        self.routes[.init(path: path, method: method)] = responder
+        return self
+    }
+
+    /// Return a group inside the route collection
+    /// - Parameter path: path prefix to add to routes inside this group
+    public func group(_ path: String) -> RouterGroup<Context> {
+        return .init(path: path, router: self)
+    }
+
+    /// Add middleware to RouteCollection
+    @discardableResult public func add(middleware: any RouterMiddleware<Context>) -> Self {
+        self.middlewares.add(middleware)
+        return self
+    }
+
+    fileprivate struct RouteDefinition: Hashable {
+        let path: String
+        let method: HTTPRequest.Method
+    }
+
+    fileprivate var routes: [RouteDefinition: any HTTPResponder<Context>]
+    let middlewares: MiddlewareGroup<Context>
+}
+
+extension RouterMethods {
+    /// Add route collection to router
+    /// - Parameter collection: Route collection
+    public func add(_ collection: RouteCollection<Context>) {
+        for (definition, responder) in collection.routes {
+            self.on(definition.path, method: definition.method, responder: collection.middlewares.constructResponder(finalResponder: responder))
+        }
+    }
+}

--- a/Sources/Hummingbird/Router/RouteCollection.swift
+++ b/Sources/Hummingbird/Router/RouteCollection.swift
@@ -64,7 +64,7 @@ public final class RouteCollection<Context: BaseRequestContext>: RouterMethods {
 extension RouterMethods {
     /// Add route collection to router
     /// - Parameter collection: Route collection
-    public func add(_ path: String = "", routes collection: RouteCollection<Context>) {
+    public func addRoutes(_ collection: RouteCollection<Context>, atPath path: String = "") {
         for route in collection.routes {
             // ensure path starts with a "/" and doesn't end with a "/"
             let path = self.combinePaths(path, route.path)

--- a/Sources/Hummingbird/Router/RouteCollection.swift
+++ b/Sources/Hummingbird/Router/RouteCollection.swift
@@ -17,7 +17,7 @@ import HTTPTypes
 /// Collection of routes
 public final class RouteCollection<Context: BaseRequestContext>: RouterMethods {
     /// Initialize RouteCollection
-    public init() {
+    public init(context: Context.Type = BasicRequestContext.self) {
         self.routes = .init()
         self.middlewares = .init()
     }
@@ -40,7 +40,7 @@ public final class RouteCollection<Context: BaseRequestContext>: RouterMethods {
 
     /// Return a group inside the route collection
     /// - Parameter path: path prefix to add to routes inside this group
-    public func group(_ path: String) -> RouterGroup<Context> {
+    public func group(_ path: String = "") -> RouterGroup<Context> {
         return .init(path: path, router: self)
     }
 
@@ -62,9 +62,11 @@ public final class RouteCollection<Context: BaseRequestContext>: RouterMethods {
 extension RouterMethods {
     /// Add route collection to router
     /// - Parameter collection: Route collection
-    public func add(_ collection: RouteCollection<Context>) {
+    public func add(_ path: String = "", routes collection: RouteCollection<Context>) {
         for (definition, responder) in collection.routes {
-            self.on(definition.path, method: definition.method, responder: collection.middlewares.constructResponder(finalResponder: responder))
+            // ensure path starts with a "/" and doesn't end with a "/"
+            let path = self.combinePaths(path, definition.path)
+            self.on(path, method: definition.method, responder: collection.middlewares.constructResponder(finalResponder: responder))
         }
     }
 }

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -69,7 +69,12 @@ public final class Router<Context: BaseRequestContext>: RouterMethods, HTTPRespo
         )
     }
 
-    /// Add path for async closure
+    /// Add responder to call when path and method are matched
+    ///
+    /// - Parameters:
+    ///   - path: Path to match
+    ///   - method: Request method to match
+    ///   - responder: Responder to call if match is made
     @discardableResult public func on<Responder: HTTPResponder>(
         _ path: String,
         method: HTTPRequest.Method,

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -54,19 +54,6 @@ public final class Router<Context: BaseRequestContext>: RouterMethods, HTTPRespo
         self.options = options
     }
 
-    /// Add route to router
-    /// - Parameters:
-    ///   - path: URI path
-    ///   - method: http method
-    ///   - responder: handler to call
-    public func add(_ path: String, method: HTTPRequest.Method, responder: any HTTPResponder<Context>) {
-        // ensure path starts with a "/" and doesn't end with a "/"
-        let path = "/\(path.dropSuffix("/").dropPrefix("/"))"
-        self.trie.addEntry(.init(path), value: EndpointResponders(path: path)) { node in
-            node.value!.addResponder(for: method, responder: self.middlewares.constructResponder(finalResponder: responder))
-        }
-    }
-
     /// build responder from router
     public func buildResponder() -> RouterResponder<Context> {
         if self.options.contains(.autoGenerateHeadEndpoints) {
@@ -82,18 +69,20 @@ public final class Router<Context: BaseRequestContext>: RouterMethods, HTTPRespo
         )
     }
 
-    /// Add path for closure returning type conforming to ResponseGenerator
-    @discardableResult public func on(
+    /// Add path for async closure
+    @discardableResult public func on<Responder: HTTPResponder>(
         _ path: String,
         method: HTTPRequest.Method,
-        use closure: @escaping @Sendable (Request, Context) async throws -> some ResponseGenerator
-    ) -> Self {
-        let responder = constructResponder(use: closure)
-        var path = path
+        responder: Responder
+    ) -> Self where Responder.Context == Context {
+        // ensure path starts with a "/" and doesn't end with a "/"
+        var path = "/\(path.dropSuffix("/").dropPrefix("/"))"
         if self.options.contains(.caseInsensitive) {
             path = path.lowercased()
         }
-        self.add(path, method: method, responder: responder)
+        self.trie.addEntry(.init(path), value: EndpointResponders(path: path)) { node in
+            node.value!.addResponder(for: method, responder: self.middlewares.constructResponder(finalResponder: responder))
+        }
         return self
     }
 

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -32,16 +32,16 @@ import NIOCore
 /// ```
 public struct RouterGroup<Context: BaseRequestContext>: RouterMethods {
     let path: String
-    let router: Router<Context>
+    let router: any RouterMethods<Context>
     let middlewares: MiddlewareGroup<Context>
 
-    init(path: String = "", middlewares: MiddlewareGroup<Context> = .init(), router: Router<Context>) {
+    init(path: String = "", middlewares: MiddlewareGroup<Context> = .init(), router: any RouterMethods<Context>) {
         self.path = path
         self.router = router
         self.middlewares = middlewares
     }
 
-    /// Add middleware to RouterEndpoint
+    /// Add middleware to RouterGroup
     @discardableResult public func add(middleware: any RouterMiddleware<Context>) -> RouterGroup<Context> {
         self.middlewares.add(middleware)
         return self
@@ -57,7 +57,13 @@ public struct RouterGroup<Context: BaseRequestContext>: RouterMethods {
         )
     }
 
-    /// Add path for async closure
+    /// Add responder to call when path and method are matched
+    ///
+    /// - Parameters:
+    ///   - path: Path to match
+    ///   - method: Request method to match
+    ///   - responder: Responder to call if match is made
+    /// - Returns: self
     @discardableResult public func on<Responder: HTTPResponder>(
         _ path: String,
         method: HTTPRequest.Method,

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -57,18 +57,15 @@ public struct RouterGroup<Context: BaseRequestContext>: RouterMethods {
         )
     }
 
-    /// Add path for closure returning type using async/await
-    @discardableResult public func on(
-        _ path: String = "",
+    /// Add path for async closure
+    @discardableResult public func on<Responder: HTTPResponder>(
+        _ path: String,
         method: HTTPRequest.Method,
-        use closure: @Sendable @escaping (Request, Context) async throws -> some ResponseGenerator
-    ) -> Self {
-        let responder = constructResponder(use: closure)
-        var path = self.combinePaths(self.path, path)
-        if self.router.options.contains(.caseInsensitive) {
-            path = path.lowercased()
-        }
-        self.router.add(path, method: method, responder: self.middlewares.constructResponder(finalResponder: responder))
+        responder: Responder
+    ) -> Self where Responder.Context == Context {
+        // ensure path starts with a "/" and doesn't end with a "/"
+        let path = self.combinePaths(self.path, path)
+        self.router.on(path, method: method, responder: self.middlewares.constructResponder(finalResponder: responder))
         return self
     }
 

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -74,10 +74,4 @@ public struct RouterGroup<Context: BaseRequestContext>: RouterMethods {
         self.router.on(path, method: method, responder: self.middlewares.constructResponder(finalResponder: responder))
         return self
     }
-
-    internal func combinePaths(_ path1: String, _ path2: String) -> String {
-        let path1 = path1.dropSuffix("/")
-        let path2 = path2.dropPrefix("/")
-        return "\(path1)/\(path2)"
-    }
 }

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -96,12 +96,18 @@ extension RouterMethods {
         return self.on(path, method: .patch, use: handler)
     }
 
-    func constructResponder(
+    internal func constructResponder(
         use closure: @Sendable @escaping (Request, Context) async throws -> some ResponseGenerator
     ) -> CallbackResponder<Context> {
         return CallbackResponder { request, context in
             let output = try await closure(request, context)
             return try output.response(from: request, context: context)
         }
+    }
+
+    internal func combinePaths(_ path1: String, _ path2: String) -> String {
+        let path1 = path1.dropSuffix("/")
+        let path2 = path2.dropPrefix("/")
+        return "\(path1)/\(path2)"
     }
 }

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -19,7 +19,13 @@ import NIOCore
 public protocol RouterMethods<Context> {
     associatedtype Context: BaseRequestContext
 
-    /// On path/method call responder
+    /// Add responder to call when path and method are matched
+    ///
+    /// - Parameters:
+    ///   - path: Path to match
+    ///   - method: Request method to match
+    ///   - responder: Responder to call if match is made
+    /// - Returns: self
     @discardableResult func on<Responder: HTTPResponder>(
         _ path: String,
         method: HTTPRequest.Method,

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -431,6 +431,75 @@ final class RouterTests: XCTestCase {
         }
     }
 
+    // Test route collection added to Router
+    func testRouteCollection() async throws {
+        let router = Router()
+        let routes = RouteCollection()
+        routes.get("that") { _, _ in
+            return HTTPResponse.Status.ok
+        }
+        router.add("this", routes: routes)
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/this/that", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+            }
+        }
+    }
+
+    // Test route collection added to Router
+    func testRouteCollectionInGroup() async throws {
+        let router = Router()
+        let routes = RouteCollection()
+            .get("that") { _, _ in
+                return HTTPResponse.Status.ok
+            }
+        router.group("this").add(routes: routes)
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/this/that", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+            }
+        }
+    }
+
+    // Test middleware in route collection
+    func testMiddlewareInRouteCollection() async throws {
+        let router = Router()
+        let routes = RouteCollection()
+            .add(middleware: TestMiddleware("Hello"))
+            .get("that") { _, _ in
+                return HTTPResponse.Status.ok
+            }
+        router.add("this", routes: routes)
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/this/that", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertEqual(response.headers[.test], "Hello")
+            }
+        }
+    }
+
+    // Test group in route collection
+    func testGroupInRouteCollection() async throws {
+        let router = Router()
+        let routes = RouteCollection()
+        routes.group("2")
+            .add(middleware: TestMiddleware("Hello"))
+            .get("3") { _, _ in
+                return HTTPResponse.Status.ok
+            }
+        router.add("1", routes: routes)
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/1/2/3", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertEqual(response.headers[.test], "Hello")
+            }
+        }
+    }
+
     // Test case insensitive router works
     func testCaseInsensitive() async throws {
         let router = Router(options: .caseInsensitive)
@@ -440,12 +509,18 @@ final class RouterTests: XCTestCase {
         router.get("lowercased") { _, _ in
             return HTTPResponse.Status.ok
         }
+        router.group("group").get("Uppercased") { _, _ in
+            return HTTPResponse.Status.ok
+        }
         let app = Application(responder: router.buildResponder())
         try await app.test(.router) { client in
             try await client.execute(uri: "/uppercased", method: .get) { response in
                 XCTAssertEqual(response.status, .ok)
             }
             try await client.execute(uri: "/LOWERCASED", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+            }
+            try await client.execute(uri: "/Group/uppercased", method: .get) { response in
                 XCTAssertEqual(response.status, .ok)
             }
         }

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -438,7 +438,7 @@ final class RouterTests: XCTestCase {
         routes.get("that") { _, _ in
             return HTTPResponse.Status.ok
         }
-        router.add("this", routes: routes)
+        router.addRoutes(routes, atPath: "/this")
         let app = Application(responder: router.buildResponder())
         try await app.test(.router) { client in
             try await client.execute(uri: "/this/that", method: .get) { response in
@@ -454,7 +454,7 @@ final class RouterTests: XCTestCase {
             .get("that") { _, _ in
                 return HTTPResponse.Status.ok
             }
-        router.group("this").add(routes: routes)
+        router.group("this").addRoutes(routes)
         let app = Application(responder: router.buildResponder())
         try await app.test(.router) { client in
             try await client.execute(uri: "/this/that", method: .get) { response in
@@ -471,7 +471,7 @@ final class RouterTests: XCTestCase {
             .get("that") { _, _ in
                 return HTTPResponse.Status.ok
             }
-        router.add("this", routes: routes)
+        router.addRoutes(routes, atPath: "/this")
         let app = Application(responder: router.buildResponder())
         try await app.test(.router) { client in
             try await client.execute(uri: "/this/that", method: .get) { response in
@@ -490,7 +490,7 @@ final class RouterTests: XCTestCase {
             .get("3") { _, _ in
                 return HTTPResponse.Status.ok
             }
-        router.add("1", routes: routes)
+        router.addRoutes(routes, atPath: "1")
         let app = Application(responder: router.buildResponder())
         try await app.test(.router) { client in
             try await client.execute(uri: "/1/2/3", method: .get) { response in


### PR DESCRIPTION
A route collection is a fragment of a router. It defines a selection of routes and middleware. `RouterMethods` has been altered slightly so that it can be used for `RouteCollections` as well as `Router` and `RouterGroup`.

```swift
struct UserController {
    var routes: RouteCollection<some BaseRequestContext> {
        let routes = RouteCollection()
        routes.post("signup", use: self.login)
        routes.group()
            .add(middleware: BasicAuthenticationMiddleware())
            .post("login", use: self.login)
        return routes
    }

    @Sendable func login(_ request: Request, context: some BaseRequestContext) -> HTTPResponse.Status {
        return .ok
    }
}

let router = Router()
router.add("/users", routes: UserController().routes)
```