### PR TITLE
Allow specialization of the RouterResponder

### DIFF
--- a/Benchmarks/Benchmarks/Router/RouterBenchmarks.swift
+++ b/Benchmarks/Benchmarks/Router/RouterBenchmarks.swift
@@ -15,11 +15,11 @@
 import Benchmark
 import HTTPTypes
 import Hummingbird
-import NIOEmbedded
-import NIOHTTPTypes
 import HummingbirdCore
 import Logging
 import NIOCore
+import NIOEmbedded
+import NIOHTTPTypes
 import NIOPosix
 
 /// Implementation of a basic request context that supports everything the Hummingbird library needs

--- a/Benchmarks/Benchmarks/Router/RouterBenchmarks.swift
+++ b/Benchmarks/Benchmarks/Router/RouterBenchmarks.swift
@@ -17,7 +17,7 @@ import HTTPTypes
 import Hummingbird
 import NIOEmbedded
 import NIOHTTPTypes
-@_spi(Internal) import HummingbirdCore
+import HummingbirdCore
 import Logging
 import NIOCore
 import NIOPosix

--- a/Sources/Hummingbird/Router/EndpointResponder.swift
+++ b/Sources/Hummingbird/Router/EndpointResponder.swift
@@ -15,13 +15,15 @@
 import HTTPTypes
 
 /// Stores endpoint responders for each HTTP method
+@usableFromInline
 struct EndpointResponders<Context: BaseRequestContext>: Sendable {
     init(path: String) {
         self.path = path
         self.methods = [:]
     }
 
-    public func getResponder(for method: HTTPRequest.Method) -> (any HTTPResponder<Context>)? {
+    @inlinable
+    public func getResponder(for method: __shared HTTPRequest.Method) -> (any HTTPResponder<Context>)? {
         return self.methods[method]
     }
 
@@ -41,6 +43,9 @@ struct EndpointResponders<Context: BaseRequestContext>: Sendable {
         }
     }
 
+    @usableFromInline
     var methods: [HTTPRequest.Method: any HTTPResponder<Context>]
+
+    @usableFromInline
     var path: String
 }

