### PR TITLE
Core request context storage

### DIFF
--- a/Sources/Hummingbird/Deprecations.swift
+++ b/Sources/Hummingbird/Deprecations.swift
@@ -33,8 +33,10 @@ public typealias HBFileIO = FileIO
 public typealias HBBaseRequestContext = BaseRequestContext
 @_documentation(visibility: internal) @available(*, deprecated, renamed: "BasicRequestContext")
 public typealias HBBasicRequestContext = BasicRequestContext
-@_documentation(visibility: internal) @available(*, deprecated, renamed: "CoreRequestContext")
-public typealias HBCoreRequestContext = CoreRequestContext
+@_documentation(visibility: internal) @available(*, deprecated, renamed: "CoreRequestContextStorage")
+public typealias HBCoreRequestContext = CoreRequestContextStorage
+@_documentation(visibility: internal) @available(*, deprecated, renamed: "CoreRequestContextStorage")
+public typealias CoreRequestContext = CoreRequestContextStorage
 @_documentation(visibility: internal) @available(*, deprecated, renamed: "RequestContext")
 public typealias HBRequestContext = RequestContext
 @_documentation(visibility: internal) @available(*, deprecated, renamed: "RequestDecoder")

--- a/Sources/Hummingbird/Server/RequestContext.swift
+++ b/Sources/Hummingbird/Server/RequestContext.swift
@@ -43,7 +43,7 @@ public protocol RequestContextSource {
 }
 
 /// Request context values required by Hummingbird itself.
-public struct CoreRequestContext: Sendable {
+public struct CoreRequestContextStorage: Sendable {
     /// ByteBuffer allocator used by request
     @usableFromInline
     let allocator: ByteBufferAllocator
@@ -76,7 +76,7 @@ public protocol BaseRequestContext: Sendable {
     /// Initialise RequestContext from source
     init(source: Source)
     /// Core context
-    var coreContext: CoreRequestContext { get set }
+    var coreContext: CoreRequestContextStorage { get set }
     /// Maximum upload size allowed for routes that don't stream the request payload. This
     /// limits how much memory would be used for one request
     var maxUploadSize: Int { get }
@@ -144,7 +144,7 @@ public protocol RequestContext: BaseRequestContext where Source == ServerRequest
 /// Implementation of a basic request context that supports everything the Hummingbird library needs
 public struct BasicRequestContext: RequestContext {
     /// core context
-    public var coreContext: CoreRequestContext
+    public var coreContext: CoreRequestContextStorage
 
     ///  Initialize an `RequestContext`
     /// - Parameters:

--- a/Sources/HummingbirdRouter/RouterBuilderContext.swift
+++ b/Sources/HummingbirdRouter/RouterBuilderContext.swift
@@ -35,7 +35,7 @@ public protocol RouterRequestContext: BaseRequestContext {
 /// Basic implementation of a context that can be used with `RouterBuilder``
 public struct BasicRouterRequestContext: RequestContext, RouterRequestContext {
     public var routerContext: RouterBuilderContext
-    public var coreContext: CoreRequestContext
+    public var coreContext: CoreRequestContextStorage
 
     public init(source: Source) {
         self.coreContext = .init(source: source)

--- a/Tests/HummingbirdRouterTests/RouterTests.swift
+++ b/Tests/HummingbirdRouterTests/RouterTests.swift
@@ -449,7 +449,7 @@ public struct TestRouterContext2: RouterRequestContext, RequestContext {
     /// router context
     public var routerContext: RouterBuilderContext
     /// core context
-    public var coreContext: CoreRequestContext
+    public var coreContext: CoreRequestContextStorage
 
     /// additional data
     public var string: String

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -372,7 +372,7 @@ final class ApplicationTests: XCTestCase {
 
     func testOptionalCodable() async throws {
         struct SortedJSONRequestContext: RequestContext {
-            var coreContext: CoreRequestContext
+            var coreContext: CoreRequestContextStorage
             var responseEncoder: JSONEncoder {
                 let encoder = JSONEncoder()
                 encoder.outputFormatting = .sortedKeys
@@ -453,7 +453,7 @@ final class ApplicationTests: XCTestCase {
                 self.coreContext = .init(source: source)
             }
 
-            var coreContext: CoreRequestContext
+            var coreContext: CoreRequestContextStorage
             var maxUploadSize: Int { 64 * 1024 }
         }
         let router = Router(context: MaxUploadRequestContext.self)
@@ -482,7 +482,7 @@ final class ApplicationTests: XCTestCase {
         /// Implementation of a basic request context that supports everything the Hummingbird library needs
         struct SocketAddressRequestContext: RequestContext {
             /// core context
-            var coreContext: CoreRequestContext
+            var coreContext: CoreRequestContextStorage
             // socket address
             let remoteAddress: SocketAddress?
 

--- a/Tests/HummingbirdTests/RouterTests.swift
+++ b/Tests/HummingbirdTests/RouterTests.swift
@@ -609,7 +609,7 @@ struct TestRouterContext2: RequestContext {
     }
 
     /// parameters
-    var coreContext: CoreRequestContext
+    var coreContext: CoreRequestContextStorage
 
     /// additional data
     var string: String

--- a/Tests/HummingbirdTests/URLEncodedForm/Application+URLEncodedFormTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/Application+URLEncodedFormTests.swift
@@ -26,7 +26,7 @@ class HummingBirdURLEncodedTests: XCTestCase {
     }
 
     struct URLEncodedCodingRequestContext: RequestContext {
-        var coreContext: CoreRequestContext
+        var coreContext: CoreRequestContextStorage
 
         init(source: Source) {
             self.coreContext = .init(source: source)


### PR DESCRIPTION
Differentiate between protocols for context and concrete types that are used in protocols
Would need to do this for auth and websocket as well