### PR TITLE
Fix compile errors for Musl

### DIFF
--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -107,7 +107,11 @@ public struct Environment: Sendable, Decodable, ExpressibleByDictionaryLiteral {
     static func getEnvironment() -> [String: String] {
         var values: [String: String] = [:]
         let equalSign = Character("=")
+#if canImport(Musl)
+        guard let envp = environ else { return [:] }
+#else
         let envp = environ
+#endif
         var idx = 0
 
         while let entry = envp.advanced(by: idx).pointee {

--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -107,11 +107,11 @@ public struct Environment: Sendable, Decodable, ExpressibleByDictionaryLiteral {
     static func getEnvironment() -> [String: String] {
         var values: [String: String] = [:]
         let equalSign = Character("=")
-#if canImport(Musl)
+        #if canImport(Musl)
         guard let envp = environ else { return [:] }
-#else
+        #else
         let envp = environ
-#endif
+        #endif
         var idx = 0
 
         while let entry = envp.advanced(by: idx).pointee {

--- a/Sources/HummingbirdTesting/AsyncHTTPClientTestFramework.swift
+++ b/Sources/HummingbirdTesting/AsyncHTTPClientTestFramework.swift
@@ -22,7 +22,6 @@ import NIOHTTP1
 import NIOPosix
 import NIOSSL
 import ServiceLifecycle
-import XCTest
 
 /// Test using a live server and AsyncHTTPClient as a client
 final class AsyncHTTPClientTestFramework<App: ApplicationProtocol>: ApplicationTestFramework {

--- a/Sources/HummingbirdTesting/LiveTestFramework.swift
+++ b/Sources/HummingbirdTesting/LiveTestFramework.swift
@@ -20,7 +20,6 @@ import NIOCore
 import NIOPosix
 import NIOTransportServices
 import ServiceLifecycle
-import XCTest
 
 /// Test using a live server
 final class LiveTestFramework<App: ApplicationProtocol>: ApplicationTestFramework {


### PR DESCRIPTION
Still complains about Swift 6. This needs to be fixed at SDK level I believe (if we are to continue using `environ`).