### PR TITLE
Use TaskLocal instead of ServiceContext for state when building router

### DIFF
--- a/Sources/HummingbirdRouter/Route.swift
+++ b/Sources/HummingbirdRouter/Route.swift
@@ -14,7 +14,6 @@
 
 import HTTPTypes
 import Hummingbird
-import ServiceContextModule
 
 /// Route definition
 public struct Route<Handler: _RouteHandlerProtocol, Context: RouterRequestContext>: RouterMiddleware where Handler.Context == Context {
@@ -33,8 +32,7 @@ public struct Route<Handler: _RouteHandlerProtocol, Context: RouterRequestContex
     ///   - routerPath: Route path, relative to group route is defined in
     ///   - handler: Route handler
     init(_ method: HTTPRequest.Method, _ routerPath: RouterPath = "", handler: Handler) {
-        let serviceContext = ServiceContext.current ?? ServiceContext.topLevel
-        let options = serviceContext.routerBuildState?.options ?? []
+        let options = RouterBuilderState.current?.options ?? []
         var routerPath = routerPath
         if options.contains(.caseInsensitive) {
             routerPath = routerPath.lowercased()
@@ -95,7 +93,7 @@ public struct Route<Handler: _RouteHandlerProtocol, Context: RouterRequestContex
 
     /// Return full path of route, using Task local stored `routeGroupPath`.
     static func getFullPath(from path: RouterPath) -> String {
-        let parentGroupPath = ServiceContext.current?.routerBuildState?.routeGroupPath ?? ""
+        let parentGroupPath = RouterBuilderState.current?.routeGroupPath ?? ""
         if path.count > 0 || parentGroupPath.count == 0 {
             return "\(parentGroupPath)/\(path)"
         } else {

--- a/Sources/HummingbirdRouter/RouteGroup.swift
+++ b/Sources/HummingbirdRouter/RouteGroup.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import Hummingbird
-import ServiceContextModule
 
 /// Router middleware that applies a middleware chain to URIs with a specified prefix
 public struct RouteGroup<Context: RouterRequestContext, Handler: MiddlewareProtocol>: RouterMiddleware where Handler.Input == Request, Handler.Output == Response, Handler.Context == Context {
@@ -40,21 +39,14 @@ public struct RouteGroup<Context: RouterRequestContext, Handler: MiddlewareProto
     ) {
         var routerPath = routerPath
         // Get builder state from service context
-        var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
-        var routerBuildState: RouterBuilderState
-        if let state = serviceContext.routerBuildState {
-            routerBuildState = state
-        } else {
-            routerBuildState = .init(options: [])
-        }
+        var routerBuildState: RouterBuilderState = RouterBuilderState.current ?? .init(options: [])
         if routerBuildState.options.contains(.caseInsensitive) {
             routerPath = routerPath.lowercased()
         }
         let parentGroupPath = routerBuildState.routeGroupPath
         self.fullPath = "\(parentGroupPath)/\(routerPath)"
         routerBuildState.routeGroupPath = self.fullPath
-        serviceContext.routerBuildState = routerBuildState
-        self.handler = ServiceContext.$current.withValue(serviceContext) {
+        self.handler = RouterBuilderState.$current.withValue(routerBuildState) {
             builder()
         }
         self.routerPath = routerPath

--- a/Sources/HummingbirdRouter/RouteGroup.swift
+++ b/Sources/HummingbirdRouter/RouteGroup.swift
@@ -39,7 +39,7 @@ public struct RouteGroup<Context: RouterRequestContext, Handler: MiddlewareProto
     ) {
         var routerPath = routerPath
         // Get builder state from service context
-        var routerBuildState: RouterBuilderState = RouterBuilderState.current ?? .init(options: [])
+        var routerBuildState = RouterBuilderState.current ?? .init(options: [])
         if routerBuildState.options.contains(.caseInsensitive) {
             routerPath = routerPath.lowercased()
         }

--- a/Sources/HummingbirdRouter/RouterBuilder.swift
+++ b/Sources/HummingbirdRouter/RouterBuilder.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import Hummingbird
-import ServiceContextModule
 
 /// Router Options
 public struct RouterBuilderOptions: OptionSet, Sendable {
@@ -45,10 +44,8 @@ public struct RouterBuilder<Context: RouterRequestContext, Handler: MiddlewarePr
         options: RouterBuilderOptions = [],
         @MiddlewareFixedTypeBuilder<Input, Output, Context> builder: () -> Handler
     ) {
-        var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
-        serviceContext.routerBuildState = .init(options: options)
         self.options = options
-        self.handler = ServiceContext.$current.withValue(serviceContext) {
+        self.handler = RouterBuilderState.$current.withValue(.init(options: options)) {
             builder()
         }
     }

--- a/Sources/HummingbirdRouter/RouterBuilderState.swift
+++ b/Sources/HummingbirdRouter/RouterBuilderState.swift
@@ -16,23 +16,7 @@ import ServiceContextModule
 
 /// Router builder state used when building Router
 internal struct RouterBuilderState {
+    @TaskLocal static var current: RouterBuilderState?
     var routeGroupPath: String = ""
     let options: RouterBuilderOptions
-}
-
-extension ServiceContext {
-    enum RouterBuilderStateKey: ServiceContextKey {
-        typealias Value = RouterBuilderState
-    }
-
-    /// Current RouteGroup path. This is used to propagate the route path down
-    /// through the Router result builder
-    internal var routerBuildState: RouterBuilderState? {
-        get {
-            self[RouterBuilderStateKey.self]
-        }
-        set {
-            self[RouterBuilderStateKey.self] = newValue
-        }
-    }
 }


### PR DESCRIPTION
Given the response to https://forums.swift.org/t/tasklocal-memory-usage/72709 I think we can use an independent TaskLocal for building the router, instead of using the ServiceContext task local