--- a/Sources/Hummingbird/Router/RouterResponder.swift
+++ b/Sources/Hummingbird/Router/RouterResponder.swift
@@ -15,8 +15,13 @@
 import NIOCore
 
 public struct RouterResponder<Context: BaseRequestContext>: HTTPResponder {
+    @usableFromInline
     let trie: RouterTrie<EndpointResponders<Context>>
+
+    @usableFromInline
     let notFoundResponder: any HTTPResponder<Context>
+
+    @usableFromInline
     let options: RouterOptions
 
     init(
@@ -33,6 +38,7 @@ public struct RouterResponder<Context: BaseRequestContext>: HTTPResponder {
     /// Respond to request by calling correct handler
     /// - Parameter request: HTTP request
     /// - Returns: EventLoopFuture that will be fulfilled with the Response
+    @inlinable
     public func respond(to request: Request, context: Context) async throws -> Response {
         let path: String
         if self.options.contains(.caseInsensitive) {

--- a/Sources/Hummingbird/Router/Trie/RouterTrie.swift
+++ b/Sources/Hummingbird/Router/Trie/RouterTrie.swift
@@ -56,15 +56,15 @@ struct Trie: Sendable {
     init() {}
 }
 
-@_spi(Internal) public final class RouterTrie<Value: Sendable>: Sendable {
+@usableFromInline
+internal final class RouterTrie<Value: Sendable>: Sendable {
     @usableFromInline
     let trie: Trie
 
     @usableFromInline
     let values: [Value?]
 
-    @inlinable
-    @_spi(Internal) public init(base: RouterPathTrieBuilder<Value>) {
+    internal init(base: RouterPathTrieBuilder<Value>) {
         var trie = Trie()
         var values: [Value?] = []
 

--- a/Sources/Hummingbird/Router/Trie/RouterTrie.swift
+++ b/Sources/Hummingbird/Router/Trie/RouterTrie.swift
@@ -64,8 +64,7 @@ public final class RouterTrie<Value: Sendable>: Sendable {
     @usableFromInline
     let values: [Value?]
 
-    @_documentation(visibility: internal)
-    public init(base: RouterPathTrieBuilder<Value>) {
+    @_spi(Internal) public init(base: RouterPathTrieBuilder<Value>) {
         var trie = Trie()
         var values: [Value?] = []
 

--- a/Sources/Hummingbird/Router/Trie/RouterTrie.swift
+++ b/Sources/Hummingbird/Router/Trie/RouterTrie.swift
@@ -56,15 +56,16 @@ struct Trie: Sendable {
     init() {}
 }
 
-@usableFromInline
-internal final class RouterTrie<Value: Sendable>: Sendable {
+@_documentation(visibility: internal)
+public final class RouterTrie<Value: Sendable>: Sendable {
     @usableFromInline
     let trie: Trie
 
     @usableFromInline
     let values: [Value?]
 
-    internal init(base: RouterPathTrieBuilder<Value>) {
+    @_documentation(visibility: internal)
+    public init(base: RouterPathTrieBuilder<Value>) {
         var trie = Trie()
         var values: [Value?] = []
 

--- a/Sources/Hummingbird/Router/Trie/Trie+resolve.swift
+++ b/Sources/Hummingbird/Router/Trie/Trie+resolve.swift
@@ -16,8 +16,8 @@ import NIOCore
 
 extension RouterTrie {
     /// Resolve a path to a `Value` if available
-    @usableFromInline
-    internal func resolve(_ path: String) -> (value: Value, parameters: Parameters)? {
+    @inlinable
+    public func resolve(_ path: String) -> (value: Value, parameters: Parameters)? {
         let pathComponents = path.split(separator: "/", omittingEmptySubsequences: true)
         var pathComponentsIterator = pathComponents.makeIterator()
         var parameters = Parameters()

--- a/Sources/Hummingbird/Router/Trie/Trie+resolve.swift
+++ b/Sources/Hummingbird/Router/Trie/Trie+resolve.swift
@@ -16,8 +16,8 @@ import NIOCore
 
 extension RouterTrie {
     /// Resolve a path to a `Value` if available
-    @inlinable
-    @_spi(Internal) public func resolve(_ path: String) -> (value: Value, parameters: Parameters)? {
+    @usableFromInline
+    internal func resolve(_ path: String) -> (value: Value, parameters: Parameters)? {
         let pathComponents = path.split(separator: "/", omittingEmptySubsequences: true)
         var pathComponentsIterator = pathComponents.makeIterator()
         var parameters = Parameters()

--- a/Sources/Hummingbird/Router/Trie/Trie+serialize.swift
+++ b/Sources/Hummingbird/Router/Trie/Trie+serialize.swift
@@ -15,7 +15,6 @@
 import NIOCore
 
 extension RouterTrie {
-    @inlinable
     static func serialize(
         _ node: RouterPathTrieBuilder<Value>.Node,
         trie: inout Trie,
@@ -82,7 +81,6 @@ extension RouterTrie {
         trie.nodes[nodeIndex].nextSiblingNodeIndex = trie.nodes.count
     }
 
-    @inlinable
     static func serializeChildren(
         of node: RouterPathTrieBuilder<Value>.Node,
         trie: inout Trie,
@@ -95,7 +93,6 @@ extension RouterTrie {
         }
     }
 
-    @inlinable
     internal static func highestPriorityFirst(lhs: RouterPathTrieBuilder<Value>.Node, rhs: RouterPathTrieBuilder<Value>.Node) -> Bool {
         lhs.key.priority > rhs.key.priority
     }

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -15,10 +15,12 @@
 import HummingbirdCore
 
 /// URI Path Trie Builder
-@_spi(Internal) public struct RouterPathTrieBuilder<Value: Sendable> {
+@_documentation(visibility: internal)
+public struct RouterPathTrieBuilder<Value: Sendable> {
     @usableFromInline
     var root: Node
 
+    @_documentation(visibility: internal)
     public init() {
         self.root = Node(key: .null, output: nil)
     }
@@ -50,7 +52,8 @@ import HummingbirdCore
     }
 
     /// Trie Node. Each node represents one component of a URI path
-    @_spi(Internal) public final class Node {
+    @_documentation(visibility: internal)
+    public final class Node {
         @usableFromInline
         let key: RouterPath.Element
 

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -19,7 +19,7 @@ import HummingbirdCore
     @usableFromInline
     var root: Node
 
-    public init() {
+    @_spi(Internal) public init() {
         self.root = Node(key: .null, output: nil)
     }
 
@@ -28,7 +28,7 @@ import HummingbirdCore
     ///   - entry: Path for entry
     ///   - value: Value to add to this path if one does not exist already
     ///   - onAdd: How to edit the value at this path
-    public func addEntry(_ entry: RouterPath, value: @autoclosure () -> Value, onAdd: (Node) -> Void = { _ in }) {
+    @_spi(Internal) public func addEntry(_ entry: RouterPath, value: @autoclosure () -> Value, onAdd: (Node) -> Void = { _ in }) {
         var node = self.root
         for key in entry {
             node = node.addChild(key: key, output: nil)

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -15,12 +15,10 @@
 import HummingbirdCore
 
 /// URI Path Trie Builder
-@_documentation(visibility: internal)
-public struct RouterPathTrieBuilder<Value: Sendable> {
+@_spi(Internal) public struct RouterPathTrieBuilder<Value: Sendable> {
     @usableFromInline
     var root: Node
 
-    @_documentation(visibility: internal)
     public init() {
         self.root = Node(key: .null, output: nil)
     }
@@ -43,7 +41,7 @@ public struct RouterPathTrieBuilder<Value: Sendable> {
         }
     }
 
-    internal func build() -> RouterTrie<Value> {
+    @_spi(Internal) public func build() -> RouterTrie<Value> {
         .init(base: self)
     }
 
@@ -52,15 +50,11 @@ public struct RouterPathTrieBuilder<Value: Sendable> {
     }
 
     /// Trie Node. Each node represents one component of a URI path
-    @_documentation(visibility: internal)
-    public final class Node {
-        @usableFromInline
+    @_spi(Internal) public final class Node {
         let key: RouterPath.Element
 
-        @usableFromInline
         var children: [Node]
 
-        @usableFromInline
         var value: Value?
 
         init(key: RouterPath.Element, output: Value?) {

--- a/Sources/Hummingbird/Router/TrieRouter.swift
+++ b/Sources/Hummingbird/Router/TrieRouter.swift
@@ -41,7 +41,7 @@ import HummingbirdCore
         }
     }
 
-    @_spi(Internal) public func build() -> RouterTrie<Value> {
+    internal func build() -> RouterTrie<Value> {
         .init(base: self)
     }
 

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import Hummingbird
+@testable @_spi(Internal) import Hummingbird
 import XCTest
 
 class TrieRouterTests: XCTestCase {

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(Internal) import Hummingbird
+@testable import Hummingbird
 import XCTest
 
 class TrieRouterTests: XCTestCase {


### PR DESCRIPTION
I've ran the `PerformanceTest` codebase two times, before and after this PR. Note that the PerformanceTest only uses 4 cores for HB2 - so that we have resource budget for regular OS use and the `wrk` client benckmark suite.

Since I made a lot of symbols inlinable, I had to make them public or internal. Public with SPI does not work with inlinable. We'll need to decide on a public API surface if we want benchmarks.

TODOs:
- [ ] Fix the router benchmarks in the Benchmarks folder.

## Before

```
Running 15s test @ http://localhost:8080
  8 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.78ms    1.35ms  47.83ms   91.64%
    Req/Sec     9.80k     1.47k   26.85k    89.11%
  1173503 requests in 15.10s, 166.75MB read
Requests/sec:  77697.81
Transfer/sec:     11.04MB
```

## After

```
Running 15s test @ http://localhost:8080
  8 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.69ms    1.37ms  50.63ms   93.09%
    Req/Sec    10.28k   694.90    13.73k    76.45%
  1233179 requests in 15.10s, 175.23MB read
Requests/sec:  81659.66
Transfer/sec:     11.60MB
```