### PR TITLE
Remove async from Environment.dotEnv()

### DIFF
--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -127,13 +127,13 @@ public struct Environment: Sendable, Decodable, ExpressibleByDictionaryLiteral {
     }
 
     /// Create Environment initialised from the `.env` file
-    public static func dotEnv(_ dovEnvPath: String = ".env") async throws -> Self {
-        guard let dotEnv = await loadDotEnv(dovEnvPath) else { return [:] }
+    public static func dotEnv(_ dovEnvPath: String = ".env") throws -> Self {
+        guard let dotEnv = loadDotEnv(dovEnvPath) else { return [:] }
         return try .init(rawValues: self.parseDotEnv(dotEnv))
     }
 
     /// Load `.env` file into string
-    internal static func loadDotEnv(_ dovEnvPath: String = ".env") async -> String? {
+    internal static func loadDotEnv(_ dovEnvPath: String = ".env") -> String? {
         do {
             let fileHandle = try NIOFileHandle(path: dovEnvPath)
             defer {


### PR DESCRIPTION
`Environment.dotEnv(_:)` was marked `async` despite not performing any async actions. This was complicating my attempts to extract `Environment` as a dependency with [swift-dependencies](https://github.com/pointfreeco/swift-dependencies) as that library assumes that dependencies can be synchronously initialized.

As far as I can tell, there's no need for `dotEnv(_:)` to be `async` so I've removed the superfluous keywords.