### PR TITLE
Ensure errors have CORS and server/date headers

### DIFF
--- a/Sources/Hummingbird/Server/EditedHTTPError.swift
+++ b/Sources/Hummingbird/Server/EditedHTTPError.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPTypes
+import HummingbirdCore
+
+/// Error generated from another error that adds additional headers to the response
+struct EditedHTTPError: HTTPResponseError {
+    let status: HTTPResponse.Status
+    let headers: HTTPFields
+    let body: ByteBuffer?
+
+    init(originalError: Error, additionalHeaders: HTTPFields, context: some BaseRequestContext) {
+        if let httpError = originalError as? HTTPResponseError {
+            self.status = httpError.status
+            self.headers = httpError.headers + additionalHeaders
+            self.body = httpError.body(allocator: context.allocator)
+        } else {
+            self.status = .internalServerError
+            self.headers = additionalHeaders
+            self.body = nil
+        }
+    }
+
+    func body(allocator: NIOCore.ByteBufferAllocator) -> NIOCore.ByteBuffer? {
+        return self.body
+    }
+}

--- a/Sources/HummingbirdCore/Error/NIOCore+HTTPResponseError.swift
+++ b/Sources/HummingbirdCore/Error/NIOCore+HTTPResponseError.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPTypes
+import NIOCore
+
+// If we catch a too many bytes error report that as payload too large
+extension NIOTooManyBytesError: HTTPResponseError {
+    public var status: HTTPResponse.Status { .contentTooLarge }
+    public var headers: HTTPFields { [:] }
+    public func body(allocator: ByteBufferAllocator) -> ByteBuffer? { nil }
+}

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -145,13 +145,6 @@ struct HTTPServerBodyWriter: Sendable, ResponseBodyWriter {
     }
 }
 
-// If we catch a too many bytes error report that as payload too large
-extension NIOTooManyBytesError: HTTPResponseError {
-    public var status: HTTPResponse.Status { .contentTooLarge }
-    public var headers: HTTPFields { [:] }
-    public func body(allocator: ByteBufferAllocator) -> ByteBuffer? { nil }
-}
-
 extension NIOLockedValueBox {
     /// Exchange stored value for new value and return the old stored value
     func exchange(_ newValue: Value) -> Value {

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -208,6 +208,20 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
+    func testErrorHeaders() async throws {
+        let router = Router()
+        router.get("error") { _, _ -> HTTPResponse.Status in
+            throw HTTPError(.badRequest, message: "BAD!")
+        }
+        let app = Application(router: router, configuration: .init(serverName: "HB"))
+        try await app.test(.live) { client in
+            try await client.execute(uri: "/error", method: .get) { response in
+                XCTAssertEqual(response.headers[.server], "HB")
+                XCTAssertNotNil(response.headers[.date])
+            }
+        }
+    }
+
     func testResponseBody() async throws {
         let router = Router()
         router

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -242,6 +242,18 @@ final class MiddlewareTests: XCTestCase {
         }
     }
 
+    func testCORSHeadersAndErrors() async throws {
+        let router = Router()
+        router.middlewares.add(CORSMiddleware())
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/hello", method: .get, headers: [.origin: "foo.com"]) { response in
+                // headers come back in opposite order as middleware is applied to responses in that order
+                XCTAssertEqual(response.headers[.accessControlAllowOrigin], "foo.com")
+            }
+        }
+    }
+
     func testLogRequestMiddleware() async throws {
         let logAccumalator = TestLogHandler.LogAccumalator()
         let router = Router()


### PR DESCRIPTION
Given we are catching errors in Application it asks the question should `throws` be removed from the Server HTTP closure. I have implement this in #462 