### PR TITLE
Type erasing ResponseBodyWriter

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -127,7 +127,7 @@ extension ApplicationProtocol {
             }
             // Write response
             let bodyWriter = try await responseWriter.writeHead(response.head)
-            try await response.body.write(bodyWriter)
+            try await response.body.write(.init(bodyWriter))
         } onServerRunning: {
             await self.onServerRunning($0)
         }

--- a/Sources/Hummingbird/Configuration.swift
+++ b/Sources/Hummingbird/Configuration.swift
@@ -48,10 +48,10 @@ public struct ApplicationConfiguration: Sendable {
     /// - Parameters:
     ///   - address: Bind address for server
     ///   - serverName: Server name to return in "server" header
-    ///   - backlog: the maximum length for the queue of pending connections.  If a connection request 
+    ///   - backlog: the maximum length for the queue of pending connections.  If a connection request
     ///         arrives with the queue full, the client may receive an error with an indication of ECONNREFUSE
     ///   - reuseAddress: Allows socket to be bound to an address that is already in use.
-    ///   - availableConnectionsDelegate: Object deciding on when we should accept new connection. Use 
+    ///   - availableConnectionsDelegate: Object deciding on when we should accept new connection. Use
     ///         ``HummingbirdCore/MaximumAvailableConnections`` to set the maximum allowed connections.
     public init(
         address: BindAddress = .hostname(),
@@ -77,7 +77,7 @@ public struct ApplicationConfiguration: Sendable {
     ///   - address: Bind address for server
     ///   - serverName: Server name to return in "server" header
     ///   - reuseAddress: Allows socket to be bound to an address that is already in use.
-    ///   - availableConnectionsDelegate: Object deciding on when we should accept new connection. Use 
+    ///   - availableConnectionsDelegate: Object deciding on when we should accept new connection. Use
     ///         ``HummingbirdCore/MaximumAvailableConnections`` to set the maximum allowed connections.
     ///   - tlsOptions: TLS options for when you are using NIOTransportServices
     public init(

--- a/Sources/Hummingbird/Exports.swift
+++ b/Sources/Hummingbird/Exports.swift
@@ -17,7 +17,8 @@
 @_exported import struct HummingbirdCore.RequestBody
 @_exported import struct HummingbirdCore.Response
 @_exported import struct HummingbirdCore.ResponseBody
-@_exported import protocol HummingbirdCore.ResponseBodyWriter
+@_exported import struct HummingbirdCore.ResponseBodyWriter
+@_exported import protocol HummingbirdCore.ResponseBodyWriterProtocol
 #if canImport(Network)
 @_exported import struct HummingbirdCore.TSTLSOptions
 #endif

--- a/Sources/HummingbirdCore/Deprecations.swift
+++ b/Sources/HummingbirdCore/Deprecations.swift
@@ -26,8 +26,8 @@ public typealias HBRequestBody = RequestBody
 public typealias HBResponse = Response
 @_documentation(visibility: internal) @available(*, unavailable, renamed: "ResponseBody")
 public typealias HBResponseBody = ResponseBody
-@_documentation(visibility: internal) @available(*, unavailable, renamed: "ResponseBodyWriter")
-public typealias HBResponseBodyWriter = ResponseBodyWriter
+@_documentation(visibility: internal) @available(*, unavailable, renamed: "ResponseBodyWriterProtocol")
+public typealias HBResponseBodyWriter = ResponseBodyWriterProtocol
 @_documentation(visibility: internal) @available(*, unavailable, renamed: "Server")
 public typealias HBServer = Server
 @_documentation(visibility: internal) @available(*, unavailable, renamed: "ServerConfiguration")

--- a/Sources/HummingbirdCore/Response/ResponseBody.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBody.swift
@@ -18,7 +18,7 @@ import NIOCore
 /// Response body
 public struct ResponseBody: Sendable {
     @usableFromInline
-    let _write: @Sendable (inout any ResponseBodyWriter) async throws -> Void
+    let _write: @Sendable (inout ResponseBodyWriter) async throws -> Void
     public let contentLength: Int?
 
     /// Initialise ResponseBody with closure writing body contents.
@@ -36,7 +36,7 @@ public struct ResponseBody: Sendable {
     /// - Parameters:
     ///   - contentLength: Optional length of body
     ///   - write: closure provided with `writer` type that can be used to write to response body
-    public init(contentLength: Int? = nil, _ write: @Sendable @escaping (inout any ResponseBodyWriter) async throws -> Void) {
+    public init(contentLength: Int? = nil, _ write: @Sendable @escaping (inout ResponseBodyWriter) async throws -> Void) {
         self._write = { writer in
             try await write(&writer)
         }
@@ -62,7 +62,7 @@ public struct ResponseBody: Sendable {
     /// Initialise ResponseBody that contains a sequence of ByteBuffers
     /// - Parameter byteBuffers: Sequence of ByteBuffers to write
     public init<BufferSequence: Sequence & Sendable>(contentsOf byteBuffers: BufferSequence) where BufferSequence.Element == ByteBuffer {
-        self.init(contentLength: byteBuffers.map { $0.readableBytes }.reduce(0, +)) { writer in
+        self.init(contentLength: byteBuffers.map(\.readableBytes).reduce(0, +)) { writer in
             try await writer.write(contentsOf: byteBuffers)
             try await writer.finish(nil)
         }
@@ -78,7 +78,7 @@ public struct ResponseBody: Sendable {
     }
 
     @inlinable
-    public consuming func write(_ writer: consuming any ResponseBodyWriter) async throws {
+    public consuming func write(_ writer: consuming ResponseBodyWriter) async throws {
         try await self._write(&writer)
     }
 

--- a/Sources/HummingbirdCore/Response/ResponseBodyWriter+map.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBodyWriter+map.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPTypes
+import NIOCore
+
+/// Response body writer with transform applied to each element written
+@usableFromInline
+struct MappedResponseBodyWriter<ParentWriter: ResponseBodyWriterProtocol>: ResponseBodyWriterProtocol {
+    var parentWriter: ParentWriter
+    var transform: @Sendable (ByteBuffer) async throws -> ByteBuffer
+
+    @usableFromInline
+    init(parentWriter: ParentWriter, transform: @escaping @Sendable (ByteBuffer) async throws -> ByteBuffer) {
+        self.parentWriter = parentWriter
+        self.transform = transform
+    }
+
+    /// Write a single ByteBuffer
+    /// - Parameter buffer: single buffer to write
+    @usableFromInline
+    mutating func write(_ buffer: ByteBuffer) async throws {
+        try await self.parentWriter.write(self.transform(buffer))
+    }
+
+    /// Write a sequence of ByteBuffers
+    /// - Parameter buffers: Sequence of buffers
+    @usableFromInline
+    mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
+        for part in buffers {
+            try await self.parentWriter.write(self.transform(part))
+        }
+    }
+
+    /// Finish writing body
+    /// - Parameter trailingHeaders: Any trailing headers you want to include at end
+    @usableFromInline
+    consuming func finish(_ trailingHeaders: HTTPFields?) async throws {
+        try await self.parentWriter.finish(trailingHeaders)
+    }
+}
+
+extension ResponseBodyWriter {
+    /// Return ResponseBodyWriter that applies transform to all ByteBuffers written to it
+    /// ResponseBodyWriter.
+    @inlinable
+    public consuming func map(_ transform: @escaping @Sendable (ByteBuffer) async throws -> ByteBuffer) -> ResponseBodyWriter {
+        self.wrapped._map(transform)
+    }
+}
+
+extension ResponseBodyWriterProtocol {
+    /// Return ResponseBodyWriter that applies transform to all ByteBuffers written to it
+    /// ResponseBodyWriter.
+    ///
+    /// Used internally to ensure we aren't passing an existential writer around that references another existential writer
+    @usableFromInline
+    consuming func _map(_ transform: @escaping @Sendable (ByteBuffer) async throws -> ByteBuffer) -> ResponseBodyWriter {
+        .init(MappedResponseBodyWriter(parentWriter: self, transform: transform))
+    }
+}

--- a/Sources/HummingbirdCore/Response/ResponseBodyWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBodyWriter.swift
@@ -15,67 +15,24 @@
 import HTTPTypes
 import NIOCore
 
-/// HTTP Response Body part writer
-public protocol ResponseBodyWriter {
-    /// Write a single ByteBuffer
-    /// - Parameter buffer: single buffer to write
-    mutating func write(_ buffer: ByteBuffer) async throws
-    /// Write a sequence of ByteBuffers
-    /// - Parameter buffers: Sequence of buffers
-    mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws
-    /// Finish writing body
-    /// - Parameter trailingHeaders: Any trailing headers you want to include at end
-    consuming func finish(_ trailingHeaders: HTTPFields?) async throws
-}
+/// Type erasing ``ResponseBodyWriterProtocol``.
+///
+/// Holds a pointer to any ResponseBodyWriterProtocol.
+public struct ResponseBodyWriter: ResponseBodyWriterProtocol {
+    public var wrapped: any ResponseBodyWriterProtocol
 
-extension ResponseBodyWriter {
-    /// Default implementation of writing a sequence of ByteBuffers
     @inlinable
-    public mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
-        for part in buffers {
-            try await self.write(part)
-        }
+    public init(_ writer: some ResponseBodyWriterProtocol) {
+        self.wrapped = writer
     }
 
-    ///  Write AsyncSequence of ByteBuffers
-    /// - Parameter buffers: ByteBuffer AsyncSequence
     @inlinable
-    public mutating func write<BufferSequence: AsyncSequence>(_ buffers: BufferSequence) async throws where BufferSequence.Element == ByteBuffer {
-        for try await buffer in buffers {
-            try await self.write(buffer)
-        }
-    }
-}
-
-struct MappedResponseBodyWriter<ParentWriter: ResponseBodyWriter>: ResponseBodyWriter {
-    fileprivate var parentWriter: ParentWriter
-    fileprivate let transform: @Sendable (ByteBuffer) async throws -> ByteBuffer
-
-    /// Write a single ByteBuffer
-    /// - Parameter buffer: single buffer to write
-    mutating func write(_ buffer: ByteBuffer) async throws {
-        try await self.parentWriter.write(self.transform(buffer))
+    public mutating func write(_ buffer: NIOCore.ByteBuffer) async throws {
+        try await self.wrapped.write(buffer)
     }
 
-    /// Write a sequence of ByteBuffers
-    /// - Parameter buffers: Sequence of buffers
-    mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
-        for part in buffers {
-            try await self.parentWriter.write(self.transform(part))
-        }
-    }
-
-    /// Finish writing body
-    /// - Parameter trailingHeaders: Any trailing headers you want to include at end
-    consuming func finish(_ trailingHeaders: HTTPFields?) async throws {
-        try await self.parentWriter.finish(trailingHeaders)
-    }
-}
-
-extension ResponseBodyWriter {
-    /// Return ResponseBodyWriter that applies transform to all ByteBuffers written to it
-    /// ResponseBodyWriter.
-    public consuming func map(_ transform: @escaping @Sendable (ByteBuffer) async throws -> ByteBuffer) -> some ResponseBodyWriter {
-        MappedResponseBodyWriter(parentWriter: self, transform: transform)
+    @inlinable
+    public func finish(_ trailingHeaders: HTTPTypes.HTTPFields? = nil) async throws {
+        try await self.wrapped.finish(trailingHeaders)
     }
 }

--- a/Sources/HummingbirdCore/Response/ResponseBodyWriterProtocol.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBodyWriterProtocol.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPTypes
+import NIOCore
+
+/// HTTP Response Body part writer
+public protocol ResponseBodyWriterProtocol {
+    /// Write a single ByteBuffer
+    /// - Parameter buffer: single buffer to write
+    mutating func write(_ buffer: ByteBuffer) async throws
+    /// Write a sequence of ByteBuffers
+    /// - Parameter buffers: Sequence of buffers
+    mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws
+    /// Finish writing body
+    /// - Parameter trailingHeaders: Any trailing headers you want to include at end
+    consuming func finish(_ trailingHeaders: HTTPFields?) async throws
+}
+
+extension ResponseBodyWriterProtocol {
+    /// Default implementation of writing a sequence of ByteBuffers
+    @inlinable
+    public mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
+        for part in buffers {
+            try await self.write(part)
+        }
+    }
+
+    ///  Write AsyncSequence of ByteBuffers
+    /// - Parameter buffers: ByteBuffer AsyncSequence
+    @inlinable
+    public mutating func write<BufferSequence: AsyncSequence>(_ buffers: BufferSequence) async throws where BufferSequence.Element == ByteBuffer {
+        for try await buffer in buffers {
+            try await self.write(buffer)
+        }
+    }
+}

--- a/Sources/HummingbirdCore/Response/ResponseWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseWriter.swift
@@ -26,9 +26,9 @@ public struct ResponseWriter: ~Copyable {
     /// - Parameter head: Response head
     /// - Returns: Response body writer used to write HTTP response body
     @inlinable
-    public consuming func writeHead(_ head: HTTPResponse) async throws -> some ResponseBodyWriter {
+    public consuming func writeHead(_ head: HTTPResponse) async throws -> ResponseBodyWriter {
         try await self.outbound.write(.head(head))
-        return RootResponseBodyWriter(outbound: self.outbound)
+        return .init(RootResponseBodyWriter(outbound: self.outbound))
     }
 
     /// Write Informational HTTP head part
@@ -52,7 +52,7 @@ public struct ResponseWriter: ~Copyable {
 
 /// ResponseBodyWriter that writes ByteBuffers to AsyncChannel outbound writer
 @usableFromInline
-struct RootResponseBodyWriter: Sendable, ResponseBodyWriter {
+struct RootResponseBodyWriter: Sendable, ResponseBodyWriterProtocol {
     typealias Out = HTTPResponsePart
     /// The components of a HTTP response from the view of a HTTP server.
     public typealias OutboundWriter = NIOAsyncChannelOutboundWriter<Out>

--- a/Sources/HummingbirdTesting/RouterTestFramework.swift
+++ b/Sources/HummingbirdTesting/RouterTestFramework.swift
@@ -119,7 +119,7 @@ struct RouterTestFramework<Responder: HTTPResponder>: ApplicationTestFramework w
                         response = Response(status: .internalServerError)
                     }
                     let responseWriter = RouterResponseWriter()
-                    try await response.body.write(responseWriter)
+                    try await response.body.write(.init(responseWriter))
                     return responseWriter.values.withLockedValue { values in
                         TestResponse(head: response.head, body: values.body, trailerHeaders: values.trailingHeaders)
                     }
@@ -140,7 +140,7 @@ struct RouterTestFramework<Responder: HTTPResponder>: ApplicationTestFramework w
         var port: Int? { nil }
     }
 
-    struct RouterResponseWriter: ResponseBodyWriter {
+    struct RouterResponseWriter: ResponseBodyWriterProtocol {
         let values: NIOLockedValueBox<(body: ByteBuffer, trailingHeaders: HTTPFields?)>
 
         init() {

--- a/Tests/HummingbirdRouterTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdRouterTests/MiddlewareTests.swift
@@ -14,6 +14,7 @@
 
 import HTTPTypes
 import Hummingbird
+import HummingbirdCore
 import HummingbirdRouter
 import HummingbirdTesting
 import Logging
@@ -130,8 +131,8 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testMiddlewareResponseBodyWriter() async throws {
-        struct TransformWriter: ResponseBodyWriter {
-            var parentWriter: any ResponseBodyWriter
+        struct TransformWriter: ResponseBodyWriterProtocol {
+            var parentWriter: any ResponseBodyWriterProtocol
 
             mutating func write(_ buffer: ByteBuffer) async throws {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
@@ -150,7 +151,7 @@ final class MiddlewareTests: XCTestCase {
                 var editedResponse = response
                 editedResponse.body = .init { writer in
                     let transformWriter = TransformWriter(parentWriter: writer)
-                    try await response.body.write(transformWriter)
+                    try await response.body.write(.init(transformWriter))
                 }
                 return editedResponse
             }

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -762,7 +762,7 @@ final class ApplicationTests: XCTestCase {
             let error: ErrorFormat
         }
 
-        final class CollatedResponseWriter: ResponseBodyWriter {
+        final class CollatedResponseWriter: ResponseBodyWriterProtocol {
             let collated: NIOLockedValueBox<ByteBuffer>
 
             init() {
@@ -799,7 +799,7 @@ final class ApplicationTests: XCTestCase {
             let error = HTTPError(.internalServerError, message: message)
             let response = try error.response(from: request, context: context)
             let writer = CollatedResponseWriter()
-            _ = try await response.body.write(writer)
+            _ = try await response.body.write(.init(writer))
             let format = try JSONDecoder().decode(HTTPErrorFormat.self, from: writer.collated.withLockedValue { $0 })
             XCTAssertEqual(format.error.message, message)
         }

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -144,8 +144,8 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testMiddlewareResponseBodyWriter() async throws {
-        struct TransformWriter: ResponseBodyWriter {
-            var parentWriter: any ResponseBodyWriter
+        struct TransformWriter: ResponseBodyWriterProtocol {
+            var parentWriter: any ResponseBodyWriterProtocol
 
             mutating func write(_ buffer: ByteBuffer) async throws {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
@@ -162,7 +162,7 @@ final class MiddlewareTests: XCTestCase {
                 var editedResponse = response
                 editedResponse.body = .init { writer in
                     let transformWriter = TransformWriter(parentWriter: writer)
-                    try await response.body.write(transformWriter)
+                    try await response.body.write(.init(transformWriter))
                 }
                 return editedResponse
             }
@@ -185,8 +185,8 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testMappedResponseBodyWriter() async throws {
-        struct TransformWriter: ResponseBodyWriter {
-            var parentWriter: any ResponseBodyWriter
+        struct TransformWriter: ResponseBodyWriterProtocol {
+            var parentWriter: any ResponseBodyWriterProtocol
 
             mutating func write(_ buffer: ByteBuffer) async throws {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })


### PR DESCRIPTION
- Rename ResponseBodyWriter to ResponseBodyWriterProtocol
- Add type ResponseBodyWriter that holds an existential ResponseBodyWriterProtocol
- Broke code into three files to make it easier to read