### PR TITLE
Don't apply middleware to earlier routes in RouteCollections

### DIFF
--- a/Sources/Hummingbird/Router/RouteCollection.swift
+++ b/Sources/Hummingbird/Router/RouteCollection.swift
@@ -34,7 +34,7 @@ public final class RouteCollection<Context: BaseRequestContext>: RouterMethods {
         method: HTTPRequest.Method,
         responder: Responder
     ) -> Self where Responder.Context == Context {
-        let route = RouteDefinition(path: path, method: method, responder: responder)
+        let route = RouteDefinition(path: path, method: method, responder: self.middlewares.constructResponder(finalResponder: responder))
         self.routes.append(route)
         return self
     }
@@ -68,7 +68,7 @@ extension RouterMethods {
         for route in collection.routes {
             // ensure path starts with a "/" and doesn't end with a "/"
             let path = self.combinePaths(path, route.path)
-            self.on(path, method: route.method, responder: collection.middlewares.constructResponder(finalResponder: route.responder))
+            self.on(path, method: route.method, responder: route.responder)
         }
     }
 }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -17,8 +17,8 @@ import HTTPTypes
 import Hummingbird
 import HummingbirdCore
 import HummingbirdHTTP2
-import HummingbirdTLS
 import HummingbirdTesting
+import HummingbirdTLS
 import Logging
 import NIOCore
 import NIOSSL
@@ -79,7 +79,8 @@ final class ApplicationTests: XCTestCase {
             return "Hello"
         }
         let app = Application(
-            responder: router.buildResponder(), configuration: .init(serverName: "TestServer"))
+            responder: router.buildResponder(), configuration: .init(serverName: "TestServer")
+        )
         try await app.test(.live) { client in
             try await client.execute(uri: "/hello", method: .get) { response in
                 XCTAssertEqual(response.headers[.server], "TestServer")
@@ -686,7 +687,8 @@ final class ApplicationTests: XCTestCase {
         try await app.test(.live) { client in
             try await client.execute(uri: "/", method: .post, body: buffer) { response in
                 XCTAssertEqual(
-                    response.body, ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 0xFF }))
+                    response.body, ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 0xFF })
+                )
             }
         }
     }
@@ -695,13 +697,17 @@ final class ApplicationTests: XCTestCase {
 
     func getServerTLSConfiguration() throws -> TLSConfiguration {
         let caCertificate = try NIOSSLCertificate(
-            bytes: [UInt8](caCertificateData.utf8), format: .pem)
+            bytes: [UInt8](caCertificateData.utf8), format: .pem
+        )
         let certificate = try NIOSSLCertificate(
-            bytes: [UInt8](serverCertificateData.utf8), format: .pem)
+            bytes: [UInt8](serverCertificateData.utf8), format: .pem
+        )
         let privateKey = try NIOSSLPrivateKey(
-            bytes: [UInt8](serverPrivateKeyData.utf8), format: .pem)
+            bytes: [UInt8](serverPrivateKeyData.utf8), format: .pem
+        )
         var tlsConfig = TLSConfiguration.makeServerConfiguration(
-            certificateChain: [.certificate(certificate)], privateKey: .privateKey(privateKey))
+            certificateChain: [.certificate(certificate)], privateKey: .privateKey(privateKey)
+        )
         tlsConfig.trustRoots = .certificates([caCertificate])
         return tlsConfig
     }

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -485,7 +485,7 @@ final class RouterTests: XCTestCase {
     func testMiddlewareOrderingInRouteCollection() async throws {
         let router = Router()
         let routes = RouteCollection()
-            .get("this") { _,_ in 
+            .get("this") { _, _ in
                 return HTTPResponse.Status.ok
             }
             .add(middleware: TestMiddleware("Hello"))

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -481,6 +481,31 @@ final class RouterTests: XCTestCase {
         }
     }
 
+    // Test middleware in route collection is only applied to routes after middleware
+    func testMiddlewareOrderingInRouteCollection() async throws {
+        let router = Router()
+        let routes = RouteCollection()
+            .get("this") { _,_ in 
+                return HTTPResponse.Status.ok
+            }
+            .add(middleware: TestMiddleware("Hello"))
+            .get("that") { _, _ in
+                return HTTPResponse.Status.ok
+            }
+        router.addRoutes(routes, atPath: "/test")
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/test/this", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertNil(response.headers[.test])
+            }
+            try await client.execute(uri: "/test/that", method: .get) { response in
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertEqual(response.headers[.test], "Hello")
+            }
+        }
+    }
+
     // Test group in route collection
     func testGroupInRouteCollection() async throws {
         let router = Router()


### PR DESCRIPTION
In the example below the middleware should only be applied to the second endpoint to make it consistent with `RouterGroup`.
```swift
let collection = RouteCollection()
collection
    .get { _,_ in HTTPResponse.Status.ok }
    .add(middleware: BasicAuthenticationMiddleware())
    .put {_,_ in User() }
```
