### PR TITLE
Extend RouterResponder to conform to RouterMiddleware.

### DIFF
--- a/Sources/Hummingbird/Router/RouterResponder.swift
+++ b/Sources/Hummingbird/Router/RouterResponder.swift
@@ -57,3 +57,14 @@ public struct RouterResponder<Context: BaseRequestContext>: HTTPResponder {
         return try await responder.respond(to: request, context: context)
     }
 }
+
+extension RouterResponder: RouterMiddleware {
+    /// Treat RouterResponder as a Middleware
+    public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
+        do {
+            return try await self.respond(to: request, context: context)
+        } catch let error as HTTPError where error.status == .notFound {
+            return try await next(request, context)
+        }
+    }
+}

--- a/Tests/HummingbirdRouterTests/RouterTests.swift
+++ b/Tests/HummingbirdRouterTests/RouterTests.swift
@@ -443,6 +443,28 @@ final class RouterTests: XCTestCase {
             }
         }
     }
+
+    func testAddRouterToBuilder() async throws {
+        let router = Router(context: BasicRouterRequestContext.self)
+        router.get("test") { _, _ in
+            return "test"
+        }
+        let routerBuilder = RouterBuilder(context: BasicRouterRequestContext.self) {
+            router.buildResponder()
+            Get("hello") { _, _ in
+                return "hello"
+            }
+        }
+        let app = Application(router: routerBuilder)
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/hello", method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), "hello")
+            }
+            try await client.execute(uri: "/test", method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), "test")
+            }
+        }
+    }
 }
 
 public struct TestRouterContext2: RouterRequestContext, RequestContext {


### PR DESCRIPTION
This means we can add a Router (eg one built with OpenAPI) into a RouterBuilder from HummingbirdRouter