### PR TITLE
Add FileIdentifier associated type to FileProvider

### DIFF
--- a/Sources/Hummingbird/Files/FileProvider.swift
+++ b/Sources/Hummingbird/Files/FileProvider.swift
@@ -25,14 +25,7 @@ public protocol FileProvider: Sendable {
     /// Get file identifier
     /// - Parameter path: path from URI
     /// - Returns: File Identifier
-    func getFileIdentifier(_ path: String) throws -> FileIdentifier
-
-    /// Append a file name component to a file identifier
-    /// - Parameter
-    ///   - filename: File name to append
-    ///   - path: File Identifier
-    /// - Returns: Resulting file identifier
-    func appendFilenameComponent(_ filename: String, to path: FileIdentifier) -> FileIdentifier?
+    func getFileIdentifier(_ path: String) -> FileIdentifier?
 
     /// Get file attributes
     /// - Parameter id: File identifier

--- a/Sources/Hummingbird/Files/FileProvider.swift
+++ b/Sources/Hummingbird/Files/FileProvider.swift
@@ -19,29 +19,38 @@ import NIOPosix
 public protocol FileProvider: Sendable {
     /// File attributes type
     associatedtype FileAttributes
+    /// File identifier
+    associatedtype FileIdentifier
 
-    /// Get full path name
+    /// Get file identifier
     /// - Parameter path: path from URI
-    /// - Returns: Full path
-    func getFullPath(_ path: String) -> String
+    /// - Returns: File Identifier
+    func getFileIdentifier(_ path: String) throws -> FileIdentifier
+
+    /// Append a file name component to a file identifier
+    /// - Parameter
+    ///   - filename: File name to append
+    ///   - path: File Identifier
+    /// - Returns: Resulting file identifier
+    func appendFilenameComponent(_ filename: String, to path: FileIdentifier) -> FileIdentifier?
 
     /// Get file attributes
-    /// - Parameter path: Full path to file
+    /// - Parameter id: File identifier
     /// - Returns: File attributes
-    func getAttributes(path: String) async throws -> FileAttributes?
+    func getAttributes(id: FileIdentifier) async throws -> FileAttributes?
 
     /// Return a reponse body that will write the file body
     /// - Parameters:
-    ///   - path: Full path to file
+    ///   - id: File identifier
     ///   - context: Request context
     /// - Returns: Response body
-    func loadFile(path: String, context: some RequestContext) async throws -> ResponseBody
+    func loadFile(id: FileIdentifier, context: some RequestContext) async throws -> ResponseBody
 
     /// Return a reponse body that will write a partial file body
     /// - Parameters:
-    ///   - path: Full path to file
+    ///   - id: File identifier
     ///   - range: Part of file to return
     ///   - context: Request context
     /// - Returns: Response body
-    func loadFile(path: String, range: ClosedRange<Int>, context: some RequestContext) async throws -> ResponseBody
+    func loadFile(id: FileIdentifier, range: ClosedRange<Int>, context: some RequestContext) async throws -> ResponseBody
 }

--- a/Sources/Hummingbird/Files/LocalFileSystem.swift
+++ b/Sources/Hummingbird/Files/LocalFileSystem.swift
@@ -35,6 +35,9 @@ public struct LocalFileSystem: FileProvider {
         }
     }
 
+    /// File Identifier (Fully qualified path)
+    public typealias FileIdentifier = String
+
     let rootFolder: String
     let fileIO: FileIO
 
