### PR TITLE
Remove unnecessary @availables

### DIFF
--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedForm.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedForm.swift
@@ -46,7 +46,6 @@ internal enum URLEncodedForm {
     /// ASCII characters that will not be percent encoded in URL encoded form data
     static let unreservedCharacters = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~")
 
-    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
     /// ISO8601 data formatter used throughout URL encoded form code
     static var iso8601Formatter: ISO8601DateFormatter {
         let formatter = ISO8601DateFormatter()

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -32,7 +32,6 @@ public struct URLEncodedFormDecoder: Sendable {
         case millisecondsSince1970
 
         /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
-        @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
         case iso8601
 
         /// Decode the `Date` as a string parsed by the given formatter.

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormEncoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormEncoder.swift
@@ -32,7 +32,6 @@ public struct URLEncodedFormEncoder: Sendable {
         case millisecondsSince1970
 
         /// Encode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
-        @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
         case iso8601
 
         /// Encode the `Date` as a string parsed by the given formatter.

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -22,7 +22,6 @@ import Tracing
 ///
 /// You may opt in to recording a specific subset of HTTP request/response header values by passing
 /// a set of header names.
-@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public struct TracingMiddleware<Context: RequestContext>: RouterMiddleware {
     private let headerNamesToRecord: Set<RecordingHeader>
     private let attributes: SpanAttributes?

--- a/Sources/HummingbirdCore/Server/Server.swift
+++ b/Sources/HummingbirdCore/Server/Server.swift
@@ -249,7 +249,6 @@ public actor Server<ChildChannel: ServerChildChannel>: Service {
 
     #if canImport(Network)
     /// create a NIOTransportServices bootstrap using Network.framework
-    @available(macOS 10.14, iOS 12, tvOS 12, *)
     private nonisolated func createTSBootstrap(
         configuration: ServerConfiguration
     ) -> NIOTSListenerBootstrap? {
@@ -291,7 +290,6 @@ protocol ServerBootstrapProtocol {
 extension ServerBootstrap: ServerBootstrapProtocol {}
 
 #if canImport(Network)
-@available(macOS 10.14, iOS 12, tvOS 12, *)
 extension NIOTSListenerBootstrap: ServerBootstrapProtocol {
     // need to be able to extend `NIOTSListenerBootstrap` to conform to `ServerBootstrapProtocol`
     // before we can use TransportServices

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -578,9 +578,6 @@ final class TracingTests: XCTestCase {
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-
-@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension TracingTests {
     /// Test tracing middleware serviceContext is propagated to async route handlers
     func testServiceContextPropagationAsync() async throws {
@@ -615,8 +612,6 @@ extension TracingTests {
         XCTAssertEqual(span2.context.traceID, span.context.traceID)
     }
 }
-
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// TestID Key used in tests
 internal enum TestIDKey: ServiceContextKey {

--- a/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
@@ -129,7 +129,6 @@ class URLDecodedFormDecoderTests: XCTestCase {
         self.testForm(test, query: "a[one]=1&a[three]=3&a[two]=2")
     }
 
-    @available(iOS 10.0, tvOS 10.0, *)
     func testDateDecode() {
         struct Test: Codable, Equatable {
             let d: Date

--- a/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
@@ -139,7 +139,6 @@ class URLEncodedFormEncoderTests: XCTestCase {
         self.testForm(test, query: "a[one]=1&a[three]=3&a[two]=2")
     }
 
-    @available(iOS 10.0, tvOS 10.0, *)
     func testDateEncode() {
         struct Test: Codable {
             let d: Date


### PR DESCRIPTION
We require macOS 14 so there is no need to have `@available(macOS some OS less than 14, *)` in the code