### PR TITLE
Remove NIOLockedValueBox from EndpointPath

### DIFF
--- a/Sources/Hummingbird/Server/RequestContext.swift
+++ b/Sources/Hummingbird/Server/RequestContext.swift
@@ -21,17 +21,10 @@ import Tracing
 
 /// Endpoint path storage
 public struct EndpointPath: Sendable {
-    public init() {
-        self._value = .init(nil)
-    }
+    public init() {}
 
     /// Endpoint path
-    public var value: String? {
-        get { self._value.withLockedValue { $0 } }
-        nonmutating set { self._value.withLockedValue { $0 = newValue } }
-    }
-
-    private let _value: NIOLockedValueBox<String?>
+    public var value: String?
 }
 
 /// Request context values required by Hummingbird itself.

--- a/Sources/HummingbirdRouter/Route.swift
+++ b/Sources/HummingbirdRouter/Route.swift
@@ -80,7 +80,7 @@ public struct Route<Handler: _RouteHandlerProtocol, Context: RouterRequestContex
     ///   - next: Next middleware to call if route method and path is not matched
     /// - Returns: Response
     public func handle(_ input: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
-        if input.method == self.method, let context = self.routerPath.matchAll(context) {
+        if input.method == self.method, var context = self.routerPath.matchAll(context) {
             context.coreContext.endpointPath.value = self.fullPath
             return try await self.handler.handle(input, context: context)
         }


### PR DESCRIPTION
It's not needed (anymore) because we expect the entire context setup to be value types