### PR TITLE
Allow for LogRequestMiddleware to filter the headers it outputs

### DIFF
--- a/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
@@ -40,12 +40,12 @@ public struct LogRequestsMiddleware<Context: BaseRequestContext>: RouterMiddlewa
         self.includeHeaders = includeHeaders
         // only include headers in the redaction list if we are outputting them
         self.redactHeaders = switch includeHeaders {
-        case .all(let except):
+        case .all(let exceptions):
             // don't include headers in the except list
-            redactHeaders.filter { header in except.first { $0 == header } == nil }
+            redactHeaders.filter { header in !exceptions.contains(header) }
         case .some(let included):
             // only include headers in the included list
-            redactHeaders.filter { header in included.first { $0 == header } != nil }
+            redactHeaders.filter { header in included.contains(header) }
         case .none:
             []
         }

--- a/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
@@ -96,7 +96,7 @@ public struct LogRequestsMiddleware<Context: BaseRequestContext>: RouterMiddlewa
                     return (key: entry.canonicalName, value: value)
                 }
             }
-        return .init(headers) { "\($0),\($1)" }
+        return .init(headers) { "\($0), \($1)" }
     }
 
     func allHeaders(headers: HTTPFields, except: [HTTPField.Name]) -> [String: String] {
@@ -109,6 +109,6 @@ public struct LogRequestsMiddleware<Context: BaseRequestContext>: RouterMiddlewa
                     return (key: entry.name.canonicalName, value: entry.value)
                 }
             }
-        return .init(headers) { "\($0),\($1)" }
+        return .init(headers) { "\($0), \($1)" }
     }
 }

--- a/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
@@ -12,32 +12,56 @@
 //
 //===----------------------------------------------------------------------===//
 
+import HTTPTypes
 import Logging
 
 /// Middleware outputting to log for every call to server
 public struct LogRequestsMiddleware<Context: BaseRequestContext>: RouterMiddleware {
-    let logLevel: Logger.Level
-    let includeHeaders: Bool
+    public enum HeaderFilter: Sendable {
+        case none
+        case all
+        case some([HTTPField.Name])
+    }
 
-    public init(_ logLevel: Logger.Level, includeHeaders: Bool = false) {
+    let logLevel: Logger.Level
+    let includeHeaders: HeaderFilter
+
+    public init(_ logLevel: Logger.Level, includeHeaders: HeaderFilter = .none) {
         self.logLevel = logLevel
         self.includeHeaders = includeHeaders
     }
 
     public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
-        if self.includeHeaders {
-            context.logger.log(
-                level: self.logLevel,
-                "\(request.headers)",
-                metadata: ["hb_uri": .stringConvertible(request.uri), "hb_method": .string(request.method.rawValue)]
-            )
-        } else {
+        switch self.includeHeaders {
+        case .none:
             context.logger.log(
                 level: self.logLevel,
                 "",
                 metadata: ["hb_uri": .stringConvertible(request.uri), "hb_method": .string(request.method.rawValue)]
             )
+        case .all:
+            context.logger.log(
+                level: self.logLevel,
+                "\(request.headers)",
+                metadata: ["hb_uri": .stringConvertible(request.uri), "hb_method": .string(request.method.rawValue)]
+            )
+        case .some(let filter):
+            context.logger.log(
+                level: self.logLevel,
+                "\(self.filterHeaders(headers: request.headers, filter: filter))",
+                metadata: ["hb_uri": .stringConvertible(request.uri), "hb_method": .string(request.method.rawValue)]
+            )
         }
         return try await next(request, context)
+    }
+
+    func filterHeaders(headers: HTTPFields, filter: [HTTPField.Name]) -> String {
+        var filteredHeaders: [(String, String)] = []
+        for entry in filter {
+            if let value = headers[entry] {
+                filteredHeaders.append((entry.canonicalName, value))
+            }
+        }
+        return "[\(filteredHeaders.map { "\"\($0)\":\"\($1)\"" }.joined(separator: ", "))]"
     }
 }

