### PR TITLE
Return 404 for loading a folder

### DIFF
--- a/Sources/Hummingbird/Middleware/FileMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/FileMiddleware.swift
@@ -42,8 +42,6 @@ public protocol FileMiddlewareFileAttributes {
 /// "modified-date", "eTag", "content-type", "cache-control" and "content-range" headers where
 /// they are relevant.
 public struct FileMiddleware<Context: BaseRequestContext, Provider: FileProvider>: RouterMiddleware where Provider.FileAttributes: FileMiddlewareFileAttributes {
-    struct IsDirectoryError: Error {}
-
     let cacheControl: CacheControl
     let searchForIndexHtml: Bool
     let fileProvider: Provider
@@ -152,7 +150,7 @@ extension FileMiddleware {
         // if file is a directory seach and `searchForIndexHtml` is set to true
         // then search for index.html in directory
         if attributes.isFolder {
-            guard self.searchForIndexHtml else { throw IsDirectoryError() }
+            guard self.searchForIndexHtml else { throw HTTPError(.notFound) }
             let indexPath = self.appendingPathComponent(path, "index.html")
             guard let indexAttributes = try await self.fileProvider.getAttributes(path: indexPath) else {
                 throw HTTPError(.notFound)

--- a/Tests/HummingbirdTests/FileMiddlewareTests.swift
+++ b/Tests/HummingbirdTests/FileMiddlewareTests.swift
@@ -316,6 +316,18 @@ class FileMiddlewareTests: XCTestCase {
         }
     }
 
+    func testFolder() async throws {
+        let router = Router()
+        router.middlewares.add(FileMiddleware(".", searchForIndexHtml: false))
+        let app = Application(responder: router.buildResponder())
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/", method: .get) { response in
+                XCTAssertEqual(response.status, .notFound)
+            }
+        }
+    }
+
     func testCustomFileProvider() async throws {
         // basic file provider
         struct MemoryFileProvider: FileProvider {


### PR DESCRIPTION
For some reason FileMiddleware was throwing a `IsDirectoryError` when we tried to get file attributes for a directory. This was then getting converted to an internal server error (500). When we should be returning a 404 for trying to load a folder.