### PR TITLE
Minor optimisations

### DIFF
--- a/Sources/Hummingbird/Codable/JSON/JSONCoding.swift
+++ b/Sources/Hummingbird/Codable/JSON/JSONCoding.swift
@@ -24,8 +24,7 @@ extension JSONEncoder: ResponseEncoder {
     ///   - request: Request used to generate response
     public func encode(_ value: some Encodable, from request: Request, context: some BaseRequestContext) throws -> Response {
         let data = try self.encode(value)
-        var buffer = context.allocator.buffer(capacity: data.count)
-        buffer.writeBytes(data)
+        let buffer = context.allocator.buffer(data: data)
         return Response(
             status: .ok,
             headers: [

--- a/Sources/Hummingbird/Codable/JSON/JSONCoding.swift
+++ b/Sources/Hummingbird/Codable/JSON/JSONCoding.swift
@@ -23,12 +23,15 @@ extension JSONEncoder: ResponseEncoder {
     ///   - value: Value to encode
     ///   - request: Request used to generate response
     public func encode(_ value: some Encodable, from request: Request, context: some BaseRequestContext) throws -> Response {
-        var buffer = context.allocator.buffer(capacity: 0)
         let data = try self.encode(value)
+        var buffer = context.allocator.buffer(capacity: data.count)
         buffer.writeBytes(data)
         return Response(
             status: .ok,
-            headers: [.contentType: "application/json; charset=utf-8"],
+            headers: [
+                .contentType: "application/json; charset=utf-8",
+                .contentLength: String(describing: data.count),
+            ],
             body: .init(byteBuffer: buffer)
         )
     }

--- a/Sources/Hummingbird/Codable/JSON/JSONCoding.swift
+++ b/Sources/Hummingbird/Codable/JSON/JSONCoding.swift
@@ -30,7 +30,7 @@ extension JSONEncoder: ResponseEncoder {
             status: .ok,
             headers: [
                 .contentType: "application/json; charset=utf-8",
-                .contentLength: String(describing: data.count),
+                .contentLength: data.count.description,
             ],
             body: .init(byteBuffer: buffer)
         )

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedForm+Request.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedForm+Request.swift
@@ -18,8 +18,8 @@ extension URLEncodedFormEncoder: ResponseEncoder {
     ///   - value: Value to encode
     ///   - request: Request used to generate response
     public func encode(_ value: some Encodable, from request: Request, context: some BaseRequestContext) throws -> Response {
-        var buffer = context.allocator.buffer(capacity: 0)
         let string = try self.encode(value)
+        var buffer = context.allocator.buffer(capacity: string.utf8.count)
         buffer.writeString(string)
         return Response(
             status: .ok,

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedForm+Request.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedForm+Request.swift
@@ -19,8 +19,7 @@ extension URLEncodedFormEncoder: ResponseEncoder {
     ///   - request: Request used to generate response
     public func encode(_ value: some Encodable, from request: Request, context: some BaseRequestContext) throws -> Response {
         let string = try self.encode(value)
-        var buffer = context.allocator.buffer(capacity: string.utf8.count)
-        buffer.writeString(string)
+        let buffer = context.allocator.buffer(string: string)
         return Response(
             status: .ok,
             headers: [

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedForm+Request.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedForm+Request.swift
@@ -23,7 +23,10 @@ extension URLEncodedFormEncoder: ResponseEncoder {
         buffer.writeString(string)
         return Response(
             status: .ok,
-            headers: [.contentType: "application/x-www-form-urlencoded"],
+            headers: [
+                .contentType: "application/x-www-form-urlencoded",
+                .contentLength: buffer.readableBytes.description,
+            ],
             body: .init(byteBuffer: buffer)
         )
     }

--- a/Sources/Hummingbird/Middleware/CORSMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/CORSMiddleware.swift
@@ -86,7 +86,7 @@ public struct CORSMiddleware<Context: BaseRequestContext>: RouterMiddleware {
     /// apply CORS middleware
     public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
         // if no origin header then don't apply CORS
-        guard request.headers[.origin] != nil else {
+        guard request.headers.contains(.origin) else {
             return try await next(request, context)
         }
 

--- a/Sources/Hummingbird/Router/ResponseGenerator.swift
+++ b/Sources/Hummingbird/Router/ResponseGenerator.swift
@@ -119,7 +119,7 @@ public struct EditedResponse<Generator: ResponseGenerator>: ResponseGenerator {
             // only add headers from generated response if they don't exist in override headers
             var headers = self.headers
             for header in response.headers {
-                if headers[header.name] == nil {
+                if !headers.contains(header.name) {
                     headers.append(header)
                 }
             }

--- a/Sources/Hummingbird/Router/ResponseGenerator.swift
+++ b/Sources/Hummingbird/Router/ResponseGenerator.swift
@@ -33,7 +33,14 @@ extension String: ResponseGenerator {
     /// Generate response holding string
     public func response(from request: Request, context: some BaseRequestContext) -> Response {
         let buffer = context.allocator.buffer(string: self)
-        return Response(status: .ok, headers: [.contentType: "text/plain; charset=utf-8"], body: .init(byteBuffer: buffer))
+        return Response(
+            status: .ok,
+            headers: [
+                .contentType: "text/plain; charset=utf-8",
+                .contentLength: buffer.readableBytes.description,
+            ],
+            body: .init(byteBuffer: buffer)
+        )
     }
 }
 
@@ -42,7 +49,14 @@ extension Substring: ResponseGenerator {
     /// Generate response holding string
     public func response(from request: Request, context: some BaseRequestContext) -> Response {
         let buffer = context.allocator.buffer(substring: self)
-        return Response(status: .ok, headers: [.contentType: "text/plain; charset=utf-8"], body: .init(byteBuffer: buffer))
+        return Response(
+            status: .ok,
+            headers: [
+                .contentType: "text/plain; charset=utf-8",
+                .contentLength: buffer.readableBytes.description,
+            ],
+            body: .init(byteBuffer: buffer)
+        )
     }
 }
 
@@ -50,7 +64,14 @@ extension Substring: ResponseGenerator {
 extension ByteBuffer: ResponseGenerator {
     /// Generate response holding bytebuffer
     public func response(from request: Request, context: some BaseRequestContext) -> Response {
-        Response(status: .ok, headers: [.contentType: "application/octet-stream"], body: .init(byteBuffer: self))
+        Response(
+            status: .ok,
+            headers: [
+                .contentType: "application/octet-stream",
+                .contentLength: self.readableBytes.description,
+            ],
+            body: .init(byteBuffer: self)
+        )
     }
 }
 

--- a/Sources/HummingbirdCore/Request/Request.swift
+++ b/Sources/HummingbirdCore/Request/Request.swift
@@ -25,8 +25,10 @@ public struct Request: Sendable {
     /// Body of HTTP request
     public var body: RequestBody
     /// Request HTTP method
+    @inlinable
     public var method: HTTPRequest.Method { self.head.method }
     /// Request HTTP headers
+    @inlinable
     public var headers: HTTPFields { self.head.headerFields }
 
     // MARK: Initialization

--- a/Sources/HummingbirdCore/Response/Response.swift
+++ b/Sources/HummingbirdCore/Response/Response.swift
@@ -16,31 +16,38 @@ import HTTPTypes
 
 /// Holds all the required to generate a HTTP Response
 public struct Response: Sendable {
-    public var head: HTTPResponse
+    /// Response status
+    public var status: HTTPResponse.Status
+    /// Response headers
+    public var headers: HTTPFields
+    /// Response head constructed from status and headers
+    @inlinable
+    public var head: HTTPResponse {
+        get { HTTPResponse(status: self.status, headerFields: self.headers) }
+        set {
+            self.status = newValue.status
+            self.headers = newValue.headerFields
+        }
+    }
+
+    /// Response body
     public var body: ResponseBody {
         didSet {
             if let contentLength = body.contentLength {
-                self.head.headerFields[.contentLength] = String(describing: contentLength)
+                self.headers[.contentLength] = String(describing: contentLength)
             }
         }
     }
 
+    /// Initialize Response
+    @inlinable
     public init(status: HTTPResponse.Status, headers: HTTPFields = .init(), body: ResponseBody = .init()) {
-        self.head = .init(status: status, headerFields: headers)
+        self.status = status
+        self.headers = headers
         self.body = body
-        if let contentLength = body.contentLength, !headers.contains(.contentLength) {
-            self.head.headerFields[.contentLength] = String(describing: contentLength)
+        if let contentLength = body.contentLength, !self.headers.contains(.contentLength) {
+            self.headers[.contentLength] = String(describing: contentLength)
         }
-    }
-
-    public var status: HTTPResponse.Status {
-        get { self.head.status }
-        set { self.head.status = newValue }
-    }
-
-    public var headers: HTTPFields {
-        get { self.head.headerFields }
-        set { self.head.headerFields = newValue }
     }
 
     /// Return HEAD response based off this response

--- a/Sources/HummingbirdCore/Response/Response.swift
+++ b/Sources/HummingbirdCore/Response/Response.swift
@@ -28,7 +28,7 @@ public struct Response: Sendable {
     public init(status: HTTPResponse.Status, headers: HTTPFields = .init(), body: ResponseBody = .init()) {
         self.head = .init(status: status, headerFields: headers)
         self.body = body
-        if let contentLength = body.contentLength, headers[.contentLength] == nil {
+        if let contentLength = body.contentLength, headers[values: .contentLength].count == 0 {
             self.head.headerFields[.contentLength] = String(describing: contentLength)
         }
     }

--- a/Sources/HummingbirdCore/Response/Response.swift
+++ b/Sources/HummingbirdCore/Response/Response.swift
@@ -28,7 +28,7 @@ public struct Response: Sendable {
     public init(status: HTTPResponse.Status, headers: HTTPFields = .init(), body: ResponseBody = .init()) {
         self.head = .init(status: status, headerFields: headers)
         self.body = body
-        if let contentLength = body.contentLength, headers[values: .contentLength].count == 0 {
+        if let contentLength = body.contentLength, !headers.contains(.contentLength) {
             self.head.headerFields[.contentLength] = String(describing: contentLength)
         }
     }

--- a/Sources/PerformanceTest/main.swift
+++ b/Sources/PerformanceTest/main.swift
@@ -37,10 +37,14 @@ router.post { request, _ in
     return Response(status: .ok, body: .init(asyncSequence: request.body))
 }
 
+struct Object: ResponseEncodable {
+    let message: String
+}
+
 // return JSON
 // ./wrk -c 128 -d 15s -t 8 http://localhost:8080/json
 router.get("json") { _, _ in
-    return ["message": "Hello, world"]
+    return Object(message: "Hello, world")
 }
 
 // return JSON


### PR DESCRIPTION
Don't allocate ByteBuffer before we know its size.
Provide contentLength when generating responses so header field size is not recalculated, when contentLength is added
Use `HTTPFields.contains` instead of subscript which constructs contents of HTTPField