@@ -68,7 +71,7 @@ public struct LocalFileSystem: FileProvider {
     /// Get full path name with local file system root prefixed
     /// - Parameter path: path from URI
     /// - Returns: Full path
-    public func getFullPath(_ path: String) -> String {
+    public func getFileIdentifier(_ path: String) throws -> FileIdentifier {
         if path.first == "/" {
             return "\(self.rootFolder)\(path.dropFirst())"
         } else {
@@ -76,10 +79,23 @@ public struct LocalFileSystem: FileProvider {
         }
     }
 
+    /// Append a file name component to a file identifier
+    /// - Parameter
+    ///   - filename: File name to append
+    ///   - path: File Identifier
+    /// - Returns: Resulting file identifier
+    func appendingFilenameComponent(_ filename: String, to path: FileIdentifier) -> FileIdentifier? {
+        if path.last == "/" {
+            return "\(path)\(filename)"
+        } else {
+            return "\(path)/\(filename)"
+        }
+    }
+
     /// Get file attributes
-    /// - Parameter path: Full path to file
+    /// - Parameter id: FileIdentifier
     /// - Returns: File attributes
-    public func getAttributes(path: String) async throws -> FileAttributes? {
+    public func getAttributes(id path: FileIdentifier) async throws -> FileAttributes? {
         do {
             let lstat = try await self.fileIO.fileIO.lstat(path: path)
             let isFolder = (lstat.st_mode & S_IFMT) == S_IFDIR
@@ -100,20 +116,20 @@ public struct LocalFileSystem: FileProvider {
 
     /// Return a reponse body that will write the file body
     /// - Parameters:
-    ///   - path: Full path to file
+    ///   - id: FileIdentifier
     ///   - context: Request context
     /// - Returns: Response body
-    public func loadFile(path: String, context: some RequestContext) async throws -> ResponseBody {
+    public func loadFile(id path: FileIdentifier, context: some RequestContext) async throws -> ResponseBody {
         try await self.fileIO.loadFile(path: path, context: context)
     }
 
     /// Return a reponse body that will write a partial file body
     /// - Parameters:
-    ///   - path: Full path to file
+    ///   - id: FileIdentifier
     ///   - range: Part of file to return
     ///   - context: Request context
     /// - Returns: Response body
-    public func loadFile(path: String, range: ClosedRange<Int>, context: some RequestContext) async throws -> ResponseBody {
+    public func loadFile(id path: FileIdentifier, range: ClosedRange<Int>, context: some RequestContext) async throws -> ResponseBody {
         try await self.fileIO.loadFile(path: path, range: range, context: context)
     }
 }

--- a/Sources/Hummingbird/Files/LocalFileSystem.swift
+++ b/Sources/Hummingbird/Files/LocalFileSystem.swift
@@ -71,24 +71,11 @@ public struct LocalFileSystem: FileProvider {
     /// Get full path name with local file system root prefixed
     /// - Parameter path: path from URI
     /// - Returns: Full path
-    public func getFileIdentifier(_ path: String) throws -> FileIdentifier {
+    public func getFileIdentifier(_ path: String) -> FileIdentifier? {
         if path.first == "/" {
             return "\(self.rootFolder)\(path.dropFirst())"
         } else {
             return "\(self.rootFolder)\(path)"
-        }
-    }
-
-    /// Append a file name component to a file identifier
-    /// - Parameter
-    ///   - filename: File name to append
-    ///   - path: File Identifier
-    /// - Returns: Resulting file identifier
-    func appendingFilenameComponent(_ filename: String, to path: FileIdentifier) -> FileIdentifier? {
-        if path.last == "/" {
-            return "\(path)\(filename)"
-        } else {
-            return "\(path)/\(filename)"
         }
     }
 

--- a/Tests/HummingbirdTests/FileMiddlewareTests.swift
+++ b/Tests/HummingbirdTests/FileMiddlewareTests.swift
@@ -341,21 +341,21 @@ class FileMiddlewareTests: XCTestCase {
                 self.files = [:]
             }
 
-            func getFullPath(_ path: String) -> String {
+            func getFileIdentifier(_ path: String) -> String? {
                 return path
             }
 
-            func getAttributes(path: String) async throws -> FileAttributes? {
+            func getAttributes(id path: String) async throws -> FileAttributes? {
                 guard let file = files[path] else { return nil }
                 return .init(size: file.readableBytes)
             }
 
-            func loadFile(path: String, context: some RequestContext) async throws -> ResponseBody {
+            func loadFile(id path: String, context: some RequestContext) async throws -> ResponseBody {
                 guard let file = files[path] else { throw HTTPError(.notFound) }
                 return .init(byteBuffer: file)
             }
 
-            func loadFile(path: String, range: ClosedRange<Int>, context: some RequestContext) async throws -> ResponseBody {
+            func loadFile(id path: String, range: ClosedRange<Int>, context: some RequestContext) async throws -> ResponseBody {
                 guard let file = files[path] else { throw HTTPError(.notFound) }
                 guard let slice = file.getSlice(at: range.lowerBound, length: range.count) else { throw HTTPError(.rangeNotSatisfiable) }
                 return .init(byteBuffer: slice)


### PR DESCRIPTION
Allow for FileProviders that may not use Strings to identify their files