### PR TITLE
MetricsMiddleware: Set hb_uri to NotFound for 404 errors

### DIFF
--- a/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
@@ -55,6 +55,7 @@ public struct MetricsMiddleware<Context: RequestContext>: RouterMiddleware {
                 Counter(label: "hb_requests", dimensions: dimensions).increment()
             } else {
                 dimensions = [
+                    ("hb_uri", "NotFound"),
                     ("hb_method", request.method.rawValue),
                 ]
             }

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -236,9 +236,11 @@ final class MetricsTests: XCTestCase {
         let counter = try XCTUnwrap(Self.testMetrics.counters["hb_errors"] as? TestCounter)
         XCTAssertEqual(counter.values.count, 1)
         XCTAssertEqual(counter.values[0].1, 1)
-        XCTAssertEqual(counter.dimensions.count, 1)
-        XCTAssertEqual(counter.dimensions[0].0, "hb_method")
-        XCTAssertEqual(counter.dimensions[0].1, "GET")
+        XCTAssertEqual(counter.dimensions.count, 2)
+        XCTAssertEqual(counter.dimensions[0].0, "hb_uri")
+        XCTAssertEqual(counter.dimensions[0].1, "NotFound")
+        XCTAssertEqual(counter.dimensions[1].0, "hb_method")
+        XCTAssertEqual(counter.dimensions[1].1, "GET")
     }
 
     func testParameterEndpoint() async throws {


### PR DESCRIPTION
This PR modifies the MetricsMiddleware to always set a `hb_uri` dimension, even if the error is a 404. To keep with the spirit of #47, the dimension's value is set to `"NotFound"` instead of the uri, which would be an unbounded value.

## Motivation

1. Prevents unbounded dimension values using the same method as #482; hard coding a string instead of dropping the dimension.
2. Works around an implementation limitation with [swift-prometheus](https://github.com/swift-server/swift-prometheus) where the library detects when the dimension[^1] set for a metric has changed and [crashes the application](https://github.com/swift-server/swift-prometheus/blob/bfcd4bbfabe11aae4b035424ee9724582e288501/Sources/Prometheus/PrometheusCollectorRegistry.swift#L136) with a `fatalError`.

[^1]: aka label, in Prometheus' terminology