### PR TITLE
ContextTransform(context:) renamed to ContextTransform(to:)

### DIFF
--- a/Sources/Hummingbird/Middleware/MiddlewareModule/MiddlewareStack.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareModule/MiddlewareStack.swift
@@ -34,7 +34,7 @@ public struct _Middleware2<M0: MiddlewareProtocol, M1: MiddlewareProtocol>: Midd
     }
 }
 
-/// Result builder used by ``RouterBuilder``
+/// Middleware chain result builder
 ///
 /// Generates a middleware stack from the elements inside the result builder. The input,
 /// context and output types passed through the middleware stack are fixed and cannot be changed.

--- a/Sources/Hummingbird/Middleware/MiddlewareModule/MiddlewareStack.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareModule/MiddlewareStack.swift
@@ -34,7 +34,7 @@ public struct _Middleware2<M0: MiddlewareProtocol, M1: MiddlewareProtocol>: Midd
     }
 }
 
-/// Middleware chain result builder
+/// Middleware stack result builder
 ///
 /// Generates a middleware stack from the elements inside the result builder. The input,
 /// context and output types passed through the middleware stack are fixed and cannot be changed.

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -95,9 +95,9 @@ extension RouterMethods {
     /// - Parameter middleware: Middleware stack result builder
     /// - Returns: router
     @discardableResult public func add(
-        @MiddlewareFixedTypeBuilder<Request, Response, Context> middleware: () -> some MiddlewareProtocol<Request, Response, Context>
+        @MiddlewareFixedTypeBuilder<Request, Response, Context> middlewareStack: () -> some MiddlewareProtocol<Request, Response, Context>
     ) -> Self {
-        return self.add(middleware: middleware())
+        return self.add(middleware: middlewareStack())
     }
 
     /// GET path for async closure returning type conforming to ResponseGenerator

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -83,7 +83,7 @@ extension RouterMethods {
         )
     }
 
-    /// Add middleware stack to Router
+    /// Add middleware stack to router
     ///
     /// This gives a slight performance boost over adding them individually.
     /// ```swift

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -85,14 +85,18 @@ extension RouterMethods {
 
     /// Add middleware stack to router
     ///
-    /// This gives a slight performance boost over adding them individually.
+    /// Add multiple middleware to the router using the middleware stack result builder
+    /// ``MiddlewareFixedTypeBuilder``.
+    ///
     /// ```swift
     /// router.add {
     ///     LogRequestsMiddleware()
     ///     MetricsMiddleware()
     /// }
     /// ```
-    /// - Parameter middleware: Middleware stack result builder
+    /// This gives a slight performance boost over adding them individually.
+    ///
+    /// - Parameter middlewareStack: Middleware stack result builder
     /// - Returns: router
     @discardableResult public func add(
         @MiddlewareFixedTypeBuilder<Request, Response, Context> middlewareStack: () -> some MiddlewareProtocol<Request, Response, Context>

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -83,6 +83,23 @@ extension RouterMethods {
         )
     }
 
+    /// Add middleware stack to Router
+    ///
+    /// This gives a slight performance boost over adding them individually.
+    /// ```swift
+    /// router.add {
+    ///     LogRequestsMiddleware()
+    ///     MetricsMiddleware()
+    /// }
+    /// ```
+    /// - Parameter middleware: Middleware stack result builder
+    /// - Returns: router
+    @discardableResult public func add(
+        @MiddlewareFixedTypeBuilder<Request, Response, Context> middleware: () -> some MiddlewareProtocol<Request, Response, Context>
+    ) -> Self {
+        return self.add(middleware: middleware())
+    }
+
     /// GET path for async closure returning type conforming to ResponseGenerator
     @discardableResult public func get(
         _ path: RouterPath = "",
@@ -129,12 +146,6 @@ extension RouterMethods {
         use handler: @Sendable @escaping (Request, Context) async throws -> some ResponseGenerator
     ) -> Self {
         return self.on(path, method: .patch, use: handler)
-    }
-
-    @discardableResult public func add(
-        @MiddlewareFixedTypeBuilder<Request, Response, Context> middleware: () -> some MiddlewareProtocol<Request, Response, Context>
-    ) -> Self {
-        return self.add(middleware: middleware())
     }
 
     internal func constructResponder(

--- a/Sources/HummingbirdRouter/ContextTransform.swift
+++ b/Sources/HummingbirdRouter/ContextTransform.swift
@@ -14,7 +14,7 @@
 
 import Hummingbird
 
-/// Router middleware that transforms the ``RequestContext`` and uses it with the contained
+/// Router middleware that transforms the ``Hummingbird/RequestContext`` and uses it with the contained
 /// Middleware chain
 ///
 /// For the transform to work the `Source` of the transformed `RequestContext`` needs to be

--- a/Sources/HummingbirdRouter/ContextTransform.swift
+++ b/Sources/HummingbirdRouter/ContextTransform.swift
@@ -41,7 +41,7 @@ public struct ContextTransform<Context: RouterRequestContext, HandlerContext: Ro
     ///   - routerPath: Path local to group route this group is defined in
     ///   - builder: RouteGroup builder
     public init(
-        context: HandlerContext.Type,
+        to context: HandlerContext.Type,
         @MiddlewareFixedTypeBuilder<Request, Response, HandlerContext> builder: () -> Handler
     ) {
         self.handler = builder()

--- a/Sources/HummingbirdRouter/RouteBuilder.swift
+++ b/Sources/HummingbirdRouter/RouteBuilder.swift
@@ -44,7 +44,7 @@ public struct Handle<HandlerOutput: ResponseGenerator, Context: RouterRequestCon
 
 /// Result builder for a Route.
 ///
-/// This is very similar to the ``MiddlewareFixedTypeBuilder`` result builder except it requires
+/// This is very similar to the ``Hummingbird/MiddlewareFixedTypeBuilder`` result builder except it requires
 /// the last entry of the builder to be a ``Handle`` so we are guaranteed a Response. It also
 /// adds the ability to pass in a closure instead of ``Handle`` type.
 @resultBuilder

--- a/Tests/HummingbirdRouterTests/RouterTests.swift
+++ b/Tests/HummingbirdRouterTests/RouterTests.swift
@@ -281,7 +281,7 @@ final class RouterTests: XCTestCase {
             var string: String
 
             typealias Source = BasicRouterRequestContext
-            init(source: Source) {
+            init(source: BasicRouterRequestContext) {
                 self.coreContext = .init(source: source)
                 self.string = ""
                 self.routerContext = source.routerContext
@@ -299,7 +299,7 @@ final class RouterTests: XCTestCase {
             RouteGroup("/test") {
                 TestMiddleware()
                 RouteGroup("/group") {
-                    ContextTransform(context: TestRouterContext2.self) {
+                    ContextTransform(to: TestRouterContext2.self) {
                         TestTransformMiddleware()
                         Get { _, context in
                             return Response(status: .ok, headers: [.middleware2: context.string])


### PR DESCRIPTION
Added a bunch of documentation fixes, additional comments as well