### PR TITLE
Provide content-length in the HTTPFields' literal when creating a response

### DIFF
--- a/Sources/Hummingbird/Codable/JSON/JSONCoding.swift
+++ b/Sources/Hummingbird/Codable/JSON/JSONCoding.swift
@@ -26,9 +26,13 @@ extension JSONEncoder: ResponseEncoder {
         var buffer = context.allocator.buffer(capacity: 0)
         let data = try self.encode(value)
         buffer.writeBytes(data)
+        
         return Response(
             status: .ok,
-            headers: [.contentType: "application/json; charset=utf-8"],
+            headers: HTTPFields(
+                contentType: "application/json; charset=utf-8",
+                contentLength: buffer.readableBytes
+            ),
             body: .init(byteBuffer: buffer)
         )
     }

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedForm+Request.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedForm+Request.swift
@@ -21,9 +21,13 @@ extension URLEncodedFormEncoder: ResponseEncoder {
         var buffer = context.allocator.buffer(capacity: 0)
         let string = try self.encode(value)
         buffer.writeString(string)
+
         return Response(
             status: .ok,
-            headers: [.contentType: "application/x-www-form-urlencoded"],
+            headers: HTTPFields(
+                contentType: "application/x-www-form-urlencoded",
+                contentLength: buffer.readableBytes
+            ),
             body: .init(byteBuffer: buffer)
         )
     }

--- a/Sources/Hummingbird/Router/EndpointResponder.swift
+++ b/Sources/Hummingbird/Router/EndpointResponder.swift
@@ -26,14 +26,14 @@ struct EndpointResponders<Context: BaseRequestContext>: Sendable {
     }
 
     mutating func addResponder(for method: HTTPRequest.Method, responder: any HTTPResponder<Context>) {
-        guard self.methods[method] == nil else {
+        guard !self.methods.keys.contains(method) else {
             preconditionFailure("\(method.rawValue) already has a handler")
         }
         self.methods[method] = responder
     }
 
     mutating func autoGenerateHeadEndpoint() {
-        if self.methods[.head] == nil, let get = methods[.get] {
+        if !self.methods.keys.contains(.head), let get = methods[.get] {
             self.methods[.head] = CallbackResponder { request, context in
                 let response = try await get.respond(to: request, context: context)
                 return response.createHeadResponse()

--- a/Sources/Hummingbird/Router/ResponseGenerator.swift
+++ b/Sources/Hummingbird/Router/ResponseGenerator.swift
@@ -33,7 +33,14 @@ extension String: ResponseGenerator {
     /// Generate response holding string
     public func response(from request: Request, context: some BaseRequestContext) -> Response {
         let buffer = context.allocator.buffer(string: self)
-        return Response(status: .ok, headers: [.contentType: "text/plain; charset=utf-8"], body: .init(byteBuffer: buffer))
+        return Response(
+            status: .ok,
+            headers: HTTPFields(
+                contentType: "text/plain; charset=utf-8",
+                contentLength: buffer.readableBytes
+            ),
+            body: .init(byteBuffer: buffer)
+        )
     }
 }
 
@@ -42,7 +49,14 @@ extension Substring: ResponseGenerator {
     /// Generate response holding string
     public func response(from request: Request, context: some BaseRequestContext) -> Response {
         let buffer = context.allocator.buffer(substring: self)
-        return Response(status: .ok, headers: [.contentType: "text/plain; charset=utf-8"], body: .init(byteBuffer: buffer))
+        return Response(
+            status: .ok,
+            headers: HTTPFields(
+                contentType: "text/plain; charset=utf-8",
+                contentLength: buffer.readableBytes
+            ),
+            body: .init(byteBuffer: buffer)
+        )
     }
 }
 
@@ -50,7 +64,14 @@ extension Substring: ResponseGenerator {
 extension ByteBuffer: ResponseGenerator {
     /// Generate response holding bytebuffer
     public func response(from request: Request, context: some BaseRequestContext) -> Response {
-        Response(status: .ok, headers: [.contentType: "application/octet-stream"], body: .init(byteBuffer: self))
+        Response(
+            status: .ok,
+            headers: HTTPFields(
+                contentType: "application/octet-stream",
+                contentLength: self.readableBytes
+            ),
+            body: .init(byteBuffer: self)
+        )
     }
 }
 
@@ -69,7 +90,7 @@ extension Optional: ResponseGenerator where Wrapped: ResponseGenerator {
         case .some(let wrapped):
             return try wrapped.response(from: request, context: context)
         case .none:
-            return Response(status: .noContent, headers: [:], body: .init())
+            return Response(status: .noContent)
         }
     }
 }

--- a/Sources/Hummingbird/Utils/HTTPFields+Payload.swift
+++ b/Sources/Hummingbird/Utils/HTTPFields+Payload.swift
@@ -1,0 +1,14 @@
+import HTTPTypes
+
+extension HTTPFields {
+    init(contentType: String, contentLength: Int) {
+        self.init()
+
+        // Content-Type, Content-Length, Server, Date + 2 extra headers
+        // This should cover our expected amount of headers
+        self.reserveCapacity(6)
+
+        self[.contentType] = contentType
+        self[.contentLength] = String(describing: contentLength)
+    }
+}

--- a/Sources/Hummingbird/Utils/HTTPFields+Payload.swift
+++ b/Sources/Hummingbird/Utils/HTTPFields+Payload.swift
@@ -2,13 +2,9 @@ import HTTPTypes
 
 extension HTTPFields {
     init(contentType: String, contentLength: Int) {
-        self.init()
-
-        // Content-Type, Content-Length, Server, Date + 2 extra headers
-        // This should cover our expected amount of headers
-        self.reserveCapacity(6)
-
-        self[.contentType] = contentType
-        self[.contentLength] = String(describing: contentLength)
+        self = [
+            .contentType: contentType,
+            .contentLength: String(describing: contentLength)
+        ]
     }
 }

--- a/Sources/HummingbirdCore/Response/Response.swift
+++ b/Sources/HummingbirdCore/Response/Response.swift
@@ -28,7 +28,7 @@ public struct Response: Sendable {
     public init(status: HTTPResponse.Status, headers: HTTPFields = .init(), body: ResponseBody = .init()) {
         self.head = .init(status: status, headerFields: headers)
         self.body = body
-        if let contentLength = body.contentLength, headers[.contentLength] == nil {
+        if let contentLength = body.contentLength, !headers.contains(.contentLength) {
             self.head.headerFields[.contentLength] = String(describing: contentLength)
         }
     }


### PR DESCRIPTION
This allows the HTTPFields to allocate sufficient room for `Content-Length`, `Server` and `Date`, preventing reallocs