### PR TITLE
Add requirement that channel is accessible in ServerChildChannel.Value

### DIFF
--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -69,3 +69,10 @@ public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
     public let responder: @Sendable (Request, Channel) async throws -> Response
     let additionalChannelHandlers: @Sendable () -> [any RemovableChannelHandler]
 }
+
+/// Extend NIOAsyncChannel to ServerChildChannelValue so it can be used in a ServerChildChannel
+#if hasFeature(RetroactiveAttribute)
+extension NIOAsyncChannel: @retroactive ServerChildChannelValue {}
+#else
+extension NIOAsyncChannel: ServerChildChannelValue {}
+#endif

--- a/Sources/HummingbirdCore/Server/ServerChildChannel.swift
+++ b/Sources/HummingbirdCore/Server/ServerChildChannel.swift
@@ -16,9 +16,15 @@ import Logging
 import NIOCore
 import ServiceLifecycle
 
-/// HTTPServer child channel setup protocol
+/// Protocol for typed server child channel
+public protocol ServerChildChannelValue: Sendable {
+    /// Child channel that spawned child channel
+    var channel: Channel { get }
+}
+
+/// Generic server child channel setup protocol
 public protocol ServerChildChannel: Sendable {
-    associatedtype Value: Sendable
+    associatedtype Value: ServerChildChannelValue
 
     /// Setup child channel
     /// - Parameters:

--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -26,7 +26,7 @@ import NIOSSL
 /// Child channel for processing HTTP1 with the option of upgrading to HTTP2
 public struct HTTP2UpgradeChannel: HTTPChannelHandler {
     public struct Value: ServerChildChannelValue {
-        let negociatedHTTPVersion: EventLoopFuture<NIONegotiatedHTTPVersion<HTTP1Channel.Value, (NIOAsyncChannel<HTTP2Frame, HTTP2Frame>, NIOHTTP2Handler.AsyncStreamMultiplexer<HTTP1Channel.Value>)>>
+        let negotiatedHTTPVersion: EventLoopFuture<NIONegotiatedHTTPVersion<HTTP1Channel.Value, (NIOAsyncChannel<HTTP2Frame, HTTP2Frame>, NIOHTTP2Handler.AsyncStreamMultiplexer<HTTP1Channel.Value>)>>
         public let channel: Channel
     }
 

--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -25,7 +25,10 @@ import NIOSSL
 
 /// Child channel for processing HTTP1 with the option of upgrading to HTTP2
 public struct HTTP2UpgradeChannel: HTTPChannelHandler {
-    public typealias Value = EventLoopFuture<NIONegotiatedHTTPVersion<HTTP1Channel.Value, (NIOAsyncChannel<HTTP2Frame, HTTP2Frame>, NIOHTTP2Handler.AsyncStreamMultiplexer<HTTP1Channel.Value>)>>
+    public struct Value: ServerChildChannelValue {
+        let negociatedHTTPVersion: EventLoopFuture<NIONegotiatedHTTPVersion<HTTP1Channel.Value, (NIOAsyncChannel<HTTP2Frame, HTTP2Frame>, NIOHTTP2Handler.AsyncStreamMultiplexer<HTTP1Channel.Value>)>>
+        public let channel: Channel
+    }
 
     private let sslContext: NIOSSLContext
     private let http1: HTTP1Channel
@@ -91,6 +94,8 @@ public struct HTTP2UpgradeChannel: HTTPChannelHandler {
                 }.flatMapThrowing {
                     try HTTP1Channel.Value(wrappingChannelSynchronously: http2ChildChannel)
                 }
+        }.map {
+            .init(negociatedHTTPVersion: $0, channel: channel)
         }
     }
 
@@ -100,7 +105,7 @@ public struct HTTP2UpgradeChannel: HTTPChannelHandler {
     ///   - logger: Logger to use while processing messages
     public func handle(value: Value, logger: Logger) async {
         do {
-            let channel = try await value.get()
+            let channel = try await value.negociatedHTTPVersion.get()
             switch channel {
             case .http1_1(let http1):
                 await handleHTTP(asyncChannel: http1, logger: logger)

--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -95,7 +95,7 @@ public struct HTTP2UpgradeChannel: HTTPChannelHandler {
                     try HTTP1Channel.Value(wrappingChannelSynchronously: http2ChildChannel)
                 }
         }.map {
-            .init(negociatedHTTPVersion: $0, channel: channel)
+            .init(negotiatedHTTPVersion: $0, channel: channel)
         }
     }
 

--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -105,7 +105,7 @@ public struct HTTP2UpgradeChannel: HTTPChannelHandler {
     ///   - logger: Logger to use while processing messages
     public func handle(value: Value, logger: Logger) async {
         do {
-            let channel = try await value.negociatedHTTPVersion.get()
+            let channel = try await value.negotiatedHTTPVersion.get()
             switch channel {
             case .http1_1(let http1):
                 await handleHTTP(asyncChannel: http1, logger: logger)


### PR DESCRIPTION
This adds an additional requirement on the Value passed around by a ServerChildChannel that the Channel that spawned the child channel is accessible from the Value. 

This PR doesn't add any additional functionality. It is here to prepare for the situation where we need the EventLoop for the Task executor.