### PR TITLE
appendPath should be appendingPath as it is non-mutating

### DIFF
--- a/Sources/Hummingbird/Router/RouteCollection.swift
+++ b/Sources/Hummingbird/Router/RouteCollection.swift
@@ -67,7 +67,7 @@ extension RouterMethods {
     @discardableResult public func addRoutes(_ collection: RouteCollection<Context>, atPath path: RouterPath = "") -> Self {
         for route in collection.routes {
             // ensure path starts with a "/" and doesn't end with a "/"
-            let path = path.appendPath(route.path)
+            let path = path.appendingPath(route.path)
             self.on(path, method: route.method, responder: route.responder)
         }
         return self

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -51,7 +51,7 @@ public struct RouterGroup<Context: RequestContext>: RouterMethods {
     /// - Parameter path: path prefix to add to routes inside this group
     @discardableResult public func group(_ path: RouterPath = "") -> RouterGroup<Context> {
         return RouterGroup(
-            path: self.path.appendPath(path),
+            path: self.path.appendingPath(path),
             middlewares: .init(middlewares: self.middlewares.middlewares),
             router: self.router
         )
@@ -70,7 +70,7 @@ public struct RouterGroup<Context: RequestContext>: RouterMethods {
         responder: Responder
     ) -> Self where Responder.Context == Context {
         // ensure path starts with a "/" and doesn't end with a "/"
-        let path = self.path.appendPath(path)
+        let path = self.path.appendingPath(path)
         self.router.on(path, method: method, responder: self.middlewares.constructResponder(finalResponder: responder))
         return self
     }

--- a/Sources/Hummingbird/Router/RouterPath.swift
+++ b/Sources/Hummingbird/Router/RouterPath.swift
@@ -197,7 +197,7 @@ public struct RouterPath: Sendable, ExpressibleByStringLiteral, ExpressibleByStr
     }
 
     /// Combine two RouterPaths
-    public func appendPath(_ path: RouterPath) -> Self {
+    public func appendingPath(_ path: RouterPath) -> Self {
         .init(components: self.components + path.components)
     }
 }

--- a/Sources/HummingbirdRouter/Route.swift
+++ b/Sources/HummingbirdRouter/Route.swift
@@ -94,7 +94,7 @@ public struct Route<Handler: _RouteHandlerProtocol, Context: RouterRequestContex
     /// Return full path of route, using Task local stored `routeGroupPath`.
     static func getFullPath(from path: RouterPath) -> RouterPath {
         if let parentGroupPath = RouterBuilderState.current?.routeGroupPath {
-            return parentGroupPath.appendPath(path)
+            return parentGroupPath.appendingPath(path)
         }
         return path
     }

--- a/Sources/HummingbirdRouter/RouteGroup.swift
+++ b/Sources/HummingbirdRouter/RouteGroup.swift
@@ -44,7 +44,7 @@ public struct RouteGroup<Context: RouterRequestContext, Handler: MiddlewareProto
             routerPath = routerPath.lowercased()
         }
         let parentGroupPath = routerBuildState.routeGroupPath
-        self.fullPath = parentGroupPath.appendPath(routerPath)
+        self.fullPath = parentGroupPath.appendingPath(routerPath)
         routerBuildState.routeGroupPath = self.fullPath
         self.handler = RouterBuilderState.$current.withValue(routerBuildState) {
             builder()


### PR DESCRIPTION
Non-mutating methods should end in `ing`, `ed`
https://www.swift.org/documentation/api-design-guidelines/#naming