### PR TITLE
Make adding middleware a requirement of RouterMethods

### DIFF
--- a/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
@@ -22,7 +22,7 @@ public final class MiddlewareGroup<Context> {
     }
 
     /// Add middleware to group
-    /// 
+    ///
     /// This middleware will only be applied to endpoints added after this call.
     public func add(_ middleware: any RouterMiddleware<Context>) {
         self.middlewares.append(middleware)

--- a/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
@@ -22,6 +22,8 @@ public final class MiddlewareGroup<Context> {
     }
 
     /// Add middleware to group
+    /// 
+    /// This middleware will only be applied to endpoints added after this call.
     public func add(_ middleware: any RouterMiddleware<Context>) {
         self.middlewares.append(middleware)
     }

--- a/Sources/Hummingbird/Router/RouteCollection.swift
+++ b/Sources/Hummingbird/Router/RouteCollection.swift
@@ -64,11 +64,12 @@ public final class RouteCollection<Context: RequestContext>: RouterMethods {
 extension RouterMethods {
     /// Add route collection to router
     /// - Parameter collection: Route collection
-    public func addRoutes(_ collection: RouteCollection<Context>, atPath path: String = "") {
+    @discardableResult public func addRoutes(_ collection: RouteCollection<Context>, atPath path: String = "") -> Self {
         for route in collection.routes {
             // ensure path starts with a "/" and doesn't end with a "/"
             let path = self.combinePaths(path, route.path)
             self.on(path, method: route.method, responder: route.responder)
         }
+        return self
     }
 }

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -96,6 +96,15 @@ public final class Router<Context: RequestContext>: RouterMethods, HTTPResponder
     public func group(_ path: String = "") -> RouterGroup<Context> {
         return .init(path: path, router: self)
     }
+
+    /// Add middleware to Router
+    /// 
+    /// This middleware will only be applied to endpoints added after this call.
+    /// - Parameter middleware: Middleware we are adding
+    @discardableResult public func add(middleware: any RouterMiddleware<Context>) -> Self {
+        self.middlewares.add(middleware)
+        return self
+    }
 }
 
 /// Responder that return a not found error

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -98,7 +98,7 @@ public final class Router<Context: RequestContext>: RouterMethods, HTTPResponder
     }
 
     /// Add middleware to Router
-    /// 
+    ///
     /// This middleware will only be applied to endpoints added after this call.
     /// - Parameter middleware: Middleware we are adding
     @discardableResult public func add(middleware: any RouterMiddleware<Context>) -> Self {

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -34,6 +34,9 @@ public protocol RouterMethods<Context> {
 
     /// add group
     func group(_ path: String) -> RouterGroup<Context>
+
+    /// add middleware
+    func add(middleware: any RouterMiddleware<Context>) -> Self
 }
 
 extension RouterMethods {

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -34,7 +34,7 @@ final class MiddlewareTests: XCTestCase {
             }
         }
         let router = Router()
-        router.middlewares.add(TestMiddleware())
+        router.add(middleware: TestMiddleware())
         router.get("/hello") { _, _ -> String in
             return "Hello"
         }
@@ -56,8 +56,8 @@ final class MiddlewareTests: XCTestCase {
             }
         }
         let router = Router()
-        router.middlewares.add(TestMiddleware(string: "first"))
-        router.middlewares.add(TestMiddleware(string: "second"))
+        router.add(middleware: TestMiddleware(string: "first"))
+        router.add(middleware: TestMiddleware(string: "second"))
         router.get("/hello") { _, _ -> String in
             return "Hello"
         }
@@ -81,7 +81,7 @@ final class MiddlewareTests: XCTestCase {
             }
         }
         let router = Router()
-        router.middlewares.add(TestMiddleware())
+        router.add(middleware: TestMiddleware())
         router.get("/hello") { _, _ -> String in
             return "Hello"
         }
@@ -111,7 +111,7 @@ final class MiddlewareTests: XCTestCase {
             }
         }
         let router = Router()
-        router.middlewares.add(TestMiddleware())
+        router.add(middleware: TestMiddleware())
         let app = Application(responder: router.buildResponder())
 
         try await app.test(.router) { client in
@@ -184,7 +184,7 @@ final class MiddlewareTests: XCTestCase {
 
     func testCORSUseOrigin() async throws {
         let router = Router()
-        router.middlewares.add(CORSMiddleware())
+        router.add(middleware: CORSMiddleware())
         router.get("/hello") { _, _ -> String in
             return "Hello"
         }
@@ -199,7 +199,7 @@ final class MiddlewareTests: XCTestCase {
 
     func testCORSUseAll() async throws {
         let router = Router()
-        router.middlewares.add(CORSMiddleware(allowOrigin: .all))
+        router.add(middleware: CORSMiddleware(allowOrigin: .all))
         router.get("/hello") { _, _ -> String in
             return "Hello"
         }
@@ -214,7 +214,7 @@ final class MiddlewareTests: XCTestCase {
 
     func testCORSOptions() async throws {
         let router = Router()
-        router.middlewares.add(CORSMiddleware(
+        router.add(middleware: CORSMiddleware(
             allowOrigin: .all,
             allowHeaders: [.contentType, .authorization],
             allowMethods: [.get, .put, .delete, .options],
@@ -244,7 +244,7 @@ final class MiddlewareTests: XCTestCase {
 
     func testCORSHeadersAndErrors() async throws {
         let router = Router()
-        router.middlewares.add(CORSMiddleware())
+        router.add(middleware: CORSMiddleware())
         let app = Application(responder: router.buildResponder())
         try await app.test(.router) { client in
             try await client.execute(uri: "/hello", method: .get, headers: [.origin: "foo.com"]) { response in
@@ -257,7 +257,7 @@ final class MiddlewareTests: XCTestCase {
     func testLogRequestMiddleware() async throws {
         let logAccumalator = TestLogHandler.LogAccumalator()
         let router = Router()
-        router.middlewares.add(LogRequestsMiddleware(.info))
+        router.add(middleware: LogRequestsMiddleware(.info))
         router.get("test") { _, _ in
             return HTTPResponse.Status.ok
         }
@@ -382,7 +382,7 @@ final class MiddlewareTests: XCTestCase {
     func testLogRequestMiddlewareMultipleHeaders() async throws {
         let logAccumalator = TestLogHandler.LogAccumalator()
         let router = Router()
-        router.middlewares.add(LogRequestsMiddleware(.info, includeHeaders: [.test]))
+        router.add(middleware: LogRequestsMiddleware(.info, includeHeaders: [.test]))
         router.get("test") { _, _ in
             return HTTPResponse.Status.ok
         }


### PR DESCRIPTION
Means Router, RouterGroup and RouteCollection all have the same interface. Also made it more explicit that adding a middleware wiil only be applied to routes added after. This should be consistent across the three types.

Given this add `Router.add(middleware:)` I could remove access to the `Router.middlewares` but I think that is probably a move too far