### PR TITLE
Eventloop executor

### DIFF
--- a/Sources/HummingbirdCore/Server/EventLoopExecutor.swift
+++ b/Sources/HummingbirdCore/Server/EventLoopExecutor.swift
@@ -44,4 +44,20 @@ import NIOCore
             self.eventLoop === other.eventLoop
         }
     }
+
+    struct EventLoopExecutorMap {
+        init(eventLoopGroup: EventLoopGroup) {
+            var executors: [ObjectIdentifier: EventLoopExecutor] = [:]
+            for eventLoop in eventLoopGroup.makeIterator() {
+                executors[ObjectIdentifier(eventLoop)] = EventLoopExecutor(eventLoop: eventLoop)
+            }
+            self.executors = executors
+        }
+
+        subscript(eventLoop: EventLoop) -> EventLoopExecutor? {
+            return self.executors[ObjectIdentifier(eventLoop)]
+        }
+
+        let executors: [ObjectIdentifier: EventLoopExecutor]
+    }
 #endif  // swift(>=6.0)

--- a/Sources/HummingbirdCore/Server/EventLoopExecutor.swift
+++ b/Sources/HummingbirdCore/Server/EventLoopExecutor.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+#if compiler(>=6.0)
+    final class EventLoopExecutor: TaskExecutor, SerialExecutor {
+        @usableFromInline let eventLoop: EventLoop
+
+        init(eventLoop: EventLoop) {
+            self.eventLoop = eventLoop
+        }
+
+        func asUnownedTaskExecutor() -> UnownedTaskExecutor {
+            UnownedTaskExecutor(ordinary: self)
+        }
+
+        @inlinable
+        func enqueue(_ job: consuming ExecutorJob) {
+            let job = UnownedJob(job)
+            self.eventLoop.execute {
+                job.runSynchronously(on: self.asUnownedTaskExecutor())
+            }
+        }
+
+        @inlinable
+        func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+            UnownedSerialExecutor(complexEquality: self)
+        }
+
+        @inlinable
+        func isSameExclusiveExecutionContext(other: EventLoopExecutor) -> Bool {
+            self.eventLoop === other.eventLoop
+        }
+    }
+#endif  // swift(>=6.0)

--- a/Sources/HummingbirdCore/Server/EventLoopExecutor.swift
+++ b/Sources/HummingbirdCore/Server/EventLoopExecutor.swift
@@ -15,49 +15,49 @@
 import NIOCore
 
 #if compiler(>=6.0)
