### PR TITLE
Fix HTTP error serialization

### DIFF
--- a/Sources/Hummingbird/Error/HTTPError.swift
+++ b/Sources/Hummingbird/Error/HTTPError.swift
@@ -13,7 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import HTTPTypes
+import Foundation
 import NIOCore
+import NIOFoundationCompat
 
 /// Default HTTP error. Provides an HTTP status and a message
 public struct HTTPError: Error, HTTPResponseError, Sendable {
@@ -55,7 +57,18 @@ public struct HTTPError: Error, HTTPResponseError, Sendable {
 
     /// Get body of error as ByteBuffer
     public func body(allocator: ByteBufferAllocator) -> ByteBuffer? {
-        return self.body.map { allocator.buffer(string: "{\"error\":{\"message\":\"\($0)\"}}\n") }
+        do {
+            if let body {
+                var buffer = allocator.buffer(string: "{\"error\":{\"message\":")
+                try JSONEncoder().encode(body, into: &buffer)
+                buffer.writeString("}}\n")
+                return buffer
+            }
+
+            return nil
+        } catch {
+            return nil
+        }
     }
 }
 

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -726,6 +726,32 @@ final class ApplicationTests: XCTestCase {
         tlsConfig.trustRoots = .certificates([caCertificate])
         return tlsConfig
     }
+
+    func testHTTPError() throws {
+        let messages = [
+            "basic-message",
+            "String\"with\"escaping",
+            "String\non\nnewlines"
+        ]
+
+        for message in messages {
+            let error = HTTPError(.internalServerError, message: message)
+            guard let body = error.body(allocator: ByteBufferAllocator()) else {
+                return XCTFail()
+            }
+
+            let format = try JSONDecoder().decode(HTTPErrorFormat.self, from: body)
+            XCTAssertEqual(format.error.message, message)
+        }
+    }
+}
+
+struct HTTPErrorFormat: Decodable {
+    struct ErrorFormat: Decodable {
+        let message: String
+    }
+
+    let error: ErrorFormat
 }
 
 /// HTTPField used during tests


### PR DESCRIPTION
Before this PR, HTTPError would not apply escaping to characters inside the message String