### PR TITLE
Add optional port to TestClientProtocol

### DIFF
--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: swift:5.9
+      image: swift:5.10
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        image: ["swift:5.9", "swift:5.10", "swiftlang/swift:nightly-jammy"]
+        image: ["swift:5.9", "swift:5.10", "swiftlang/swift:nightly-6.0-jammy"]
     
     container:
       image: ${{ matrix.image }}

--- a/Sources/HummingbirdTesting/ApplicationTester.swift
+++ b/Sources/HummingbirdTesting/ApplicationTester.swift
@@ -61,6 +61,8 @@ public protocol TestClientProtocol: Sendable {
         headers: HTTPFields,
         body: ByteBuffer?
     ) async throws -> TestResponse
+    // Port to connect to if test client is connecting to a live server
+    var port: Int? { get }
 }
 
 extension TestClientProtocol {

--- a/Sources/HummingbirdTesting/AsyncHTTPClientTestFramework.swift
+++ b/Sources/HummingbirdTesting/AsyncHTTPClientTestFramework.swift
@@ -29,6 +29,7 @@ final class AsyncHTTPClientTestFramework<App: ApplicationProtocol>: ApplicationT
     struct Client: TestClientProtocol {
         let client: HTTPClient
         let urlPrefix: String
+        let port: Int?
         let timeout: TimeAmount
 
         /// Send request and call test callback on the response returned
@@ -75,7 +76,7 @@ final class AsyncHTTPClientTestFramework<App: ApplicationProtocol>: ApplicationT
                 eventLoopGroupProvider: .singleton,
                 configuration: .init(tlsConfiguration: tlsConfiguration)
             )
-            let client = Client(client: httpClient, urlPrefix: "\(self.scheme)://localhost:\(port)", timeout: self.timeout)
+            let client = Client(client: httpClient, urlPrefix: "\(self.scheme)://localhost:\(port)", port: port, timeout: self.timeout)
             do {
                 let value = try await test(client)
                 await serviceGroup.triggerGracefulShutdown()

--- a/Sources/HummingbirdTesting/LiveTestFramework.swift
+++ b/Sources/HummingbirdTesting/LiveTestFramework.swift
@@ -40,6 +40,8 @@ final class LiveTestFramework<App: ApplicationProtocol>: ApplicationTestFramewor
             let response = try await client.execute(request)
             return .init(head: response.head, body: response.body ?? ByteBuffer(), trailerHeaders: response.trailerHeaders)
         }
+
+        var port: Int? { self.client.port }
     }
 
     init(app: App) {

--- a/Sources/HummingbirdTesting/RouterTestFramework.swift
+++ b/Sources/HummingbirdTesting/RouterTestFramework.swift
@@ -133,6 +133,8 @@ struct RouterTestFramework<Responder: HTTPResponder>: ApplicationTestFramework w
                 return try await group.next()!
             }
         }
+
+        var port: Int? { nil }
     }
 
     final class RouterResponseWriter: ResponseBodyWriter {


### PR DESCRIPTION
Port is only available when running a live server so port has to be optional
This is to be used by the WebSocket testing code