### PR TITLE
Remove @escaping from test closure in Application.test(_:_:)

### DIFF
--- a/Sources/HummingbirdTesting/Application+Test.swift
+++ b/Sources/HummingbirdTesting/Application+Test.swift
@@ -76,7 +76,7 @@ extension ApplicationProtocol {
     ///   - test: test function
     public func test<Value>(
         _ testingSetup: TestingSetup,
-        _ test: @escaping @Sendable (any TestClientProtocol) async throws -> Value
+        _ test: @Sendable (any TestClientProtocol) async throws -> Value
     ) async throws -> Value {
         let app: any ApplicationTestFramework = switch testingSetup.value {
         case .router: try await RouterTestFramework(app: self)

--- a/Sources/HummingbirdTesting/ApplicationTester.swift
+++ b/Sources/HummingbirdTesting/ApplicationTester.swift
@@ -93,5 +93,5 @@ protocol ApplicationTestFramework {
     associatedtype Client: TestClientProtocol
 
     /// Run test server
-    func run<Value>(_ test: @escaping @Sendable (any TestClientProtocol) async throws -> Value) async throws -> Value
+    func run<Value>(_ test: @Sendable (any TestClientProtocol) async throws -> Value) async throws -> Value
 }

--- a/Sources/HummingbirdTesting/AsyncHTTPClientTestFramework.swift
+++ b/Sources/HummingbirdTesting/AsyncHTTPClientTestFramework.swift
@@ -56,7 +56,7 @@ final class AsyncHTTPClientTestFramework<App: ApplicationProtocol>: ApplicationT
     }
 
     /// Start tests
-    func run<Value>(_ test: @escaping @Sendable (TestClientProtocol) async throws -> Value) async throws -> Value {
+    func run<Value>(_ test: @Sendable (TestClientProtocol) async throws -> Value) async throws -> Value {
         try await withThrowingTaskGroup(of: Void.self) { group in
             let serviceGroup = ServiceGroup(
                 configuration: .init(

--- a/Sources/HummingbirdTesting/LiveTestFramework.swift
+++ b/Sources/HummingbirdTesting/LiveTestFramework.swift
@@ -49,7 +49,7 @@ final class LiveTestFramework<App: ApplicationProtocol>: ApplicationTestFramewor
     }
 
     /// Start tests
-    func run<Value>(_ test: @escaping @Sendable (TestClientProtocol) async throws -> Value) async throws -> Value {
+    func run<Value>(_ test: @Sendable (TestClientProtocol) async throws -> Value) async throws -> Value {
         try await withThrowingTaskGroup(of: Void.self) { group in
             let serviceGroup = ServiceGroup(
                 configuration: .init(

--- a/Sources/HummingbirdTesting/RouterTestFramework.swift
+++ b/Sources/HummingbirdTesting/RouterTestFramework.swift
@@ -48,7 +48,7 @@ struct RouterTestFramework<Responder: HTTPResponder>: ApplicationTestFramework w
     }
 
     /// Run test
-    func run<Value>(_ test: @escaping @Sendable (TestClientProtocol) async throws -> Value) async throws -> Value {
+    func run<Value>(_ test: @Sendable (TestClientProtocol) async throws -> Value) async throws -> Value {
         let client = Client(
             responder: self.responder,
             logger: self.logger,


### PR DESCRIPTION
In theory this should be non-breaking