### PR TITLE
Revert to using quiescing helper

### DIFF
--- a/Sources/HummingbirdCore/Server/HTTPUserEventHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPUserEventHandler.swift
@@ -73,16 +73,9 @@ public final class HTTPUserEventHandler: ChannelDuplexHandler, RemovableChannelH
         case IdleStateHandler.IdleStateEvent.read:
             // if we get an idle read event and we haven't completed reading the request
             // close the connection
-            if self.requestsBeingRead > 0 {
+            if self.requestsBeingRead > 0 || self.requestsInProgress == 0 {
                 self.logger.trace("Idle read timeout, so close channel")
                 context.close(promise: nil)
-            }
-
-        case IdleStateHandler.IdleStateEvent.write:
-            // if we get an idle write event and are not currently processing a request
-            if self.requestsInProgress == 0 {
-                self.logger.trace("Idle write timeout, so close channel")
-                context.close(mode: .input, promise: nil)
             }
 
         default:

--- a/Sources/HummingbirdCore/Server/HTTPUserEventHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPUserEventHandler.swift
@@ -72,7 +72,7 @@ public final class HTTPUserEventHandler: ChannelDuplexHandler, RemovableChannelH
 
         case IdleStateHandler.IdleStateEvent.read:
             // if we get an idle read event and we haven't completed reading the request
-            // close the connection
+            // close the connection, or a request hasnt been initiated
             if self.requestsBeingRead > 0 || self.requestsInProgress == 0 {
                 self.logger.trace("Idle read timeout, so close channel")
                 context.close(promise: nil)

--- a/Sources/HummingbirdTesting/LiveTestFramework.swift
+++ b/Sources/HummingbirdTesting/LiveTestFramework.swift
@@ -72,12 +72,12 @@ final class LiveTestFramework<App: ApplicationProtocol>: ApplicationTestFramewor
             client.connect()
             do {
                 let value = try await test(Client(client: client))
-                await serviceGroup.triggerGracefulShutdown()
                 try await client.shutdown()
+                await serviceGroup.triggerGracefulShutdown()
                 return value
             } catch {
-                await serviceGroup.triggerGracefulShutdown()
                 try await client.shutdown()
+                await serviceGroup.triggerGracefulShutdown()
                 throw error
             }
         }

--- a/Tests/HummingbirdCoreTests/HTTP2Tests.swift
+++ b/Tests/HummingbirdCoreTests/HTTP2Tests.swift
@@ -28,6 +28,8 @@ class HummingBirdHTTP2Tests: XCTestCase {
     func testConnect() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        var logger = Logger(label: "Hummingbird")
+        logger.logLevel = .trace
         try await testServer(
             responder: { _, _ in
                 .init(status: .ok)
@@ -35,7 +37,7 @@ class HummingBirdHTTP2Tests: XCTestCase {
             httpChannelSetup: .http2Upgrade(tlsConfiguration: getServerTLSConfiguration()),
             configuration: .init(address: .hostname(port: 0), serverName: testServerName),
             eventLoopGroup: eventLoopGroup,
-            logger: Logger(label: "Hummingbird")
+            logger: logger
         ) { port in
             var tlsConfiguration = try getClientTLSConfiguration()
             // no way to override the SSL server name with AsyncHTTPClient so need to set

--- a/Tests/HummingbirdCoreTests/TLSTests.swift
+++ b/Tests/HummingbirdCoreTests/TLSTests.swift
@@ -41,7 +41,7 @@ class HummingBirdTLSTests: XCTestCase {
         }
     }
 
-    func testGracefulShutdown() async throws {
+    func testGracefulShutdownWithDanglingConnection() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         let clientChannel: NIOLockedValueBox<Channel?> = .init(nil)


### PR DESCRIPTION
This means we can quiesce channels outside of the handle task. Required for channels which involve an upgrade path before passing to concurrency handlers.  