### PR TITLE
Remove an unnecessary allocation from the trie router benchmark

### DIFF
--- a/Benchmarks/Benchmarks/Router/TrieRouterBenchmarks.swift
+++ b/Benchmarks/Benchmarks/Router/TrieRouterBenchmarks.swift
@@ -28,7 +28,9 @@ func trieRouterBenchmarks() {
         benchmark.startMeasurement()
 
         for _ in benchmark.scaledIterations {
-            blackHole(testValues.map { trie.resolve($0) })
+            for testValue in testValues {
+                blackHole(trie.resolve(testValue))
+            }
         }
     } setup: {
         let trieBuilder = RouterPathTrieBuilder<String>()
@@ -53,7 +55,9 @@ func trieRouterBenchmarks() {
         benchmark.startMeasurement()
 
         for _ in benchmark.scaledIterations {
-            blackHole(testValues.map { trie2.resolve($0) })
+            for testValue in testValues {
+                blackHole(trie2.resolve(testValue))
+            }
         }
     } setup: {
         let trieBuilder = RouterPathTrieBuilder<String>()
@@ -73,7 +77,9 @@ func trieRouterBenchmarks() {
         benchmark.startMeasurement()
 
         for _ in benchmark.scaledIterations {
-            blackHole(testValues.map { trie3.resolve($0) })
+            for testValue in testValues {
+                blackHole(trie3.resolve(testValue))
+            }
         }
     } setup: {
         let trieBuilder = RouterPathTrieBuilder<String>()


### PR DESCRIPTION
The new baseline:

```
TrieRouter:LongPaths
╒═══════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                    │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *          │      15 │      15 │      15 │      15 │      15 │      15 │      15 │     319 │
├───────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Throughput (# / s) (K)    │     330 │     328 │     325 │     318 │     314 │     305 │     292 │     319 │
├───────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (total CPU) (ns) *   │    3049 │    3066 │    3095 │    3152 │    3199 │    3273 │    3358 │     319 │
╘═══════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

TrieRouter:Parameters
╒═══════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                    │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *          │      27 │      27 │      27 │      27 │      27 │      27 │      27 │     217 │
├───────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Throughput (# / s) (K)    │     224 │     221 │     220 │     217 │     214 │     209 │     201 │     217 │
├───────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (total CPU) (ns) *   │    4483 │    4534 │    4563 │    4620 │    4682 │    4755 │    4964 │     217 │
╘═══════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛

TrieRouter:Routing
╒═══════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                    │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞═══════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ Malloc (total) *          │      23 │      23 │      23 │      23 │      23 │      23 │      23 │     288 │
├───────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Throughput (# / s) (K)    │     298 │     296 │     293 │     288 │     284 │     275 │     265 │     288 │
├───────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (total CPU) (ns) *   │    3372 │    3402 │    3426 │    3478 │    3535 │    3664 │    3719 │     288 │
╘═══════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```