### PR TITLE
Remove ServerChildChannel generic associatedtype from ApplicationProtocol

### DIFF
--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelBuilder.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelBuilder.swift
@@ -18,13 +18,13 @@ import NIOCore
 ///
 /// Used when building an ``Hummingbird/Application``. It delays the building
 /// of the ``ServerChildChannel`` until the HTTP responder has been built.
-public struct HTTPChannelBuilder<ChildChannel: ServerChildChannel>: Sendable {
+public struct HTTPChannelBuilder: Sendable {
     /// build child channel from HTTP responder
-    public let build: @Sendable (@escaping HTTPChannelHandler.Responder) throws -> ChildChannel
+    public let build: @Sendable (@escaping HTTPChannelHandler.Responder) throws -> any ServerChildChannel
 
     /// Initialize HTTPChannelBuilder
     /// - Parameter build: closure building child channel from HTTP responder
-    public init(_ build: @escaping @Sendable (@escaping HTTPChannelHandler.Responder) throws -> ChildChannel) {
+    public init(_ build: @escaping @Sendable (@escaping HTTPChannelHandler.Responder) throws -> any ServerChildChannel) {
         self.build = build
     }
 }
@@ -43,7 +43,7 @@ extension HTTPChannelBuilder {
     /// - Returns: HTTPChannelHandler builder
     public static func http1(
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
-    ) -> HTTPChannelBuilder<HTTP1Channel> {
+    ) -> HTTPChannelBuilder {
         return .init { responder in
             return HTTP1Channel(responder: responder, additionalChannelHandlers: additionalChannelHandlers)
         }

--- a/Sources/HummingbirdCore/Server/Server.swift
+++ b/Sources/HummingbirdCore/Server/Server.swift
@@ -69,8 +69,11 @@ public actor Server<ChildChannel: ServerChildChannel>: Service {
 
     /// Initialize Server
     /// - Parameters:
-    ///   - group: EventLoopGroup server uses
+    ///   - childChannelSetup: Server child channel
     ///   - configuration: Configuration for server
+    ///   - onServerRunning: Closure to run once server is up and running
+    ///   - eventLoopGroup: EventLoopGroup the server uses
+    ///   = logger: Logger used by server
     public init(
         childChannelSetup: ChildChannel,
         configuration: ServerConfiguration,
@@ -209,7 +212,7 @@ public actor Server<ChildChannel: ServerChildChannel>: Service {
                         logger: self.logger
                     )
                 }
-                self.logger.info("Server started and listening on \(host):\(port)")
+                self.logger.info("Server started and listening on \(host):\(asyncChannel.channel.localAddress?.port ?? port)")
                 return asyncChannel
 
             case .unixDomainSocket(let path):

--- a/Sources/HummingbirdCore/Server/Server.swift
+++ b/Sources/HummingbirdCore/Server/Server.swift
@@ -73,7 +73,7 @@ public actor Server<ChildChannel: ServerChildChannel>: Service {
     ///   - configuration: Configuration for server
     ///   - onServerRunning: Closure to run once server is up and running
     ///   - eventLoopGroup: EventLoopGroup the server uses
-    ///   = logger: Logger used by server
+    ///   - logger: Logger used by server
     public init(
         childChannelSetup: ChildChannel,
         configuration: ServerConfiguration,

--- a/Sources/HummingbirdCore/Server/ServerChildChannel.swift
+++ b/Sources/HummingbirdCore/Server/ServerChildChannel.swift
@@ -14,6 +14,7 @@
 
 import Logging
 import NIOCore
+import ServiceLifecycle
 
 /// HTTPServer child channel setup protocol
 public protocol ServerChildChannel: Sendable {
@@ -31,4 +32,29 @@ public protocol ServerChildChannel: Sendable {
     ///   - value: Object to process input/output on child channel
     ///   - logger: Logger to use while processing messages
     func handle(value: Value, logger: Logger) async
+}
+
+extension ServerChildChannel {
+    /// Build existential ``Server`` from existential `ServerChildChannel`
+    ///
+    /// - Parameters:
+    ///   - configuration: Configuration for server
+    ///   - onServerRunning: Closure to run once server is up and running
+    ///   - eventLoopGroup: EventLoopGroup the server uses
+    ///   = logger: Logger used by server
+    /// - Returns: Server Service
+    public func server(
+        configuration: ServerConfiguration,
+        onServerRunning: (@Sendable (Channel) async -> Void)? = { _ in },
+        eventLoopGroup: EventLoopGroup,
+        logger: Logger
+    ) -> Service {
+        Server(
+            childChannelSetup: self,
+            configuration: configuration,
+            onServerRunning: onServerRunning,
+            eventLoopGroup: eventLoopGroup,
+            logger: logger
+        )
+    }
 }

--- a/Sources/HummingbirdCore/Server/ServerChildChannel.swift
+++ b/Sources/HummingbirdCore/Server/ServerChildChannel.swift
@@ -41,7 +41,7 @@ extension ServerChildChannel {
     ///   - configuration: Configuration for server
     ///   - onServerRunning: Closure to run once server is up and running
     ///   - eventLoopGroup: EventLoopGroup the server uses
-    ///   = logger: Logger used by server
+    ///   - logger: Logger used by server
     /// - Returns: Server Service
     public func server(
         configuration: ServerConfiguration,

--- a/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2ChannelBuilder.swift
@@ -33,7 +33,7 @@ extension HTTPChannelBuilder {
     public static func http2Upgrade(
         tlsConfiguration: TLSConfiguration,
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
-    ) throws -> HTTPChannelBuilder<HTTP2UpgradeChannel> {
+    ) throws -> HTTPChannelBuilder {
         return .init { responder in
             return try HTTP2UpgradeChannel(
                 tlsConfiguration: tlsConfiguration,

--- a/Sources/HummingbirdTLS/TLSChannel.swift
+++ b/Sources/HummingbirdTLS/TLSChannel.swift
@@ -62,3 +62,10 @@ extension TLSChannel: HTTPChannelHandler where BaseChannel: HTTPChannelHandler {
         baseChannel.responder
     }
 }
+
+extension ServerChildChannel {
+    /// Construct existential ``TLSChannel`` from existential `ServerChildChannel`
+    func withTLS(tlsConfiguration: TLSConfiguration) throws -> any ServerChildChannel {
+        try TLSChannel(self, tlsConfiguration: tlsConfiguration)
+    }
+}

--- a/Sources/HummingbirdTLS/TLSChannelBuilder.swift
+++ b/Sources/HummingbirdTLS/TLSChannelBuilder.swift
@@ -29,12 +29,12 @@ extension HTTPChannelBuilder {
     ///   - base: Base child channel to wrap with TLS
     ///   - tlsConfiguration: TLS configuration
     /// - Returns: HTTPChannelHandler builder
-    public static func tls<BaseChannel: ServerChildChannel>(
-        _ base: HTTPChannelBuilder<BaseChannel> = .http1(),
+    public static func tls(
+        _ base: HTTPChannelBuilder = .http1(),
         tlsConfiguration: TLSConfiguration
-    ) throws -> HTTPChannelBuilder<TLSChannel<BaseChannel>> {
+    ) throws -> HTTPChannelBuilder {
         return .init { responder in
-            return try TLSChannel(base.build(responder), tlsConfiguration: tlsConfiguration)
+            return try base.build(responder).withTLS(tlsConfiguration: tlsConfiguration)
         }
     }
 }

--- a/Sources/HummingbirdTesting/TestApplication.swift
+++ b/Sources/HummingbirdTesting/TestApplication.swift
@@ -23,7 +23,6 @@ import ServiceLifecycle
 /// This is needed to override the `onServerRunning` function
 internal struct TestApplication<BaseApp: ApplicationProtocol>: ApplicationProtocol, Service {
     typealias Responder = BaseApp.Responder
-    typealias ChildChannel = BaseApp.ChildChannel
 
     let base: BaseApp
 
@@ -31,7 +30,7 @@ internal struct TestApplication<BaseApp: ApplicationProtocol>: ApplicationProtoc
         get async throws { try await self.base.responder }
     }
 
-    var server: HTTPChannelBuilder<ChildChannel> {
+    var server: HTTPChannelBuilder {
         self.base.server
     }
 

--- a/Tests/HummingbirdCoreTests/HTTP2Tests.swift
+++ b/Tests/HummingbirdCoreTests/HTTP2Tests.swift
@@ -36,7 +36,7 @@ class HummingBirdHTTP2Tests: XCTestCase {
             configuration: .init(address: .hostname(port: 0), serverName: testServerName),
             eventLoopGroup: eventLoopGroup,
             logger: Logger(label: "Hummingbird")
-        ) { _, port in
+        ) { port in
             var tlsConfiguration = try getClientTLSConfiguration()
             // no way to override the SSL server name with AsyncHTTPClient so need to set
             // hostname verification off


### PR DESCRIPTION
Instead use `any ServerChildChannel`. We don’t gain any real benefit from the parameter being a generic over an existential, it gets converted to an existential `Service` anyway. But I’ve had to jump through a number of hoops to ensure we can keep generic parameters where they do make a performance improvement. 

The reason I’m doing this is I was trying to flip between a TLS and non-TLS child channel when build an application and it was really quite awkward as the child channel changed the type of the Application. Removing the ServerChildChannel generic parameter simplifies this considerably.