### PR TITLE
Use a response writer at the Server level

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -125,8 +125,9 @@ extension ApplicationProtocol {
             if let serverName = self.configuration.serverName {
                 response.headers[.server] = serverName
             }
+            // Write response
             try await responseWriter.write(.head(response.head))
-            let tailHeaders = try await response.body.write(ChannelResponseBodyWriter(writer: responseWriter))
+            let tailHeaders = try await response.body.write(RootResponseBodyWriter(writer: responseWriter))
             try await responseWriter.write(.end(tailHeaders))
         } onServerRunning: {
             await self.onServerRunning($0)
@@ -305,7 +306,8 @@ extension Logger {
     }
 }
 
-struct ChannelResponseBodyWriter: ResponseBodyWriter {
+/// Response body writer that writes body directly to the AsyncChannel ResponseWriter
+struct RootResponseBodyWriter: ResponseBodyWriter {
     let writer: ResponseWriter
 
     func write(_ buffer: ByteBuffer) async throws {

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -101,7 +101,7 @@ extension ApplicationProtocol {
             configuration: self.configuration.httpServer,
             eventLoopGroup: self.eventLoopGroup,
             logger: self.logger
-        ) { request, responseWriter, channel in
+        ) { (request, responseWriter: consuming ResponseWriter, channel) in
             let logger = self.logger.with(metadataKey: "hb_id", value: .stringConvertible(RequestID()))
             let context = Self.Responder.Context(
                 source: .init(

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -126,9 +126,8 @@ extension ApplicationProtocol {
                 response.headers[.server] = serverName
             }
             // Write response
-            try await responseWriter.write(.head(response.head))
-            let tailHeaders = try await response.body.write(RootResponseBodyWriter(writer: responseWriter))
-            try await responseWriter.write(.end(tailHeaders))
+            let bodyWriter = try await responseWriter.writeHead(response.head)
+            try await response.body.write(bodyWriter)
         } onServerRunning: {
             await self.onServerRunning($0)
         }
@@ -303,14 +302,5 @@ extension Logger {
         var logger = self
         logger[metadataKey: metadataKey] = value
         return logger
-    }
-}
-
-/// Response body writer that writes body directly to the AsyncChannel ResponseWriter
-struct RootResponseBodyWriter: ResponseBodyWriter {
-    let writer: ResponseWriter
-
-    func write(_ buffer: ByteBuffer) async throws {
-        try await self.writer.write(.body(buffer))
     }
 }

--- a/Sources/HummingbirdCore/Response/ResponseBody.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBody.swift
@@ -22,10 +22,10 @@ public struct ResponseBody: Sendable {
     public let contentLength: Int?
 
     /// Initialise ResponseBody with closure writing body contents.
-    /// 
-    /// When you have finished writing the response body you need to indicate you 
+    ///
+    /// When you have finished writing the response body you need to indicate you
     /// have finished by calling ``ResponseBodyWriter.finish``. At this point you can also
-    /// send trailing headers by including them as a parameter in the finsh() call. 
+    /// send trailing headers by including them as a parameter in the finsh() call.
     /// ```
     /// let responseBody = ResponseBody(contentLength: contentLength) { writer in
     ///     try await writer.write(buffer)

--- a/Sources/HummingbirdCore/Response/ResponseBody.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBody.swift
@@ -21,7 +21,17 @@ public struct ResponseBody: Sendable {
     let _write: @Sendable (any ResponseBodyWriter) async throws -> Void
     public let contentLength: Int?
 
-    /// Initialise ResponseBody with closure writing body contents
+    /// Initialise ResponseBody with closure writing body contents.
+    /// 
+    /// When you have finished writing the response body you need to indicate you 
+    /// have finished by calling ``ResponseBodyWriter.finish``. At this point you can also
+    /// send trailing headers by including them as a parameter in the finsh() call. 
+    /// ```
+    /// let responseBody = ResponseBody(contentLength: contentLength) { writer in
+    ///     try await writer.write(buffer)
+    ///     try await writer.finish()
+    /// }
+    /// ```
     /// - Parameters:
     ///   - contentLength: Optional length of body
     ///   - write: closure provided with `writer` type that can be used to write to response body
@@ -75,7 +85,7 @@ public struct ResponseBody: Sendable {
         }
     }
 
-    /// Create new response body that call a callback once original response body has been written
+    /// Create new response body that calls a closure once original response body has been written
     /// to the channel
     ///
     /// When you return a response from a handler, this cannot be considered to be the point the

--- a/Sources/HummingbirdCore/Response/ResponseWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseWriter.swift
@@ -17,7 +17,7 @@ import NIOCore
 import NIOHTTPTypes
 
 /// ResponseWriter that writes directly to AsyncChannel
-public struct ResponseWriter {
+public struct ResponseWriter: ~Copyable {
     @usableFromInline
     let outbound: NIOAsyncChannelOutboundWriter<HTTPResponsePart>
 

--- a/Sources/HummingbirdCore/Response/ResponseWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseWriter.swift
@@ -39,7 +39,7 @@ public struct ResponseWriter {
     ///  Write AsyncSequence of response parts
     /// - Parameter parts: response parts AsyncSequence
     @inlinable
-    public func write<AsyncSeq: AsyncSequence>(_ parts: AsyncSeq) async throws where AsyncSeq.Element == HTTPResponsePart {
+    public func write<Parts: AsyncSequence>(_ parts: Parts) async throws where Parts.Element == HTTPResponsePart {
         for try await part in parts {
             try await self.outbound.write(part)
         }

--- a/Sources/HummingbirdCore/Response/ResponseWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseWriter.swift
@@ -57,6 +57,7 @@ struct RootResponseBodyWriter: Sendable, ResponseBodyWriter {
     /// The components of a HTTP response from the view of a HTTP server.
     public typealias OutboundWriter = NIOAsyncChannelOutboundWriter<Out>
 
+    @usableFromInline
     let outbound: OutboundWriter
 
     @usableFromInline
@@ -66,21 +67,21 @@ struct RootResponseBodyWriter: Sendable, ResponseBodyWriter {
 
     /// Write a single ByteBuffer
     /// - Parameter buffer: single buffer to write
-    @usableFromInline
+    @inlinable
     func write(_ buffer: ByteBuffer) async throws {
         try await self.outbound.write(.body(buffer))
     }
 
     /// Write a sequence of ByteBuffers
     /// - Parameter buffers: Sequence of buffers
-    @usableFromInline
+    @inlinable
     func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
         try await self.outbound.write(contentsOf: buffers.map { .body($0) })
     }
 
     /// Finish writing body
     /// - Parameter trailingHeaders: Any trailing headers you want to include at end
-    @usableFromInline
+    @inlinable
     consuming func finish(_ trailingHeaders: HTTPFields?) async throws {
         try await self.outbound.write(.end(trailingHeaders))
     }

--- a/Sources/HummingbirdCore/Response/ResponseWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseWriter.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOHTTPTypes
+
+public struct ResponseWriter {
+    @usableFromInline
+    let outbound: NIOAsyncChannelOutboundWriter<HTTPResponsePart>
+
+    @inlinable
+    public func write(_ part: HTTPResponsePart) async throws {
+        try await self.outbound.write(part)
+    }
+
+    @inlinable
+    public func write(_ parts: some Sequence<HTTPResponsePart>) async throws {
+        for part in parts {
+            try await self.outbound.write(part)
+        }
+    }
+
+    @inlinable
+    public func write<AsyncSeq: AsyncSequence>(_ parts: AsyncSeq) async throws where AsyncSeq.Element == HTTPResponsePart {
+        for try await part in parts {
+            try await self.outbound.write(part)
+        }
+    }
+}

--- a/Sources/HummingbirdCore/Response/ResponseWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseWriter.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import HTTPTypes
 import NIOCore
 import NIOHTTPTypes
 
@@ -20,28 +21,56 @@ public struct ResponseWriter {
     @usableFromInline
     let outbound: NIOAsyncChannelOutboundWriter<HTTPResponsePart>
 
-    ///  Write single response part
-    /// - Parameter part: response part
     @inlinable
-    public func write(_ part: HTTPResponsePart) async throws {
-        try await self.outbound.write(part)
+    public consuming func writeHead(_ head: HTTPResponse) async throws -> some ResponseBodyWriter {
+        try await self.outbound.write(.head(head))
+        return RootResponseBodyWriter(outbound: self.outbound)
     }
 
-    ///  Write sequence of response parts
-    /// - Parameter parts: response parts sequence
     @inlinable
-    public func write(_ parts: some Sequence<HTTPResponsePart>) async throws {
-        for part in parts {
-            try await self.outbound.write(part)
-        }
+    public consuming func writeInformationalHead(_ head: HTTPResponse) async throws {
+        precondition((100..<200).contains(head.status.code), "Informational HTTP responses require a status code between 100 and 199")
+        try await self.outbound.write(.head(head))
     }
 
-    ///  Write AsyncSequence of response parts
-    /// - Parameter parts: response parts AsyncSequence
     @inlinable
-    public func write<Parts: AsyncSequence>(_ parts: Parts) async throws where Parts.Element == HTTPResponsePart {
-        for try await part in parts {
-            try await self.outbound.write(part)
-        }
+    public consuming func writeResponse(_ head: HTTPResponse) async throws {
+        try await self.outbound.write(contentsOf: [.head(head), .end(nil)])
+    }
+}
+
+/// ResponseBodyWriter that writes ByteBuffers to AsyncChannel outbound writer
+@usableFromInline
+struct RootResponseBodyWriter: Sendable, ResponseBodyWriter {
+    typealias Out = HTTPResponsePart
+    /// The components of a HTTP response from the view of a HTTP server.
+    public typealias OutboundWriter = NIOAsyncChannelOutboundWriter<Out>
+
+    let outbound: OutboundWriter
+
+    @usableFromInline
+    init(outbound: OutboundWriter) {
+        self.outbound = outbound
+    }
+
+    /// Write a single ByteBuffer
+    /// - Parameter buffer: single buffer to write
+    @usableFromInline
+    func write(_ buffer: ByteBuffer) async throws {
+        try await self.outbound.write(.body(buffer))
+    }
+
+    /// Write a sequence of ByteBuffers
+    /// - Parameter buffers: Sequence of buffers
+    @usableFromInline
+    func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
+        try await self.outbound.write(contentsOf: buffers.map { .body($0) })
+    }
+
+    /// Finish writing body
+    /// - Parameter trailingHeaders: Any trailing headers you want to include at end
+    @usableFromInline
+    consuming func finish(_ trailingHeaders: HTTPFields?) async throws {
+        try await self.outbound.write(.end(trailingHeaders))
     }
 }

--- a/Sources/HummingbirdCore/Response/ResponseWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseWriter.swift
@@ -15,15 +15,20 @@
 import NIOCore
 import NIOHTTPTypes
 
+/// ResponseWriter that writes directly to AsyncChannel
 public struct ResponseWriter {
     @usableFromInline
     let outbound: NIOAsyncChannelOutboundWriter<HTTPResponsePart>
 
+    ///  Write single response part
+    /// - Parameter part: response part
     @inlinable
     public func write(_ part: HTTPResponsePart) async throws {
         try await self.outbound.write(part)
     }
 
+    ///  Write sequence of response parts
+    /// - Parameter parts: response parts sequence
     @inlinable
     public func write(_ parts: some Sequence<HTTPResponsePart>) async throws {
         for part in parts {
@@ -31,6 +36,8 @@ public struct ResponseWriter {
         }
     }
 
+    ///  Write AsyncSequence of response parts
+    /// - Parameter parts: response parts AsyncSequence
     @inlinable
     public func write<AsyncSeq: AsyncSequence>(_ parts: AsyncSeq) async throws where AsyncSeq.Element == HTTPResponsePart {
         for try await part in parts {

--- a/Sources/HummingbirdCore/Response/ResponseWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseWriter.swift
@@ -37,7 +37,7 @@ public struct ResponseWriter: ~Copyable {
     /// - Parameter head: Informational response head
     @inlinable
     public func writeInformationalHead(_ head: HTTPResponse) async throws {
-        precondition((100..<200).contains(head.status.code), "Informational HTTP responses require a status code between 100 and 199")
+        precondition((100..<200).contains(head.status.code), "Informational HTTP responses require a status code in the range of 100 through 199")
         try await self.outbound.write(.head(head))
     }
 

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -89,24 +89,3 @@ extension HTTPChannelHandler {
         }
     }
 }
-
-/// ResponseBodyWriter that writes ByteBuffers to AsyncChannel outbound writer
-struct HTTPServerBodyWriter: Sendable, ResponseBodyWriter {
-    typealias Out = HTTPResponsePart
-    /// The components of a HTTP response from the view of a HTTP server.
-    public typealias OutboundWriter = NIOAsyncChannelOutboundWriter<Out>
-
-    let outbound: OutboundWriter
-
-    /// Write a single ByteBuffer
-    /// - Parameter buffer: single buffer to write
-    func write(_ buffer: ByteBuffer) async throws {
-        try await self.outbound.write(.body(buffer))
-    }
-
-    /// Write a sequence of ByteBuffers
-    /// - Parameter buffers: Sequence of buffers
-    func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
-        try await self.outbound.write(contentsOf: buffers.map { .body($0) })
-    }
-}

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -21,7 +21,7 @@ import ServiceLifecycle
 
 /// Protocol for HTTP channels
 public protocol HTTPChannelHandler: ServerChildChannel {
-    typealias Responder = @Sendable (Request, ResponseWriter, Channel) async throws -> Void
+    typealias Responder = @Sendable (Request, consuming ResponseWriter, Channel) async throws -> Void
     var responder: Responder { get }
 }
 

--- a/Tests/HummingbirdCoreTests/HTTP2Tests.swift
+++ b/Tests/HummingbirdCoreTests/HTTP2Tests.swift
@@ -31,7 +31,7 @@ class HummingBirdHTTP2Tests: XCTestCase {
         var logger = Logger(label: "Hummingbird")
         logger.logLevel = .trace
         try await testServer(
-            responder: { _, responseWriter, _ in
+            responder: { (_, responseWriter: consuming ResponseWriter, _) in
                 try await responseWriter.writeResponse(.init(status: .ok))
             },
             httpChannelSetup: .http2Upgrade(tlsConfiguration: getServerTLSConfiguration()),

--- a/Tests/HummingbirdCoreTests/HTTP2Tests.swift
+++ b/Tests/HummingbirdCoreTests/HTTP2Tests.swift
@@ -31,8 +31,9 @@ class HummingBirdHTTP2Tests: XCTestCase {
         var logger = Logger(label: "Hummingbird")
         logger.logLevel = .trace
         try await testServer(
-            responder: { _, _ in
-                .init(status: .ok)
+            responder: { _, responseWriter, _ in
+                try await responseWriter.write(.head(.init(status: .ok)))
+                try await responseWriter.write(.end(nil))
             },
             httpChannelSetup: .http2Upgrade(tlsConfiguration: getServerTLSConfiguration()),
             configuration: .init(address: .hostname(port: 0), serverName: testServerName),

--- a/Tests/HummingbirdCoreTests/HTTP2Tests.swift
+++ b/Tests/HummingbirdCoreTests/HTTP2Tests.swift
@@ -32,8 +32,7 @@ class HummingBirdHTTP2Tests: XCTestCase {
         logger.logLevel = .trace
         try await testServer(
             responder: { _, responseWriter, _ in
-                try await responseWriter.write(.head(.init(status: .ok)))
-                try await responseWriter.write(.end(nil))
+                try await responseWriter.writeResponse(.init(status: .ok))
             },
             httpChannelSetup: .http2Upgrade(tlsConfiguration: getServerTLSConfiguration()),
             configuration: .init(address: .hostname(port: 0), serverName: testServerName),

--- a/Tests/HummingbirdCoreTests/TestUtils.swift
+++ b/Tests/HummingbirdCoreTests/TestUtils.swift
@@ -27,9 +27,9 @@ public enum TestErrors: Error {
 /// Basic responder that just returns "Hello" in body
 @Sendable public func helloResponder(to request: Request, responseWriter: ResponseWriter, channel: Channel) async throws {
     let responseBody = channel.allocator.buffer(string: "Hello")
-    try await responseWriter.write(.head(.init(status: .ok)))
-    try await responseWriter.write(.body(responseBody))
-    try await responseWriter.write(.end(nil))
+    let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+    try await bodyWriter.write(responseBody)
+    try await bodyWriter.finish(nil)
 }
 
 /// Helper function for testing a server

--- a/Tests/HummingbirdCoreTests/TestUtils.swift
+++ b/Tests/HummingbirdCoreTests/TestUtils.swift
@@ -25,9 +25,11 @@ public enum TestErrors: Error {
 }
 
 /// Basic responder that just returns "Hello" in body
-@Sendable public func helloResponder(to request: Request, channel: Channel) async -> Response {
+@Sendable public func helloResponder(to request: Request, responseWriter: ResponseWriter, channel: Channel) async throws {
     let responseBody = channel.allocator.buffer(string: "Hello")
-    return Response(status: .ok, body: .init(byteBuffer: responseBody))
+    try await responseWriter.write(.head(.init(status: .ok)))
+    try await responseWriter.write(.body(responseBody))
+    try await responseWriter.write(.end(nil))
 }
 
 /// Helper function for testing a server

--- a/Tests/HummingbirdCoreTests/TestUtils.swift
+++ b/Tests/HummingbirdCoreTests/TestUtils.swift
@@ -25,7 +25,7 @@ public enum TestErrors: Error {
 }
 
 /// Basic responder that just returns "Hello" in body
-@Sendable public func helloResponder(to request: Request, responseWriter: ResponseWriter, channel: Channel) async throws {
+@Sendable public func helloResponder(to request: Request, responseWriter: consuming ResponseWriter, channel: Channel) async throws {
     let responseBody = channel.allocator.buffer(string: "Hello")
     let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
     try await bodyWriter.write(responseBody)

--- a/Tests/HummingbirdRouterTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdRouterTests/MiddlewareTests.swift
@@ -139,6 +139,8 @@ final class MiddlewareTests: XCTestCase {
             }
 
             func finish(_ trailingHeaders: HTTPFields?) async throws {
+                var trailingHeaders = trailingHeaders ?? [:]
+                trailingHeaders[.middleware2] = "test2"
                 try await self.parentWriter.finish(trailingHeaders)
             }
         }
@@ -157,7 +159,10 @@ final class MiddlewareTests: XCTestCase {
             RouteGroup("") {
                 TransformMiddleware()
                 Get("test") { request, _ in
-                    return Response(status: .ok, body: .init(asyncSequence: request.body))
+                    Response(status: .ok, body: .init { writer in
+                        try await writer.write(request.body)
+                        try await writer.finish([.middleware: "test"])
+                    })
                 }
             }
         }
@@ -166,6 +171,8 @@ final class MiddlewareTests: XCTestCase {
         try await app.test(.router) { client in
             let buffer = Self.randomBuffer(size: 64000)
             try await client.execute(uri: "/test", method: .get, body: buffer) { response in
+                XCTAssertEqual(response.trailerHeaders?[.middleware], "test")
+                XCTAssertEqual(response.trailerHeaders?[.middleware2], "test2")
                 let expectedOutput = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
                 XCTAssertEqual(expectedOutput, response.body)
             }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -750,6 +750,8 @@ final class ApplicationTests: XCTestCase {
                     collated.writeImmutableBuffer(buffer)
                 }
             }
+
+            func finish(_: HTTPFields?) async throws {}
         }
 
         let messages = [

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -697,6 +697,7 @@ final class ApplicationTests: XCTestCase {
                             bytes: buffer.readableBytesView.map { $0 ^ 0xFF })
                         try await writer.write(processed)
                     }
+                    try await writer.finish(nil)
                 }
             )
         }

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -151,15 +151,18 @@ final class MiddlewareTests: XCTestCase {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
                 try await self.parentWriter.write(output)
             }
+
+            func finish(_ trailingHeaders: HTTPFields?) async throws {
+                try await self.parentWriter.finish(trailingHeaders)
+            }
         }
         struct TransformMiddleware<Context: RequestContext>: RouterMiddleware {
             public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
                 let response = try await next(request, context)
                 var editedResponse = response
-                editedResponse.body = .withTrailingHeaders { writer in
+                editedResponse.body = .init { writer in
                     let transformWriter = TransformWriter(parentWriter: writer)
-                    let tailHeaders = try await response.body.write(transformWriter)
-                    return tailHeaders
+                    try await response.body.write(transformWriter)
                 }
                 return editedResponse
             }
@@ -188,6 +191,10 @@ final class MiddlewareTests: XCTestCase {
             func write(_ buffer: ByteBuffer) async throws {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
                 try await self.parentWriter.write(output)
+            }
+
+            func finish(_ trailingHeaders: HTTPFields?) async throws {
+                try await self.parentWriter.finish(trailingHeaders)
             }
         }
         struct TransformMiddleware<Context: RequestContext>: RouterMiddleware {


### PR DESCRIPTION
This is an experiment

Instead of returning a Response to HTTPChannelHandler pass a ResponseWriter to the request handler. This change would not be propagated up the chain though, users would still be returning a Response from the Router. But Application would use the ResponseWriter to write the Response returned by the Router instead of passing it back to the HTTPChannelHandler.

Why would we do this? It gives us flexibility in the future to support things like 1xx headers, better support tracing maybe at the server level instead of the slightly flakey way we do it at the moment where we end the trace span in a non-structured way.

For most users this will have no visible effect.