### PR TITLE
Make `chunkSize` for file reads configurable and default to the suggested value from `SwiftNIO`

### DIFF
--- a/Sources/Hummingbird/Files/FileIO.swift
+++ b/Sources/Hummingbird/Files/FileIO.swift
@@ -34,12 +34,12 @@ public struct FileIO: Sendable {
     /// - Parameters:
     ///   - path: System file path
     ///   - context: Context this request is being called in
-    ///   - chunkSize: Size of the chunks read from disk and loaded into memory (in bytes). Defaults to the value suggested by `swift-nio`.
+    ///   - chunkLength: Size of the chunks read from disk and loaded into memory (in bytes). Defaults to the value suggested by `swift-nio`.
     /// - Returns: Response body
-    public func loadFile(path: String, context: some BaseRequestContext, chunkSize: Int = NonBlockingFileIO.defaultChunkSize) async throws -> ResponseBody {
+    public func loadFile(path: String, context: some BaseRequestContext, chunkLength: Int = NonBlockingFileIO.defaultChunkSize) async throws -> ResponseBody {
         do {
             let stat = try await fileIO.lstat(path: path)
-            return self.readFile(path: path, range: 0...numericCast(stat.st_size - 1), context: context, chunkSize: chunkSize)
+            return self.readFile(path: path, range: 0...numericCast(stat.st_size - 1), context: context, chunkLength: chunkLength)
         } catch {
             throw HTTPError(.notFound)
         }
@@ -53,14 +53,14 @@ public struct FileIO: Sendable {
     ///   - path: System file path
     ///   - range:Range defining how much of the file is to be loaded
     ///   - context: Context this request is being called in
-    ///   - chunkSize: Size of the chunks read from disk and loaded into memory (in bytes). Defaults to the value suggested by `swift-nio`.
+    ///   - chunkLength: Size of the chunks read from disk and loaded into memory (in bytes). Defaults to the value suggested by `swift-nio`.
     /// - Returns: Response body plus file size
-    public func loadFile(path: String, range: ClosedRange<Int>, context: some BaseRequestContext, chunkSize: Int = NonBlockingFileIO.defaultChunkSize) async throws -> ResponseBody {
+    public func loadFile(path: String, range: ClosedRange<Int>, context: some BaseRequestContext, chunkLength: Int = NonBlockingFileIO.defaultChunkSize) async throws -> ResponseBody {
         do {
             let stat = try await fileIO.lstat(path: path)
             let fileRange: ClosedRange<Int> = 0...numericCast(stat.st_size - 1)
             let range = range.clamped(to: fileRange)
-            return self.readFile(path: path, range: range, context: context, chunkSize: chunkSize)
+            return self.readFile(path: path, range: range, context: context, chunkLength: chunkLength)
         } catch {
             throw HTTPError(.notFound)
         }
@@ -103,16 +103,16 @@ public struct FileIO: Sendable {
     }
 
     /// Return response body that will read file
-    func readFile(path: String, range: ClosedRange<Int>, context: some BaseRequestContext, chunkSize: Int = NonBlockingFileIO.defaultChunkSize) -> ResponseBody {
+    func readFile(path: String, range: ClosedRange<Int>, context: some BaseRequestContext, chunkLength: Int = NonBlockingFileIO.defaultChunkSize) -> ResponseBody {
         return ResponseBody(contentLength: range.count) { writer in
             try await self.fileIO.withFileHandle(path: path, mode: .read) { handle in
                 let endOffset = range.endIndex
-                let chunkSize = chunkSize
+                let chunkLength = chunkLength
                 var fileOffset = range.startIndex
 
                 while case .inRange(let offset) = fileOffset {
                     let bytesLeft = range.distance(from: fileOffset, to: endOffset)
-                    let bytesToRead = Swift.min(chunkSize, bytesLeft)
+                    let bytesToRead = Swift.min(chunkLength, bytesLeft)
                     let buffer = try await self.fileIO.read(
                         fileHandle: handle,
                         fromOffset: numericCast(offset),

--- a/Sources/Hummingbird/Files/FileIO.swift
+++ b/Sources/Hummingbird/Files/FileIO.swift
@@ -20,13 +20,11 @@ import NIOPosix
 /// Manages File reading and writing.
 public struct FileIO: Sendable {
     let fileIO: NonBlockingFileIO
-    let chunkSize: Int
 
     /// Initialize FileIO
     /// - Parameter application: application using FileIO
     public init(threadPool: NIOThreadPool = .singleton) {
         self.fileIO = .init(threadPool: threadPool)
-        self.chunkSize = NonBlockingFileIO.defaultChunkSize
     }
 
     /// Load file and return response body
@@ -36,11 +34,12 @@ public struct FileIO: Sendable {
     /// - Parameters:
     ///   - path: System file path
     ///   - context: Context this request is being called in
+    ///   - chunkSize: Size of the chunks read from disk and loaded into memory (in bytes). Defaults to the value suggested by `swift-nio`.
     /// - Returns: Response body
-    public func loadFile(path: String, context: some BaseRequestContext) async throws -> ResponseBody {
+    public func loadFile(path: String, context: some BaseRequestContext, chunkSize: Int = NonBlockingFileIO.defaultChunkSize) async throws -> ResponseBody {
         do {
             let stat = try await fileIO.lstat(path: path)
-            return self.readFile(path: path, range: 0...numericCast(stat.st_size - 1), context: context)
+            return self.readFile(path: path, range: 0...numericCast(stat.st_size - 1), context: context, chunkSize: chunkSize)
         } catch {
             throw HTTPError(.notFound)
         }
@@ -54,13 +53,14 @@ public struct FileIO: Sendable {
     ///   - path: System file path
     ///   - range:Range defining how much of the file is to be loaded
     ///   - context: Context this request is being called in
+    ///   - chunkSize: Size of the chunks read from disk and loaded into memory (in bytes). Defaults to the value suggested by `swift-nio`.
     /// - Returns: Response body plus file size
-    public func loadFile(path: String, range: ClosedRange<Int>, context: some BaseRequestContext) async throws -> ResponseBody {
+    public func loadFile(path: String, range: ClosedRange<Int>, context: some BaseRequestContext, chunkSize: Int = NonBlockingFileIO.defaultChunkSize) async throws -> ResponseBody {
         do {
             let stat = try await fileIO.lstat(path: path)
             let fileRange: ClosedRange<Int> = 0...numericCast(stat.st_size - 1)
             let range = range.clamped(to: fileRange)
-            return self.readFile(path: path, range: range, context: context)
+            return self.readFile(path: path, range: range, context: context, chunkSize: chunkSize)
         } catch {
             throw HTTPError(.notFound)
         }
@@ -103,11 +103,11 @@ public struct FileIO: Sendable {
     }
 
     /// Return response body that will read file
-    func readFile(path: String, range: ClosedRange<Int>, context: some BaseRequestContext) -> ResponseBody {
+    func readFile(path: String, range: ClosedRange<Int>, context: some BaseRequestContext, chunkSize: Int = NonBlockingFileIO.defaultChunkSize) -> ResponseBody {
         return ResponseBody(contentLength: range.count) { writer in
             try await self.fileIO.withFileHandle(path: path, mode: .read) { handle in
                 let endOffset = range.endIndex
-                let chunkSize = 8 * 1024
+                let chunkSize = chunkSize
                 var fileOffset = range.startIndex
 
                 while case .inRange(let offset) = fileOffset {


### PR DESCRIPTION
This PR lowers the CPU usage for file reads in `FileIO` by increasing the `chunkSize` to SwiftNIO's default value (`NonBlockingFileIO.defaultChunkSize`).

It also makes the `chunkSize` configurable for each read.

Fixes #470