### PR TITLE
API Cleanup: HTTPChannelBuilder should build server not channel

### DIFF
--- a/Sources/Hummingbird/Configuration.swift
+++ b/Sources/Hummingbird/Configuration.swift
@@ -26,7 +26,7 @@ public struct ApplicationConfiguration: Sendable {
     // MARK: Member variables
 
     /// Bind address for server
-    public var address: Address
+    public var address: BindAddress
     /// Server name to return in "server" header
     public var serverName: String?
     /// Defines the maximum length for the queue of pending connections
@@ -49,7 +49,7 @@ public struct ApplicationConfiguration: Sendable {
     ///         the client may receive an error with an indication of ECONNREFUSE
     ///   - reuseAddress: Allows socket to be bound to an address that is already in use.
     public init(
-        address: Address = .hostname(),
+        address: BindAddress = .hostname(),
         serverName: String? = nil,
         backlog: Int = 256,
         reuseAddress: Bool = true
@@ -72,7 +72,7 @@ public struct ApplicationConfiguration: Sendable {
     ///   - reuseAddress: Allows socket to be bound to an address that is already in use.
     ///   - tlsOptions: TLS options for when you are using NIOTransportServices
     public init(
-        address: Address = .hostname(),
+        address: BindAddress = .hostname(),
         serverName: String? = nil,
         reuseAddress: Bool = true,
         tlsOptions: TSTLSOptions
@@ -88,7 +88,7 @@ public struct ApplicationConfiguration: Sendable {
 
     /// Create new configuration struct with updated values
     public func with(
-        address: Address? = nil,
+        address: BindAddress? = nil,
         serverName: String? = nil,
         backlog: Int? = nil,
         reuseAddress: Bool? = nil

--- a/Sources/Hummingbird/Exports.swift
+++ b/Sources/Hummingbird/Exports.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_exported import struct HummingbirdCore.Address
+@_exported import struct HummingbirdCore.BindAddress
 @_exported import struct HummingbirdCore.HTTPError
 @_exported import protocol HummingbirdCore.HTTPResponseError
 @_exported import struct HummingbirdCore.Request

--- a/Sources/HummingbirdCore/Server/BindAddress.swift
+++ b/Sources/HummingbirdCore/Server/BindAddress.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Address to bind server to
-public struct Address: Sendable, Equatable {
+public struct BindAddress: Sendable, Equatable {
     enum _Internal: Equatable {
         case hostname(_ host: String = "127.0.0.1", port: Int = 8080)
         case unixDomainSocket(path: String)

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPServerBuilder.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPServerBuilder.swift
@@ -43,7 +43,7 @@ public struct HTTPServerBuilder: Sendable {
         eventLoopGroup: EventLoopGroup,
         logger: Logger,
         responder: @escaping HTTPChannelHandler.Responder,
-        onServerRunning: (@Sendable (Channel) async -> Void)? = { _ in }
+        onServerRunning: (@Sendable (Channel) async -> Void)? = nil
     ) throws -> Service {
         let childChannel = try buildChildChannel(responder)
         return childChannel.server(configuration: configuration, onServerRunning: onServerRunning, eventLoopGroup: eventLoopGroup, logger: logger)

--- a/Sources/HummingbirdCore/Server/Server.swift
+++ b/Sources/HummingbirdCore/Server/Server.swift
@@ -77,7 +77,7 @@ public actor Server<ChildChannel: ServerChildChannel>: Service {
     public init(
         childChannelSetup: ChildChannel,
         configuration: ServerConfiguration,
-        onServerRunning: (@Sendable (Channel) async -> Void)? = { _ in },
+        onServerRunning: (@Sendable (Channel) async -> Void)? = nil,
         eventLoopGroup: EventLoopGroup,
         logger: Logger
     ) {

--- a/Sources/HummingbirdCore/Server/ServerChildChannel.swift
+++ b/Sources/HummingbirdCore/Server/ServerChildChannel.swift
@@ -51,7 +51,7 @@ extension ServerChildChannel {
     /// - Returns: Server Service
     public func server(
         configuration: ServerConfiguration,
-        onServerRunning: (@Sendable (Channel) async -> Void)? = { _ in },
+        onServerRunning: (@Sendable (Channel) async -> Void)? = nil,
         eventLoopGroup: EventLoopGroup,
         logger: Logger
     ) -> Service {

--- a/Sources/HummingbirdCore/Server/ServerConfiguration.swift
+++ b/Sources/HummingbirdCore/Server/ServerConfiguration.swift
@@ -17,7 +17,7 @@ import NIOCore
 /// HTTP server configuration
 public struct ServerConfiguration: Sendable {
     /// Bind address for server
-    public let address: Address
+    public let address: BindAddress
     /// Server name to return in "server" header
     public let serverName: String?
     /// Defines the maximum length for the queue of pending connections
@@ -37,7 +37,7 @@ public struct ServerConfiguration: Sendable {
     ///         the client may receive an error with an indication of ECONNREFUSE
     ///   - reuseAddress: Allows socket to be bound to an address that is already in use.
     public init(
-        address: Address = .hostname(),
+        address: BindAddress = .hostname(),
         serverName: String? = nil,
         backlog: Int = 256,
         reuseAddress: Bool = true
@@ -61,7 +61,7 @@ public struct ServerConfiguration: Sendable {
     ///   - tlsOptions: TLS options for when you are using NIOTransportServices
     #if canImport(Network)
     public init(
-        address: Address = .hostname(),
+        address: BindAddress = .hostname(),
         serverName: String? = nil,
         backlog: Int = 256,
         reuseAddress: Bool = true,

--- a/Sources/HummingbirdHTTP2/HTTPServerBuilder+http2.swift
+++ b/Sources/HummingbirdHTTP2/HTTPServerBuilder+http2.swift
@@ -16,7 +16,7 @@ import HummingbirdCore
 import NIOCore
 import NIOSSL
 
-extension HTTPChannelBuilder {
+extension HTTPServerBuilder {
     ///  Build HTTP channel with HTTP2 upgrade
     ///
     /// Use in ``Hummingbird/Application`` initialization.
@@ -33,7 +33,7 @@ extension HTTPChannelBuilder {
     public static func http2Upgrade(
         tlsConfiguration: TLSConfiguration,
         additionalChannelHandlers: @autoclosure @escaping @Sendable () -> [any RemovableChannelHandler] = []
-    ) throws -> HTTPChannelBuilder {
+    ) throws -> HTTPServerBuilder {
         return .init { responder in
             return try HTTP2UpgradeChannel(
                 tlsConfiguration: tlsConfiguration,

--- a/Sources/HummingbirdTLS/HTTPServerBuilder+tls.swift
+++ b/Sources/HummingbirdTLS/HTTPServerBuilder+tls.swift
@@ -15,8 +15,8 @@
 import HummingbirdCore
 import NIOSSL
 
-extension HTTPChannelBuilder {
-    ///  Build child channel supporting HTTP with TLS
+extension HTTPServerBuilder {
+    ///  Build server supporting HTTP with TLS
     ///
     /// Use in ``Hummingbird/Application`` initialization.
     /// ```
@@ -30,11 +30,11 @@ extension HTTPChannelBuilder {
     ///   - tlsConfiguration: TLS configuration
     /// - Returns: HTTPChannelHandler builder
     public static func tls(
-        _ base: HTTPChannelBuilder = .http1(),
+        _ base: HTTPServerBuilder = .http1(),
         tlsConfiguration: TLSConfiguration
-    ) throws -> HTTPChannelBuilder {
+    ) throws -> HTTPServerBuilder {
         return .init { responder in
-            return try base.build(responder).withTLS(tlsConfiguration: tlsConfiguration)
+            return try base.buildChildChannel(responder).withTLS(tlsConfiguration: tlsConfiguration)
         }
     }
 }

--- a/Sources/HummingbirdTesting/TestApplication.swift
+++ b/Sources/HummingbirdTesting/TestApplication.swift
@@ -30,7 +30,7 @@ internal struct TestApplication<BaseApp: ApplicationProtocol>: ApplicationProtoc
         get async throws { try await self.base.responder }
     }
 
-    var server: HTTPChannelBuilder {
+    var server: HTTPServerBuilder {
         self.base.server
     }
 


### PR DESCRIPTION
Also renamed it to HTTPServerBuilder

Also rename Address back to BindAddress now that it is only being used as a bind address (It got named to Address when  I introduced the generic client, which has been removed now)