### PR TITLE
Additional init for HTTPError, fix content type

### DIFF
--- a/Sources/Hummingbird/Error/HTTPError.swift
+++ b/Sources/Hummingbird/Error/HTTPError.swift
@@ -20,17 +20,8 @@ import NIOFoundationCompat
 public struct HTTPError: Error, HTTPResponseError, Sendable {
     /// status code for the error
     public var status: HTTPResponse.Status
-    /// internal representation of error headers without contentType
-    private var _headers: HTTPFields
-    /// headers
-    public var headers: HTTPFields {
-        get {
-            return self.body != nil ? self._headers + [.contentType: "application/json; charset=utf-8"] : self._headers
-        }
-        set {
-            self._headers = newValue
-        }
-    }
+    /// response headers
+    public var headers: HTTPFields
 
     /// error message
     public var body: String?
@@ -40,7 +31,7 @@ public struct HTTPError: Error, HTTPResponseError, Sendable {
     ///   - status: HTTP status
     public init(_ status: HTTPResponse.Status) {
         self.status = status
-        self._headers = [:]
+        self.headers = [:]
         self.body = nil
     }
 
@@ -50,7 +41,7 @@ public struct HTTPError: Error, HTTPResponseError, Sendable {
     ///   - message: Associated message
     public init(_ status: HTTPResponse.Status, message: String) {
         self.status = status
-        self._headers = [:]
+        self.headers = [:]
         self.body = message
     }
 
@@ -61,7 +52,7 @@ public struct HTTPError: Error, HTTPResponseError, Sendable {
     ///   - message: Optional associated message
     public init(_ status: HTTPResponse.Status, headers: HTTPFields, message: String? = nil) {
         self.status = status
-        self._headers = headers
+        self.headers = headers
         self.body = message
     }
 

--- a/Sources/Hummingbird/Error/HTTPError.swift
+++ b/Sources/Hummingbird/Error/HTTPError.swift
@@ -54,6 +54,17 @@ public struct HTTPError: Error, HTTPResponseError, Sendable {
         self.body = message
     }
 
+    /// Initialize HTTPError
+    /// - Parameters:
+    ///   - status: HTTP status
+    ///   - headers: Headers to include in error
+    ///   - message: Optional associated message
+    public init(_ status: HTTPResponse.Status, headers: HTTPFields, message: String? = nil) {
+        self.status = status
+        self._headers = headers
+        self.body = message
+    }
+
     fileprivate struct CodableFormat: Encodable {
         struct ErrorFormat: Encodable {
             let message: String

--- a/Tests/HummingbirdTests/URLEncodedForm/Application+URLEncodedFormTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/Application+URLEncodedFormTests.swift
@@ -71,4 +71,19 @@ final class HummingBirdURLEncodedTests: XCTestCase {
             }
         }
     }
+
+    func testError() async throws {
+        let router = Router(context: URLEncodedCodingRequestContext.self)
+        router.get("/error") { _, _ -> User in
+            throw HTTPError(.badRequest, message: "Bad Request")
+        }
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/error", method: .get) { response in
+                XCTAssertEqual(response.status, .badRequest)
+                XCTAssertEqual(response.headers[.contentType], "application/x-www-form-urlencoded")
+                XCTAssertEqual(String(buffer: response.body), "error[message]=Bad%20Request")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add new init
Removed the automatic addition of JSON content type, this is set by the response encoder