-    final class EventLoopExecutor: TaskExecutor, SerialExecutor {
-        @usableFromInline let eventLoop: EventLoop
+final class EventLoopExecutor: TaskExecutor, SerialExecutor {
+    @usableFromInline let eventLoop: EventLoop
 
-        init(eventLoop: EventLoop) {
-            self.eventLoop = eventLoop
-        }
+    init(eventLoop: EventLoop) {
+        self.eventLoop = eventLoop
+    }
 
-        func asUnownedTaskExecutor() -> UnownedTaskExecutor {
-            UnownedTaskExecutor(ordinary: self)
-        }
+    func asUnownedTaskExecutor() -> UnownedTaskExecutor {
+        UnownedTaskExecutor(ordinary: self)
+    }
 
-        @inlinable
-        func enqueue(_ job: consuming ExecutorJob) {
-            let job = UnownedJob(job)
-            self.eventLoop.execute {
-                job.runSynchronously(on: self.asUnownedTaskExecutor())
-            }
-        }
-
-        @inlinable
-        func asUnownedSerialExecutor() -> UnownedSerialExecutor {
-            UnownedSerialExecutor(complexEquality: self)
-        }
-
-        @inlinable
-        func isSameExclusiveExecutionContext(other: EventLoopExecutor) -> Bool {
-            self.eventLoop === other.eventLoop
+    @inlinable
+    func enqueue(_ job: consuming ExecutorJob) {
+        let job = UnownedJob(job)
+        self.eventLoop.execute {
+            job.runSynchronously(on: self.asUnownedTaskExecutor())
         }
     }
 
-    struct EventLoopExecutorMap {
-        init(eventLoopGroup: EventLoopGroup) {
-            var executors: [ObjectIdentifier: EventLoopExecutor] = [:]
-            for eventLoop in eventLoopGroup.makeIterator() {
-                executors[ObjectIdentifier(eventLoop)] = EventLoopExecutor(eventLoop: eventLoop)
-            }
-            self.executors = executors
-        }
-
-        subscript(eventLoop: EventLoop) -> EventLoopExecutor? {
-            return self.executors[ObjectIdentifier(eventLoop)]
-        }
-
-        let executors: [ObjectIdentifier: EventLoopExecutor]
+    @inlinable
+    func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+        UnownedSerialExecutor(complexEquality: self)
     }
-#endif  // swift(>=6.0)
+
+    @inlinable
+    func isSameExclusiveExecutionContext(other: EventLoopExecutor) -> Bool {
+        self.eventLoop === other.eventLoop
+    }
+}
+
+struct EventLoopExecutorMap {
+    init(eventLoopGroup: EventLoopGroup) {
+        var executors: [ObjectIdentifier: EventLoopExecutor] = [:]
+        for eventLoop in eventLoopGroup.makeIterator() {
+            executors[ObjectIdentifier(eventLoop)] = EventLoopExecutor(eventLoop: eventLoop)
+        }
+        self.executors = executors
+    }
+
+    subscript(eventLoop: EventLoop) -> EventLoopExecutor? {
+        return self.executors[ObjectIdentifier(eventLoop)]
+    }
+
+    let executors: [ObjectIdentifier: EventLoopExecutor]
+}
+#endif // swift(>=6.0)

--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -46,13 +46,13 @@ public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
     public func setup(channel: Channel, logger: Logger) -> EventLoopFuture<Value> {
         let childChannelHandlers: [any ChannelHandler] =
             [HTTP1ToHTTPServerCodec(secure: false)] + self.additionalChannelHandlers() + [
-                HTTPUserEventHandler(logger: logger)
+                HTTPUserEventHandler(logger: logger),
             ]
         return channel.eventLoop.makeCompletedFuture {
             try channel.pipeline.syncOperations.configureHTTPServerPipeline(
-                withPipeliningAssistance: false,  // HTTP is pipelined by NIOAsyncChannel
+                withPipeliningAssistance: false, // HTTP is pipelined by NIOAsyncChannel
                 withErrorHandling: true,
-                withOutboundHeaderValidation: false  // Swift HTTP Types are already doing this validation
+                withOutboundHeaderValidation: false // Swift HTTP Types are already doing this validation
             )
             try channel.pipeline.syncOperations.addHandlers(childChannelHandlers)
             return try NIOAsyncChannel(

--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -18,6 +18,10 @@ import NIOCore
 import NIOHTTPTypes
 import NIOHTTPTypesHTTP1
 
+extension NIOAsyncChannel: ChildChannel {
+    public var eventLoop: EventLoop { self.channel.eventLoop }
+}
+
 /// Child channel for processing HTTP1
 public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
     public typealias Value = NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>
@@ -41,14 +45,14 @@ public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
     /// - Returns: Object to process input/output on child channel
     public func setup(channel: Channel, logger: Logger) -> EventLoopFuture<Value> {
         let childChannelHandlers: [any ChannelHandler] =
-            [HTTP1ToHTTPServerCodec(secure: false)] +
-            self.additionalChannelHandlers() +
-            [HTTPUserEventHandler(logger: logger)]
+            [HTTP1ToHTTPServerCodec(secure: false)] + self.additionalChannelHandlers() + [
+                HTTPUserEventHandler(logger: logger)
+            ]
         return channel.eventLoop.makeCompletedFuture {
             try channel.pipeline.syncOperations.configureHTTPServerPipeline(
-                withPipeliningAssistance: false, // HTTP is pipelined by NIOAsyncChannel
+                withPipeliningAssistance: false,  // HTTP is pipelined by NIOAsyncChannel
                 withErrorHandling: true,
-                withOutboundHeaderValidation: false // Swift HTTP Types are already doing this validation
+                withOutboundHeaderValidation: false  // Swift HTTP Types are already doing this validation
             )
             try channel.pipeline.syncOperations.addHandlers(childChannelHandlers)
             return try NIOAsyncChannel(
@@ -62,7 +66,10 @@ public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
     /// - Parameters:
     ///   - value: Object to process input/output on child channel
     ///   - logger: Logger to use while processing messages
-    public func handle(value asyncChannel: NIOCore.NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>, logger: Logging.Logger) async {
+    public func handle(
+        value asyncChannel: NIOCore.NIOAsyncChannel<HTTPRequestPart, HTTPResponsePart>,
+        logger: Logging.Logger
+    ) async {
         await handleHTTP(asyncChannel: asyncChannel, logger: logger)
     }
 

--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -18,7 +18,7 @@ import NIOCore
 import NIOHTTPTypes
 import NIOHTTPTypesHTTP1
 
-extension NIOAsyncChannel: ChildChannel {
+extension NIOAsyncChannel: ChildChannelValue {
     public var eventLoop: EventLoop { self.channel.eventLoop }
 }
 

--- a/Sources/HummingbirdCore/Server/ServerChildChannel.swift
+++ b/Sources/HummingbirdCore/Server/ServerChildChannel.swift
@@ -16,9 +16,12 @@ import Logging
 import NIOCore
 import ServiceLifecycle
 
+public protocol ChildChannel: Sendable {
+    var eventLoop: EventLoop { get }
+}
 /// HTTPServer child channel setup protocol
 public protocol ServerChildChannel: Sendable {
-    associatedtype Value: Sendable
+    associatedtype Value: ChildChannel
 
     /// Setup child channel
     /// - Parameters:

--- a/Sources/HummingbirdCore/Server/ServerChildChannel.swift
+++ b/Sources/HummingbirdCore/Server/ServerChildChannel.swift
@@ -16,12 +16,13 @@ import Logging
 import NIOCore
 import ServiceLifecycle
 
-public protocol ChildChannel: Sendable {
+public protocol ChildChannelValue: Sendable {
     var eventLoop: EventLoop { get }
 }
+
 /// HTTPServer child channel setup protocol
 public protocol ServerChildChannel: Sendable {
-    associatedtype Value: ChildChannel
+    associatedtype Value: ChildChannelValue
 
     /// Setup child channel
     /// - Parameters:

--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -61,7 +61,8 @@ public struct HTTP2UpgradeChannel: HTTPChannelHandler {
         self.sslContext = try NIOSSLContext(configuration: tlsConfiguration)
         self.additionalChannelHandlers = additionalChannelHandlers
         self.http1 = HTTP1Channel(
-            responder: responder, additionalChannelHandlers: additionalChannelHandlers)
+            responder: responder, additionalChannelHandlers: additionalChannelHandlers
+        )
     }
 
     /// Setup child channel for HTTP1 with HTTP2 upgrade
@@ -82,7 +83,7 @@ public struct HTTP2UpgradeChannel: HTTPChannelHandler {
                 http1Channel -> EventLoopFuture<HTTP1Channel.Value> in
                 let childChannelHandlers: [ChannelHandler] =
                     [HTTP1ToHTTPServerCodec(secure: false)] + self.additionalChannelHandlers() + [
-                        HTTPUserEventHandler(logger: logger)
+                        HTTPUserEventHandler(logger: logger),
                     ]
 
                 return http1Channel
@@ -100,7 +101,7 @@ public struct HTTP2UpgradeChannel: HTTPChannelHandler {
             } http2StreamInitializer: { http2ChildChannel -> EventLoopFuture<HTTP1Channel.Value> in
                 let childChannelHandlers: [ChannelHandler] =
                     self.additionalChannelHandlers() + [
-                        HTTPUserEventHandler(logger: logger)
+                        HTTPUserEventHandler(logger: logger),
                     ]
 
                 return http2ChildChannel

--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -25,7 +25,7 @@ import NIOSSL
 
 /// Child channel for processing HTTP1 with the option of upgrading to HTTP2
 public struct HTTP2UpgradeChannel: HTTPChannelHandler {
-    public struct Value: ChildChannel {
+    public struct Value: ChildChannelValue {
         let negotiatedResult:
             EventLoopFuture<
                 NIONegotiatedHTTPVersion<


### PR DESCRIPTION
- Add `EventLoopExecutor`
- Add `EventLoopExecutorMap` to map `EventLoop` to an `EventLoopExecutor`
- Require that `ServerChildChannel.Value` conforms to `ChildChannelValue` which returns an EventLoop
- Server then gets the `EventLoop` from the `ServerChildChannel.Value` and runs the Task using the associated `EventLoopExecutor`
 