### PR TITLE
Make ResponseBodyWriter methods mutating

### DIFF
--- a/Sources/HummingbirdCore/Response/ResponseBody.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBody.swift
@@ -18,7 +18,7 @@ import NIOCore
 /// Response body
 public struct ResponseBody: Sendable {
     @usableFromInline
-    let _write: @Sendable (any ResponseBodyWriter) async throws -> Void
+    let _write: @Sendable (inout any ResponseBodyWriter) async throws -> Void
     public let contentLength: Int?
 
     /// Initialise ResponseBody with closure writing body contents.
@@ -35,9 +35,9 @@ public struct ResponseBody: Sendable {
     /// - Parameters:
     ///   - contentLength: Optional length of body
     ///   - write: closure provided with `writer` type that can be used to write to response body
-    public init(contentLength: Int? = nil, _ write: @Sendable @escaping (any ResponseBodyWriter) async throws -> Void) {
+    public init(contentLength: Int? = nil, _ write: @Sendable @escaping (inout any ResponseBodyWriter) async throws -> Void) {
         self._write = { writer in
-            try await write(writer)
+            try await write(&writer)
         }
         self.contentLength = contentLength
     }
@@ -70,8 +70,8 @@ public struct ResponseBody: Sendable {
     }
 
     @inlinable
-    public consuming func write(_ writer: any ResponseBodyWriter) async throws {
-        try await self._write(writer)
+    public consuming func write(_ writer: consuming any ResponseBodyWriter) async throws {
+        try await self._write(&writer)
     }
 
     /// Returns a ResponseBody containing the results of mapping the given closure over the sequence of

--- a/Sources/HummingbirdTesting/RouterTestFramework.swift
+++ b/Sources/HummingbirdTesting/RouterTestFramework.swift
@@ -140,7 +140,7 @@ struct RouterTestFramework<Responder: HTTPResponder>: ApplicationTestFramework w
         var port: Int? { nil }
     }
 
-    final class RouterResponseWriter: ResponseBodyWriter {
+    struct RouterResponseWriter: ResponseBodyWriter {
         let values: NIOLockedValueBox<(body: ByteBuffer, trailingHeaders: HTTPFields?)>
 
         init() {

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -126,7 +126,7 @@ class HummingBirdCoreTests: XCTestCase {
         @Sendable func helloResponder(to request: Request, responseWriter: consuming ResponseWriter, channel: Channel) async throws {
             try? await Task.sleep(for: .milliseconds(10))
             let responseBody = channel.allocator.buffer(string: "Hello")
-            let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+            var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
             try await bodyWriter.write(responseBody)
             try await bodyWriter.finish(nil)
         }
@@ -171,7 +171,7 @@ class HummingBirdCoreTests: XCTestCase {
                     try await responseWriter.writeResponse(.init(status: .contentTooLarge))
                     return
                 }
-                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(buffer)
                 try await bodyWriter.finish(nil)
             },
@@ -190,7 +190,7 @@ class HummingBirdCoreTests: XCTestCase {
         try await testServer(
             responder: { (_, responseWriter: consuming ResponseWriter, _) in
                 let buffer = Self.randomBuffer(size: 1_140_000)
-                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(buffer)
                 try await bodyWriter.finish(nil)
             },
@@ -207,7 +207,7 @@ class HummingBirdCoreTests: XCTestCase {
     func testStreamBody() async throws {
         try await testServer(
             responder: { (request, responseWriter: consuming ResponseWriter, _) in
-                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(request.body)
                 try await bodyWriter.finish(nil)
             },
@@ -225,7 +225,7 @@ class HummingBirdCoreTests: XCTestCase {
     func testStreamBodyWriteSlow() async throws {
         try await testServer(
             responder: { (request, responseWriter: consuming ResponseWriter, _) in
-                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(request.body.delayed())
                 try await bodyWriter.finish(nil)
             },
@@ -255,7 +255,7 @@ class HummingBirdCoreTests: XCTestCase {
         }
         try await testServer(
             responder: { (request, responseWriter: consuming ResponseWriter, _) in
-                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(request.body.delayed())
                 try await bodyWriter.finish(nil)
             },
@@ -497,7 +497,7 @@ class HummingBirdCoreTests: XCTestCase {
             ) { (request, responseWriter: consuming ResponseWriter, _) in
                 await handlerPromise.complete(())
                 try? await Task.sleep(for: .milliseconds(500))
-                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(request.body.delayed())
                 try await bodyWriter.finish(nil)
             } onServerRunning: {

--- a/Tests/HummingbirdCoreTests/TestUtils.swift
+++ b/Tests/HummingbirdCoreTests/TestUtils.swift
@@ -27,7 +27,7 @@ public enum TestErrors: Error {
 /// Basic responder that just returns "Hello" in body
 @Sendable public func helloResponder(to request: Request, responseWriter: consuming ResponseWriter, channel: Channel) async throws {
     let responseBody = channel.allocator.buffer(string: "Hello")
-    let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+    var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
     try await bodyWriter.write(responseBody)
     try await bodyWriter.finish(nil)
 }

--- a/Tests/HummingbirdRouterTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdRouterTests/MiddlewareTests.swift
@@ -131,14 +131,14 @@ final class MiddlewareTests: XCTestCase {
 
     func testMiddlewareResponseBodyWriter() async throws {
         struct TransformWriter: ResponseBodyWriter {
-            let parentWriter: any ResponseBodyWriter
+            var parentWriter: any ResponseBodyWriter
 
-            func write(_ buffer: ByteBuffer) async throws {
+            mutating func write(_ buffer: ByteBuffer) async throws {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
                 try await self.parentWriter.write(output)
             }
 
-            func finish(_ trailingHeaders: HTTPFields?) async throws {
+            consuming func finish(_ trailingHeaders: HTTPFields?) async throws {
                 var trailingHeaders = trailingHeaders ?? [:]
                 trailingHeaders[.middleware2] = "test2"
                 try await self.parentWriter.finish(trailingHeaders)

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -145,14 +145,14 @@ final class MiddlewareTests: XCTestCase {
 
     func testMiddlewareResponseBodyWriter() async throws {
         struct TransformWriter: ResponseBodyWriter {
-            let parentWriter: any ResponseBodyWriter
+            var parentWriter: any ResponseBodyWriter
 
-            func write(_ buffer: ByteBuffer) async throws {
+            mutating func write(_ buffer: ByteBuffer) async throws {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
                 try await self.parentWriter.write(output)
             }
 
-            func finish(_ trailingHeaders: HTTPFields?) async throws {
+            consuming func finish(_ trailingHeaders: HTTPFields?) async throws {
                 try await self.parentWriter.finish(trailingHeaders)
             }
         }
@@ -186,9 +186,9 @@ final class MiddlewareTests: XCTestCase {
 
     func testMappedResponseBodyWriter() async throws {
         struct TransformWriter: ResponseBodyWriter {
-            let parentWriter: any ResponseBodyWriter
+            var parentWriter: any ResponseBodyWriter
 
-            func write(_ buffer: ByteBuffer) async throws {
+            mutating func write(_ buffer: ByteBuffer) async throws {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
                 try await self.parentWriter.write(output)
             }


### PR DESCRIPTION
This means a `ResponseBodyWriter` with internal mutable state isn't forced to be reference object. 
