### PR TITLE
Add test dependency to fix linking error in unit tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -127,6 +127,7 @@ let package = Package(
             .byName(name: "HummingbirdTLS"),
             .byName(name: "HummingbirdHTTP2"),
             .byName(name: "HummingbirdTesting"),
+			.byName(name: "HummingbirdRouter"),
         ]),
         .testTarget(name: "HummingbirdRouterTests", dependencies: [
             .byName(name: "HummingbirdRouter"),

--- a/Package.swift
+++ b/Package.swift
@@ -6,144 +6,144 @@ import PackageDescription
 let swiftSettings: [SwiftSetting] = [.enableExperimentalFeature("StrictConcurrency=complete")]
 
 let package = Package(
-	name: "hummingbird",
-	platforms: [.macOS(.v14), .iOS(.v17), .tvOS(.v17)],
-	products: [
-		.library(name: "Hummingbird", targets: ["Hummingbird"]),
-		.library(name: "HummingbirdCore", targets: ["HummingbirdCore"]),
-		.library(name: "HummingbirdHTTP2", targets: ["HummingbirdHTTP2"]),
-		.library(name: "HummingbirdTLS", targets: ["HummingbirdTLS"]),
-		.library(name: "HummingbirdRouter", targets: ["HummingbirdRouter"]),
-		.library(name: "HummingbirdTesting", targets: ["HummingbirdTesting"]),
-		.executable(name: "PerformanceTest", targets: ["PerformanceTest"]),
-	],
-	dependencies: [
-		.package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
-		.package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
-		.package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
-		.package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
-		.package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
-		.package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
-		.package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.1"),
-		.package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
-		.package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.20.0"),
-		.package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
-		.package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
-		.package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.20.0"),
-		.package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
-		.package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
-	],
-	targets: [
-		.target(
-			name: "Hummingbird",
-			dependencies: [
-				.byName(name: "HummingbirdCore"),
-				.product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
-				.product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
-				.product(name: "Atomics", package: "swift-atomics"),
-				.product(name: "HTTPTypes", package: "swift-http-types"),
-				.product(name: "Logging", package: "swift-log"),
-				.product(name: "Metrics", package: "swift-metrics"),
-				.product(name: "Tracing", package: "swift-distributed-tracing"),
-				.product(name: "NIOCore", package: "swift-nio"),
-				.product(name: "NIOPosix", package: "swift-nio"),
-			],
-			swiftSettings: swiftSettings
-		),
-		.target(
-			name: "HummingbirdCore",
-			dependencies: [
-				.product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
-				.product(name: "Collections", package: "swift-collections"),
-				.product(name: "HTTPTypes", package: "swift-http-types"),
-				.product(name: "Logging", package: "swift-log"),
-				.product(name: "NIOCore", package: "swift-nio"),
-				.product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
-				.product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
-				.product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
-				.product(name: "NIOExtras", package: "swift-nio-extras"),
-				.product(name: "NIOPosix", package: "swift-nio"),
-				.product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
-				.product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
-			],
-			swiftSettings: swiftSettings
-		),
-		.target(
-			name: "HummingbirdRouter",
-			dependencies: [
-				.byName(name: "Hummingbird"),
-				.product(name: "Logging", package: "swift-log"),
-			],
-			swiftSettings: swiftSettings
-		),
-		.target(
-			name: "HummingbirdTesting",
-			dependencies: [
-				.byName(name: "Hummingbird"),
-				.product(name: "AsyncHTTPClient", package: "async-http-client"),
-				.product(name: "HTTPTypes", package: "swift-http-types"),
-				.product(name: "NIOCore", package: "swift-nio"),
-				.product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
-				.product(name: "NIOEmbedded", package: "swift-nio"),
-				.product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
-				.product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
-				.product(name: "NIOPosix", package: "swift-nio"),
-				.product(name: "NIOSSL", package: "swift-nio-ssl"),
-			],
-			swiftSettings: swiftSettings
-		),
-		.target(
-			name: "HummingbirdHTTP2",
-			dependencies: [
-				.byName(name: "HummingbirdCore"),
-				.product(name: "NIOCore", package: "swift-nio"),
-				.product(name: "NIOHTTP2", package: "swift-nio-http2"),
-				.product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
-				.product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
-				.product(name: "NIOHTTPTypesHTTP2", package: "swift-nio-extras"),
-				.product(name: "NIOSSL", package: "swift-nio-ssl"),
-			]
-		),
-		.target(
-			name: "HummingbirdTLS",
-			dependencies: [
-				.byName(name: "HummingbirdCore"),
-				.product(name: "NIOCore", package: "swift-nio"),
-				.product(name: "NIOSSL", package: "swift-nio-ssl"),
-			],
-			swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
-		),
-		.executableTarget(
-			name: "PerformanceTest",
-			dependencies: [
-				.byName(name: "Hummingbird"),
-				.product(name: "NIOPosix", package: "swift-nio"),
-			],
-			swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
-		),
-		// test targets
-		.testTarget(name: "HummingbirdTests", dependencies: [
-			.byName(name: "Hummingbird"),
-			.byName(name: "HummingbirdTLS"),
-			.byName(name: "HummingbirdHTTP2"),
-			.byName(name: "HummingbirdTesting"),
-			.byName(name: "HummingbirdRouter"),
-		]),
-		.testTarget(name: "HummingbirdRouterTests", dependencies: [
-			.byName(name: "HummingbirdRouter"),
-			.byName(name: "HummingbirdTesting"),
-		]),
-		.testTarget(
-			name: "HummingbirdCoreTests",
-			dependencies:
-			[
-				.byName(name: "HummingbirdCore"),
-				.byName(name: "HummingbirdHTTP2"),
-				.byName(name: "HummingbirdTLS"),
-				.byName(name: "HummingbirdTesting"),
-				.product(name: "AsyncHTTPClient", package: "async-http-client"),
-			],
-			resources: [.process("Certificates")]
-		),
-	]
+    name: "hummingbird",
+    platforms: [.macOS(.v14), .iOS(.v17), .tvOS(.v17)],
+    products: [
+        .library(name: "Hummingbird", targets: ["Hummingbird"]),
+        .library(name: "HummingbirdCore", targets: ["HummingbirdCore"]),
+        .library(name: "HummingbirdHTTP2", targets: ["HummingbirdHTTP2"]),
+        .library(name: "HummingbirdTLS", targets: ["HummingbirdTLS"]),
+        .library(name: "HummingbirdRouter", targets: ["HummingbirdRouter"]),
+        .library(name: "HummingbirdTesting", targets: ["HummingbirdTesting"]),
+        .executable(name: "PerformanceTest", targets: ["PerformanceTest"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
+        .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
+        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.20.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.20.0"),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
+    ],
+    targets: [
+        .target(
+            name: "Hummingbird",
+            dependencies: [
+                .byName(name: "HummingbirdCore"),
+                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+                .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+                .product(name: "Atomics", package: "swift-atomics"),
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Metrics", package: "swift-metrics"),
+                .product(name: "Tracing", package: "swift-distributed-tracing"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+            ],
+            swiftSettings: swiftSettings
+        ),
+        .target(
+            name: "HummingbirdCore",
+            dependencies: [
+                .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+                .product(name: "Collections", package: "swift-collections"),
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
+                .product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
+                .product(name: "NIOExtras", package: "swift-nio-extras"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
+                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+            ],
+            swiftSettings: swiftSettings
+        ),
+        .target(
+            name: "HummingbirdRouter",
+            dependencies: [
+                .byName(name: "Hummingbird"),
+                .product(name: "Logging", package: "swift-log"),
+            ],
+            swiftSettings: swiftSettings
+        ),
+        .target(
+            name: "HummingbirdTesting",
+            dependencies: [
+                .byName(name: "Hummingbird"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
+                .product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
+                .product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
+            ],
+            swiftSettings: swiftSettings
+        ),
+        .target(
+            name: "HummingbirdHTTP2",
+            dependencies: [
+                .byName(name: "HummingbirdCore"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOHTTP2", package: "swift-nio-http2"),
+                .product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
+                .product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
+                .product(name: "NIOHTTPTypesHTTP2", package: "swift-nio-extras"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
+            ]
+        ),
+        .target(
+            name: "HummingbirdTLS",
+            dependencies: [
+                .byName(name: "HummingbirdCore"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
+            ],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+        ),
+        .executableTarget(
+            name: "PerformanceTest",
+            dependencies: [
+                .byName(name: "Hummingbird"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+            ],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+        ),
+        // test targets
+        .testTarget(name: "HummingbirdTests", dependencies: [
+            .byName(name: "Hummingbird"),
+            .byName(name: "HummingbirdTLS"),
+            .byName(name: "HummingbirdHTTP2"),
+            .byName(name: "HummingbirdTesting"),
+            .byName(name: "HummingbirdRouter"),
+        ]),
+        .testTarget(name: "HummingbirdRouterTests", dependencies: [
+            .byName(name: "HummingbirdRouter"),
+            .byName(name: "HummingbirdTesting"),
+        ]),
+        .testTarget(
+            name: "HummingbirdCoreTests",
+            dependencies:
+            [
+                .byName(name: "HummingbirdCore"),
+                .byName(name: "HummingbirdHTTP2"),
+                .byName(name: "HummingbirdTLS"),
+                .byName(name: "HummingbirdTesting"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            ],
+            resources: [.process("Certificates")]
+        ),
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -6,144 +6,144 @@ import PackageDescription
 let swiftSettings: [SwiftSetting] = [.enableExperimentalFeature("StrictConcurrency=complete")]
 
 let package = Package(
-    name: "hummingbird",
-    platforms: [.macOS(.v14), .iOS(.v17), .tvOS(.v17)],
-    products: [
-        .library(name: "Hummingbird", targets: ["Hummingbird"]),
-        .library(name: "HummingbirdCore", targets: ["HummingbirdCore"]),
-        .library(name: "HummingbirdHTTP2", targets: ["HummingbirdHTTP2"]),
-        .library(name: "HummingbirdTLS", targets: ["HummingbirdTLS"]),
-        .library(name: "HummingbirdRouter", targets: ["HummingbirdRouter"]),
-        .library(name: "HummingbirdTesting", targets: ["HummingbirdTesting"]),
-        .executable(name: "PerformanceTest", targets: ["PerformanceTest"]),
-    ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
-        .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
-        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.1"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
-        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.20.0"),
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.20.0"),
-        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
-    ],
-    targets: [
-        .target(
-            name: "Hummingbird",
-            dependencies: [
-                .byName(name: "HummingbirdCore"),
-                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
-                .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
-                .product(name: "Atomics", package: "swift-atomics"),
-                .product(name: "HTTPTypes", package: "swift-http-types"),
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "Metrics", package: "swift-metrics"),
-                .product(name: "Tracing", package: "swift-distributed-tracing"),
-                .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOPosix", package: "swift-nio"),
-            ],
-            swiftSettings: swiftSettings
-        ),
-        .target(
-            name: "HummingbirdCore",
-            dependencies: [
-                .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
-                .product(name: "Collections", package: "swift-collections"),
-                .product(name: "HTTPTypes", package: "swift-http-types"),
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
-                .product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
-                .product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
-                .product(name: "NIOExtras", package: "swift-nio-extras"),
-                .product(name: "NIOPosix", package: "swift-nio"),
-                .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
-                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
-            ],
-            swiftSettings: swiftSettings
-        ),
-        .target(
-            name: "HummingbirdRouter",
-            dependencies: [
-                .byName(name: "Hummingbird"),
-                .product(name: "Logging", package: "swift-log"),
-            ],
-            swiftSettings: swiftSettings
-        ),
-        .target(
-            name: "HummingbirdTesting",
-            dependencies: [
-                .byName(name: "Hummingbird"),
-                .product(name: "AsyncHTTPClient", package: "async-http-client"),
-                .product(name: "HTTPTypes", package: "swift-http-types"),
-                .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
-                .product(name: "NIOEmbedded", package: "swift-nio"),
-                .product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
-                .product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
-                .product(name: "NIOPosix", package: "swift-nio"),
-                .product(name: "NIOSSL", package: "swift-nio-ssl"),
-            ],
-            swiftSettings: swiftSettings
-        ),
-        .target(
-            name: "HummingbirdHTTP2",
-            dependencies: [
-                .byName(name: "HummingbirdCore"),
-                .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOHTTP2", package: "swift-nio-http2"),
-                .product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
-                .product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
-                .product(name: "NIOHTTPTypesHTTP2", package: "swift-nio-extras"),
-                .product(name: "NIOSSL", package: "swift-nio-ssl"),
-            ]
-        ),
-        .target(
-            name: "HummingbirdTLS",
-            dependencies: [
-                .byName(name: "HummingbirdCore"),
-                .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOSSL", package: "swift-nio-ssl"),
-            ],
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
-        ),
-        .executableTarget(
-            name: "PerformanceTest",
-            dependencies: [
-                .byName(name: "Hummingbird"),
-                .product(name: "NIOPosix", package: "swift-nio"),
-            ],
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
-        ),
-        // test targets
-        .testTarget(name: "HummingbirdTests", dependencies: [
-            .byName(name: "Hummingbird"),
-            .byName(name: "HummingbirdTLS"),
-            .byName(name: "HummingbirdHTTP2"),
-            .byName(name: "HummingbirdTesting"),
+	name: "hummingbird",
+	platforms: [.macOS(.v14), .iOS(.v17), .tvOS(.v17)],
+	products: [
+		.library(name: "Hummingbird", targets: ["Hummingbird"]),
+		.library(name: "HummingbirdCore", targets: ["HummingbirdCore"]),
+		.library(name: "HummingbirdHTTP2", targets: ["HummingbirdHTTP2"]),
+		.library(name: "HummingbirdTLS", targets: ["HummingbirdTLS"]),
+		.library(name: "HummingbirdRouter", targets: ["HummingbirdRouter"]),
+		.library(name: "HummingbirdTesting", targets: ["HummingbirdTesting"]),
+		.executable(name: "PerformanceTest", targets: ["PerformanceTest"]),
+	],
+	dependencies: [
+		.package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
+		.package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
+		.package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
+		.package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
+		.package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
+		.package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
+		.package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.1"),
+		.package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
+		.package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.20.0"),
+		.package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
+		.package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
+		.package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.20.0"),
+		.package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
+		.package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
+	],
+	targets: [
+		.target(
+			name: "Hummingbird",
+			dependencies: [
+				.byName(name: "HummingbirdCore"),
+				.product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+				.product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+				.product(name: "Atomics", package: "swift-atomics"),
+				.product(name: "HTTPTypes", package: "swift-http-types"),
+				.product(name: "Logging", package: "swift-log"),
+				.product(name: "Metrics", package: "swift-metrics"),
+				.product(name: "Tracing", package: "swift-distributed-tracing"),
+				.product(name: "NIOCore", package: "swift-nio"),
+				.product(name: "NIOPosix", package: "swift-nio"),
+			],
+			swiftSettings: swiftSettings
+		),
+		.target(
+			name: "HummingbirdCore",
+			dependencies: [
+				.product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+				.product(name: "Collections", package: "swift-collections"),
+				.product(name: "HTTPTypes", package: "swift-http-types"),
+				.product(name: "Logging", package: "swift-log"),
+				.product(name: "NIOCore", package: "swift-nio"),
+				.product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+				.product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
+				.product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
+				.product(name: "NIOExtras", package: "swift-nio-extras"),
+				.product(name: "NIOPosix", package: "swift-nio"),
+				.product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
+				.product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+			],
+			swiftSettings: swiftSettings
+		),
+		.target(
+			name: "HummingbirdRouter",
+			dependencies: [
+				.byName(name: "Hummingbird"),
+				.product(name: "Logging", package: "swift-log"),
+			],
+			swiftSettings: swiftSettings
+		),
+		.target(
+			name: "HummingbirdTesting",
+			dependencies: [
+				.byName(name: "Hummingbird"),
+				.product(name: "AsyncHTTPClient", package: "async-http-client"),
+				.product(name: "HTTPTypes", package: "swift-http-types"),
+				.product(name: "NIOCore", package: "swift-nio"),
+				.product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+				.product(name: "NIOEmbedded", package: "swift-nio"),
+				.product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
+				.product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
+				.product(name: "NIOPosix", package: "swift-nio"),
+				.product(name: "NIOSSL", package: "swift-nio-ssl"),
+			],
+			swiftSettings: swiftSettings
+		),
+		.target(
+			name: "HummingbirdHTTP2",
+			dependencies: [
+				.byName(name: "HummingbirdCore"),
+				.product(name: "NIOCore", package: "swift-nio"),
+				.product(name: "NIOHTTP2", package: "swift-nio-http2"),
+				.product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
+				.product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
+				.product(name: "NIOHTTPTypesHTTP2", package: "swift-nio-extras"),
+				.product(name: "NIOSSL", package: "swift-nio-ssl"),
+			]
+		),
+		.target(
+			name: "HummingbirdTLS",
+			dependencies: [
+				.byName(name: "HummingbirdCore"),
+				.product(name: "NIOCore", package: "swift-nio"),
+				.product(name: "NIOSSL", package: "swift-nio-ssl"),
+			],
+			swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+		),
+		.executableTarget(
+			name: "PerformanceTest",
+			dependencies: [
+				.byName(name: "Hummingbird"),
+				.product(name: "NIOPosix", package: "swift-nio"),
+			],
+			swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+		),
+		// test targets
+		.testTarget(name: "HummingbirdTests", dependencies: [
+			.byName(name: "Hummingbird"),
+			.byName(name: "HummingbirdTLS"),
+			.byName(name: "HummingbirdHTTP2"),
+			.byName(name: "HummingbirdTesting"),
 			.byName(name: "HummingbirdRouter"),
-        ]),
-        .testTarget(name: "HummingbirdRouterTests", dependencies: [
-            .byName(name: "HummingbirdRouter"),
-            .byName(name: "HummingbirdTesting"),
-        ]),
-        .testTarget(
-            name: "HummingbirdCoreTests",
-            dependencies:
-            [
-                .byName(name: "HummingbirdCore"),
-                .byName(name: "HummingbirdHTTP2"),
-                .byName(name: "HummingbirdTLS"),
-                .byName(name: "HummingbirdTesting"),
-                .product(name: "AsyncHTTPClient", package: "async-http-client"),
-            ],
-            resources: [.process("Certificates")]
-        ),
-    ]
+		]),
+		.testTarget(name: "HummingbirdRouterTests", dependencies: [
+			.byName(name: "HummingbirdRouter"),
+			.byName(name: "HummingbirdTesting"),
+		]),
+		.testTarget(
+			name: "HummingbirdCoreTests",
+			dependencies:
+			[
+				.byName(name: "HummingbirdCore"),
+				.byName(name: "HummingbirdHTTP2"),
+				.byName(name: "HummingbirdTLS"),
+				.byName(name: "HummingbirdTesting"),
+				.product(name: "AsyncHTTPClient", package: "async-http-client"),
+			],
+			resources: [.process("Certificates")]
+		),
+	]
 )


### PR DESCRIPTION
I was getting a linking error when trying to run the unit tests. Adding this dependency to `HummingbirdRouter` fixed that error.