--- a/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/LogRequestMiddleware.swift
@@ -102,7 +102,7 @@ public struct LogRequestsMiddleware<Context: BaseRequestContext>: RouterMiddlewa
     func allHeaders(headers: HTTPFields, except: [HTTPField.Name]) -> [String: String] {
         let headers = headers
             .compactMap { entry -> (key: String, value: String)? in
-                guard except.first(where: { entry.name == $0 }) == nil else { return nil }
+                if except.contains(where: { entry.name == $0 }) { return nil }
                 if self.redactHeaders.contains(entry.name) {
                     return (key: entry.name.canonicalName, value: "***")
                 } else {

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -287,7 +287,7 @@ final class MiddlewareTests: XCTestCase {
                 body: .init(string: "{}")
             ) { _ in
                 let logEntries = logAccumalator.filter { $0.metadata?["hb_uri"]?.description == "/some" }
-                XCTAssertEqual(logEntries.first?.metadata?["hb_headers"]?.description, #"{"content-type":"application/json"}"#)
+                XCTAssertEqual(logEntries.first?.metadata?["hb_headers"], .stringConvertible(["content-type": "application/json"]))
             }
             try await client.execute(
                 uri: "/none",
@@ -305,8 +305,10 @@ final class MiddlewareTests: XCTestCase {
                 body: .init(string: "{}")
             ) { _ in
                 let logEntries = logAccumalator.filter { $0.metadata?["hb_uri"]?.description == "/all" }
-                let reportedHeadersString = try XCTUnwrap(logEntries.first?.metadata?["hb_headers"]?.description)
-                let reportedHeaders = try JSONDecoder().decode([String: String].self, from: Data(reportedHeadersString.utf8))
+                guard case .stringConvertible(let headers) = logEntries.first?.metadata?["hb_headers"] else {
+                    fatalError("Should never get here")
+                }
+                let reportedHeaders = try XCTUnwrap(headers as? [String: String])
                 XCTAssertEqual(reportedHeaders["content-type"], "application/json")
                 XCTAssertEqual(reportedHeaders["content-length"], "2")
                 XCTAssertNil(reportedHeaders["connection"])
@@ -337,7 +339,7 @@ final class MiddlewareTests: XCTestCase {
                 body: .init(string: "{}")
             ) { _ in
                 let logEntries = logAccumalator.filter { $0.metadata?["hb_uri"]?.description == "/some" }
-                XCTAssertEqual(logEntries.first?.metadata?["hb_headers"]?.description, #"{"authorization":"***"}"#)
+                XCTAssertEqual(logEntries.first?.metadata?["hb_headers"], .stringConvertible(["authorization": "***"]))
             }
             try await client.execute(
                 uri: "/all",
@@ -346,8 +348,10 @@ final class MiddlewareTests: XCTestCase {
                 body: .init(string: "{}")
             ) { _ in
                 let logEntries = logAccumalator.filter { $0.metadata?["hb_uri"]?.description == "/all" }
-                let reportedHeadersString = try XCTUnwrap(logEntries.first?.metadata?["hb_headers"]?.description)
-                let reportedHeaders = try JSONDecoder().decode([String: String].self, from: Data(reportedHeadersString.utf8))
+                guard case .stringConvertible(let headers) = logEntries.first?.metadata?["hb_headers"] else {
+                    fatalError("Should never get here")
+                }
+                let reportedHeaders = try XCTUnwrap(headers as? [String: String])
                 XCTAssertEqual(reportedHeaders["authorization"], "***")
                 XCTAssertEqual(reportedHeaders["content-length"], "2")
             }

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -14,6 +14,8 @@
 
 @testable import Hummingbird
 import HummingbirdTesting
+import Logging
+import NIOConcurrencyHelpers
 import XCTest
 
 final class MiddlewareTests: XCTestCase {
@@ -231,21 +233,148 @@ final class MiddlewareTests: XCTestCase {
         }
     }
 
-    func testRouteLoggingMiddleware() async throws {
+    func testLogRequestMiddleware() async throws {
+        let logAccumalator = TestLogHandler.LogAccumalator()
         let router = Router()
-        router.middlewares.add(LogRequestsMiddleware(.info, includeHeaders: .some([.contentType])))
-        router.put("/hello") { _, _ -> String in
-            throw HTTPError(.badRequest)
+        router.middlewares.add(LogRequestsMiddleware(.info))
+        router.get("test") { _, _ in
+            return HTTPResponse.Status.ok
         }
-        let app = Application(responder: router.buildResponder())
+        let app = Application(
+            responder: router.buildResponder(),
+            logger: Logger(label: "TestLogging") { label in
+                TestLogHandler(label, accumalator: logAccumalator)
+            }
+        )
         try await app.test(.router) { client in
             try await client.execute(
-                uri: "/hello",
-                method: .put,
+                uri: "/test",
+                method: .get,
                 headers: [.contentType: "application/json"],
                 body: .init(string: "{}")
             ) { _ in
+                let logs = logAccumalator.filter { $0.metadata?["hb_uri"]?.description == "/test" }
+                let firstLog = try XCTUnwrap(logs.first)
+                XCTAssertEqual(firstLog.metadata?["hb_method"]?.description, "GET")
+                XCTAssertNotNil(firstLog.metadata?["hb_id"])
             }
         }
     }
+
+    func testLogRequestMiddlewareHeaderFiltering() async throws {
+        let logAccumalator = TestLogHandler.LogAccumalator()
+        let router = Router()
+        router.group()
+            .add(middleware: LogRequestsMiddleware(.info, includeHeaders: .all))
+            .get("all") { _, _ in return HTTPResponse.Status.ok }
+        router.group()
+            .add(middleware: LogRequestsMiddleware(.info, includeHeaders: .none))
+            .get("none") { _, _ in return HTTPResponse.Status.ok }
+        router.group()
+            .add(middleware: LogRequestsMiddleware(.info, includeHeaders: [.contentType]))
+            .get("some") { _, _ in return HTTPResponse.Status.ok }
+        let app = Application(
+            responder: router.buildResponder(),
+            logger: Logger(label: "TestLogging") { label in
+                TestLogHandler(label, accumalator: logAccumalator)
+            }
+        )
+        try await app.test(.live) { client in
+            try await client.execute(
+                uri: "/some",
+                method: .get,
+                headers: [.contentType: "application/json"],
+                body: .init(string: "{}")
+            ) { _ in
+                let logEntries = logAccumalator.filter { $0.metadata?["hb_uri"]?.description == "/some" }
+                XCTAssertEqual(logEntries.first?.metadata?["hb_headers"]?.description, #"{"content-type":"application/json"}"#)
+            }
+            try await client.execute(
+                uri: "/none",
+                method: .get,
+                headers: [.contentType: "application/json"],
+                body: .init(string: "{}")
+            ) { _ in
+                let logEntries = logAccumalator.filter { $0.metadata?["hb_uri"]?.description == "/none" }
+                XCTAssertNil(logEntries.first?.metadata?["hb_headers"])
+            }
+            try await client.execute(
+                uri: "/all",
+                method: .get,
+                headers: [.contentType: "application/json"],
+                body: .init(string: "{}")
+            ) { _ in
+                let logEntries = logAccumalator.filter { $0.metadata?["hb_uri"]?.description == "/all" }
+                let reportedHeadersString = try XCTUnwrap(logEntries.first?.metadata?["hb_headers"]?.description)
+                let reportedHeaders = try JSONDecoder().decode([String: String].self, from: Data(reportedHeadersString.utf8))
+                XCTAssertEqual(reportedHeaders["content-type"], "application/json")
+                XCTAssertEqual(reportedHeaders["content-length"], "2")
+            }
+        }
+    }
+}
+
+/// LogHandler used in tests. Stores all log entries in provided `LogAccumalator``
+struct TestLogHandler: LogHandler {
+    struct LogEntry {
+        let level: Logger.Level
+        let message: Logger.Message
+        let metadata: Logger.Metadata?
+    }
+
+    /// Used to store Logs
+    final class LogAccumalator {
+        var logEntries: NIOLockedValueBox<[LogEntry]>
+
+        init() {
+            self.logEntries = .init([])
+        }
+
+        func addEntry(_ entry: LogEntry) {
+            self.logEntries.withLockedValue { value in
+                value.append(entry)
+            }
+        }
+
+        func filter(_ isIncluded: (LogEntry) -> Bool) -> [LogEntry] {
+            self.logEntries.withLockedValue { logs in
+                logs.filter(isIncluded)
+            }
+        }
+    }
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get {
+            self.metadata[key]
+        }
+        set(newValue) {
+            self.metadata[key] = newValue
+        }
+    }
+
+    init(_: String, accumalator: LogAccumalator) {
+        self.logLevel = .info
+        self.metadata = [:]
+        self.accumalator = accumalator
+    }
+
+    public func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata explicitMetadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        var metadata = self.metadata
+        if let explicitMetadata, !explicitMetadata.isEmpty {
+            metadata.merge(explicitMetadata, uniquingKeysWith: { _, explicit in explicit })
+        }
+        self.accumalator.addEntry(.init(level: level, message: message, metadata: metadata))
+    }
+
+    var logLevel: Logger.Level
+    var metadata: Logger.Metadata
+    let accumalator: LogAccumalator
 }

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -233,13 +233,18 @@ final class MiddlewareTests: XCTestCase {
 
     func testRouteLoggingMiddleware() async throws {
         let router = Router()
-        router.middlewares.add(LogRequestsMiddleware(.debug))
+        router.middlewares.add(LogRequestsMiddleware(.info, includeHeaders: .some([.contentType])))
         router.put("/hello") { _, _ -> String in
             throw HTTPError(.badRequest)
         }
         let app = Application(responder: router.buildResponder())
         try await app.test(.router) { client in
-            try await client.execute(uri: "/hello", method: .put) { _ in
+            try await client.execute(
+                uri: "/hello",
+                method: .put,
+                headers: [.contentType: "application/json"],
+                body: .init(string: "{}")
+            ) { _ in
             }
         }
     }


### PR DESCRIPTION
Instead of displaying all the headers, only display ones you care about
```swift
router.middlewares.add(LogRequestMiddleware(.debug, includesHeaders: .some([.contentType, .contentLength]))
```
Options are `.none`, `.all` or `.some([HTTPField.Name])`