### PR TITLE
Enable the builder pattern on MiddlewareGroup

### DIFF
--- a/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
@@ -24,8 +24,9 @@ public final class MiddlewareGroup<Context> {
     /// Add middleware to group
     ///
     /// This middleware will only be applied to endpoints added after this call.
-    public func add(_ middleware: any RouterMiddleware<Context>) {
+    @discardableResult public func add(_ middleware: any RouterMiddleware<Context>) -> Self {
         self.middlewares.append(middleware)
+        return self
     }
 
     /// Construct responder chain from this middleware group


### PR DESCRIPTION
- Makes the `MiddlewareGroup.add(_ middleware:)` function return itself

This enables the following API:

```swift
let router = Router()

router.middlewares
    .add(LogRequestsMiddleware(.info))
    .add(MyMiddleware())
    .add(...)

```