### PR TITLE
Optimise FlatDictionary init for scenarios where no values are stored and llow inlining access

### DIFF
--- a/Sources/HummingbirdCore/Utils/FlatDictionary.swift
+++ b/Sources/HummingbirdCore/Utils/FlatDictionary.swift
@@ -175,4 +175,5 @@ public struct FlatDictionary<Key: Hashable, Value>: Collection, ExpressibleByDic
 }
 
 // FlatDictionary is Sendable when Key and Value are Sendable
+extension FlatDictionary.Storage: Sendable where Key: Sendable, Value: Sendable {}
 extension FlatDictionary: Sendable where Key: Sendable, Value: Sendable {}


### PR DESCRIPTION
This provides specialized access to the type, and virtually eliminates its presence from routes where a flat dictionary is not used. This affects the route parameters primarily, but helps in particular because `CoreRequestContext` _always_ starts out with an empty `Parameters` instance.