### PR TITLE
chore(metrics): renamed hb_request_duration to hb_request_duration_se…

### DIFF
--- a/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
@@ -36,7 +36,7 @@ public struct MetricsMiddleware<Context: RequestContext>: RouterMiddleware {
                 ]
                 Counter(label: "hb_requests", dimensions: dimensions).increment()
                 Metrics.Timer(
-                    label: "hb_request_duration",
+                    label: "hb_request_duration_seconds",
                     dimensions: dimensions,
                     preferredDisplayUnit: .seconds
                 ).recordNanoseconds(DispatchTime.now().uptimeNanoseconds - startTime)

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -14,7 +14,7 @@
 
 import Hummingbird
 import HummingbirdTesting
-@preconcurrency import Metrics
+import Metrics
 import NIOConcurrencyHelpers
 import XCTest
 
@@ -283,7 +283,7 @@ final class MetricsTests: XCTestCase {
             try await client.execute(uri: "/hello", method: .get) { _ in }
         }
 
-        let timer = try XCTUnwrap(Self.testMetrics.timers.withLockedValue { $0 }["hb_request_duration"] as? TestTimer)
+        let timer = try XCTUnwrap(Self.testMetrics.timers.withLockedValue { $0 }["hb_request_duration_seconds"] as? TestTimer)
         XCTAssertGreaterThan(timer.values.withLockedValue { $0 }[0].1, 5_000_000)
     }
 }


### PR DESCRIPTION
Renamed `hb_request_duration` to  `hb_request_duration_seconds`

I think it would be nice to expose the response status code if possible. This would afford us to compute metrics such as error status per method (GET, PUT, POST, DELETE) e.t.c