### PR TITLE
feat: make LocalFileSystem.init public

### DIFF
--- a/Sources/Hummingbird/Files/LocalFileSystem.swift
+++ b/Sources/Hummingbird/Files/LocalFileSystem.swift
@@ -43,7 +43,7 @@ public struct LocalFileSystem: FileProvider {
     ///   - rootFolder: Root folder to serve files from
     ///   - threadPool: Thread pool used when loading files
     ///   - logger: Logger to output root folder information
-    init(rootFolder: String, threadPool: NIOThreadPool, logger: Logger) {
+    public init(rootFolder: String, threadPool: NIOThreadPool, logger: Logger) {
         if rootFolder.last != "/" {
             self.rootFolder = "\(rootFolder)/"
         } else {


### PR DESCRIPTION
As mentioned in the discord, I would like to use `LocalFileSystem` for a implementing something similar to `FileMiddleware`, but the initializer is currently internal. 

`LocalFileSystem` itself and all of its methods are public.