### PR TITLE
Fix router path precedence, parsing of parameter paths

### DIFF
--- a/Sources/Hummingbird/Router/RouterPath.swift
+++ b/Sources/Hummingbird/Router/RouterPath.swift
@@ -92,7 +92,11 @@ public struct RouterPath: Sendable, ExpressibleByStringLiteral, CustomStringConv
                 let parameter = component.dropFirst(1)
                 if let closingParethesis = parameter.firstIndex(of: "}") {
                     let charAfterClosingParethesis = parameter.index(after: closingParethesis)
-                    return .prefixCapture(suffix: parameter[charAfterClosingParethesis...], parameter: parameter[..<closingParethesis])
+                    if charAfterClosingParethesis == parameter.endIndex {
+                        return .capture(parameter[..<closingParethesis])
+                    } else {
+                        return .prefixCapture(suffix: parameter[charAfterClosingParethesis...], parameter: parameter[..<closingParethesis])
+                    }
                 } else {
                     return .path(component)
                 }

--- a/Sources/Hummingbird/Router/Trie/Trie+serialize.swift
+++ b/Sources/Hummingbird/Router/Trie/Trie+serialize.swift
@@ -102,24 +102,24 @@ extension RouterPath.Element {
     @usableFromInline
     var priority: Int {
         switch self {
-        case .prefixCapture, .suffixCapture:
-            // Most specific
-            return 1
         case .path, .null:
-            // Specific
+            // Most specific
             return 0
+        case .prefixCapture, .suffixCapture:
+            // specific
+            return -1
         case .prefixWildcard, .suffixWildcard:
             // Less specific
-            return -1
+            return -2
         case .capture:
             // More important than wildcards
-            return -2
+            return -3
         case .wildcard:
             // Not specific at all
-            return -3
+            return -4
         case .recursiveWildcard:
             // Least specific
-            return -4
+            return -5
         }
     }
 }

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -77,11 +77,15 @@ class TrieRouterTests: XCTestCase {
         let trieBuilder = RouterPathTrieBuilder<String>()
         trieBuilder.addEntry("users/:user", value: "test1")
         trieBuilder.addEntry("users/:user/name", value: "john smith")
+        trieBuilder.addEntry("users/:user/name/{id}", value: "41D2DF67-C2C2-4842-B1DA-9F4549BED3F0")
         let trie = trieBuilder.build()
         XCTAssertNil(trie.resolve("/user/"))
         XCTAssertEqual(trie.resolve("/users/1234")?.parameters.get("user"), "1234")
         XCTAssertEqual(trie.resolve("/users/1234/name")?.parameters.get("user"), "1234")
         XCTAssertEqual(trie.resolve("/users/1234/name")?.value, "john smith")
+        XCTAssertEqual(trie.resolve("/users/1234/name/34")?.value, "41D2DF67-C2C2-4842-B1DA-9F4549BED3F0")
+        XCTAssertEqual(trie.resolve("/users/5678/name/34")?.parameters.get("user"), "5678")
+        XCTAssertEqual(trie.resolve("/users/1234/name/90")?.parameters.get("id"), "90")
     }
 
     func testRecursiveWildcard() {

--- a/Tests/HummingbirdTests/TrieRouterTests.swift
+++ b/Tests/HummingbirdTests/TrieRouterTests.swift
@@ -29,6 +29,30 @@ class TrieRouterTests: XCTestCase {
         XCTAssertEqual(trie.resolve("/Users/jane/bin")?.value, "test3")
     }
 
+    func testPathParsing() {
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        func getFirstChildElement(_ path: String) -> RouterPath.Element? {
+            trieBuilder.root.children.first(where: { $0.key == path })?.children.first?.key
+        }
+        trieBuilder.addEntry("test1/:param", value: "*")
+        trieBuilder.addEntry("test2/{param}", value: "*")
+        trieBuilder.addEntry("test3/*", value: "*")
+        trieBuilder.addEntry("test4/**", value: "*")
+        trieBuilder.addEntry("test5/*.jpg", value: "*")
+        trieBuilder.addEntry("test6/test.*", value: "*")
+        trieBuilder.addEntry("test7/{image}.jpg", value: "*")
+        trieBuilder.addEntry("test8/test.{ext}", value: "*")
+
+        XCTAssertEqual(getFirstChildElement("test1"), .capture("param"))
+        XCTAssertEqual(getFirstChildElement("test2"), .capture("param"))
+        XCTAssertEqual(getFirstChildElement("test3"), .wildcard)
+        XCTAssertEqual(getFirstChildElement("test4"), .recursiveWildcard)
+        XCTAssertEqual(getFirstChildElement("test5"), .prefixWildcard(".jpg"))
+        XCTAssertEqual(getFirstChildElement("test6"), .suffixWildcard("test."))
+        XCTAssertEqual(getFirstChildElement("test7"), .prefixCapture(suffix: ".jpg", parameter: "image"))
+        XCTAssertEqual(getFirstChildElement("test8"), .suffixCapture(prefix: "test.", parameter: "ext"))
+    }
+
     func testRootNode() {
         let trieBuilder = RouterPathTrieBuilder<String>()
         trieBuilder.addEntry("", value: "test1")
@@ -147,5 +171,19 @@ class TrieRouterTests: XCTestCase {
         let trie = trieBuilder.build()
         XCTAssertEqual(trie.resolve("/text}")?.value, "test")
         XCTAssertNil(trie.resolve("/text"))
+    }
+
+    func testRoutePrecedence() {
+        let trieBuilder = RouterPathTrieBuilder<String>()
+        trieBuilder.addEntry("path.jpg", value: "path")
+        trieBuilder.addEntry("{parameter}", value: "parameter")
+        trieBuilder.addEntry("{parameter}.jpg", value: "prefixParameter")
+        trieBuilder.addEntry("*.txt", value: "prefixWildcard")
+        trieBuilder.addEntry("*", value: "wildcard")
+        let trie = trieBuilder.build()
+        XCTAssertEqual(trie.resolve("path.jpg")?.value, "path")
+        XCTAssertEqual(trie.resolve("this.jpg")?.value, "prefixParameter")
+        XCTAssertEqual(trie.resolve("this.txt")?.value, "prefixWildcard")
+        XCTAssertEqual(trie.resolve("hello")?.value, "parameter")
     }
 }


### PR DESCRIPTION
parameter with prefix/suffix should not have precedence over a fully specified path name 
Also fixed parsing of path elements so `{param}` is parsed as `.parameter` and not `.prefixParameter`