### PR TITLE
Allow use of middleware result builder in `Router`

### DIFF
--- a/Sources/Hummingbird/Middleware/Middleware.swift
+++ b/Sources/Hummingbird/Middleware/Middleware.swift
@@ -53,7 +53,7 @@ public protocol MiddlewareProtocol<Input, Output, Context>: Sendable {
 public protocol RouterMiddleware<Context>: MiddlewareProtocol where Input == Request, Output == Response {}
 
 struct MiddlewareResponder<Context>: HTTPResponder {
-    let middleware: any RouterMiddleware<Context>
+    let middleware: any MiddlewareProtocol<Request, Response, Context>
     let next: @Sendable (Request, Context) async throws -> Response
 
     func respond(to request: Request, context: Context) async throws -> Response {

--- a/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareGroup.swift
@@ -14,17 +14,17 @@
 
 /// Group of middleware that can be used to create a responder chain. Each middleware calls the next one
 public final class MiddlewareGroup<Context> {
-    var middlewares: [any RouterMiddleware<Context>]
+    var middlewares: [any MiddlewareProtocol<Request, Response, Context>]
 
     /// Initialize `MiddlewareGroup`
-    init(middlewares: [any RouterMiddleware<Context>] = []) {
+    init(middlewares: [any MiddlewareProtocol<Request, Response, Context>] = []) {
         self.middlewares = middlewares
     }
 
     /// Add middleware to group
     ///
     /// This middleware will only be applied to endpoints added after this call.
-    @discardableResult public func add(_ middleware: any RouterMiddleware<Context>) -> Self {
+    @discardableResult public func add(_ middleware: any MiddlewareProtocol<Request, Response, Context>) -> Self {
         self.middlewares.append(middleware)
         return self
     }

--- a/Sources/Hummingbird/Middleware/MiddlewareModule/MiddlewareStack.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareModule/MiddlewareStack.swift
@@ -11,7 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import Hummingbird
 
 public struct _Middleware2<M0: MiddlewareProtocol, M1: MiddlewareProtocol>: MiddlewareProtocol where M0.Input == M1.Input, M0.Context == M1.Context, M0.Output == M1.Output {
     public typealias Input = M0.Input

--- a/Sources/Hummingbird/Router/RouteCollection.swift
+++ b/Sources/Hummingbird/Router/RouteCollection.swift
@@ -46,7 +46,7 @@ public final class RouteCollection<Context: RequestContext>: RouterMethods {
     }
 
     /// Add middleware to RouteCollection
-    @discardableResult public func add(middleware: any RouterMiddleware<Context>) -> Self {
+    @discardableResult public func add(middleware: any MiddlewareProtocol<Request, Response, Context>) -> Self {
         self.middlewares.add(middleware)
         return self
     }

--- a/Sources/Hummingbird/Router/Router.swift
+++ b/Sources/Hummingbird/Router/Router.swift
@@ -100,7 +100,7 @@ public final class Router<Context: RequestContext>: RouterMethods, HTTPResponder
     ///
     /// This middleware will only be applied to endpoints added after this call.
     /// - Parameter middleware: Middleware we are adding
-    @discardableResult public func add(middleware: any RouterMiddleware<Context>) -> Self {
+    @discardableResult public func add(middleware: any MiddlewareProtocol<Request, Response, Context>) -> Self {
         self.middlewares.add(middleware)
         return self
     }

--- a/Sources/Hummingbird/Router/RouterGroup.swift
+++ b/Sources/Hummingbird/Router/RouterGroup.swift
@@ -42,7 +42,7 @@ public struct RouterGroup<Context: RequestContext>: RouterMethods {
     }
 
     /// Add middleware to RouterGroup
-    @discardableResult public func add(middleware: any RouterMiddleware<Context>) -> RouterGroup<Context> {
+    @discardableResult public func add(middleware: any MiddlewareProtocol<Request, Response, Context>) -> RouterGroup<Context> {
         self.middlewares.add(middleware)
         return self
     }

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -36,7 +36,7 @@ public protocol RouterMethods<Context> {
     func group(_ path: RouterPath) -> RouterGroup<Context>
 
     /// add middleware
-    func add(middleware: any RouterMiddleware<Context>) -> Self
+    func add(middleware: any MiddlewareProtocol<Request, Response, Context>) -> Self
 }
 
 extension RouterMethods {
@@ -97,6 +97,12 @@ extension RouterMethods {
         use handler: @Sendable @escaping (Request, Context) async throws -> some ResponseGenerator
     ) -> Self {
         return self.on(path, method: .patch, use: handler)
+    }
+
+    @discardableResult public func add(
+        @MiddlewareFixedTypeBuilder<Request, Response, Context> middleware: () -> some MiddlewareProtocol<Request, Response, Context>
+    ) -> Self {
+        return self.add(middleware: middleware())
     }
 
     internal func constructResponder(


### PR DESCRIPTION
Middleware are stored as `Middleware<Request, Response, Context>` instead of `RouterMiddleware`. Once middleware result builder is moved to separate package this allows for outside libraries to create Middleware that can be used by Hummingbird without knowing about `RouterMiddleware` (an HB type). `RouterMiddleware` is just a helper protocol to avoid having to set `Input` and `Output` in hummingbird specific middleware.

The work above has allowed me to move the middleware stack to Hummingbird so users can take advantage of it in the Hummingbird standard router. eg
```swift
router.add {
    LogRequestsMiddleware()
    FileMiddleware()
}
```