### PR TITLE
Add route controller for better composability. (#565)

### DIFF
--- a/Sources/Hummingbird/Error/HTTPError.swift
+++ b/Sources/Hummingbird/Error/HTTPError.swift
@@ -20,17 +20,8 @@ import NIOFoundationCompat
 public struct HTTPError: Error, HTTPResponseError, Sendable {
     /// status code for the error
     public var status: HTTPResponse.Status
-    /// internal representation of error headers without contentType
-    private var _headers: HTTPFields
-    /// headers
-    public var headers: HTTPFields {
-        get {
-            return self.body != nil ? self._headers + [.contentType: "application/json; charset=utf-8"] : self._headers
-        }
-        set {
-            self._headers = newValue
-        }
-    }
+    /// response headers
+    public var headers: HTTPFields
 
     /// error message
     public var body: String?
@@ -40,7 +31,7 @@ public struct HTTPError: Error, HTTPResponseError, Sendable {
     ///   - status: HTTP status
     public init(_ status: HTTPResponse.Status) {
         self.status = status
-        self._headers = [:]
+        self.headers = [:]
         self.body = nil
     }
 
@@ -50,7 +41,18 @@ public struct HTTPError: Error, HTTPResponseError, Sendable {
     ///   - message: Associated message
     public init(_ status: HTTPResponse.Status, message: String) {
         self.status = status
-        self._headers = [:]
+        self.headers = [:]
+        self.body = message
+    }
+
+    /// Initialize HTTPError
+    /// - Parameters:
+    ///   - status: HTTP status
+    ///   - headers: Headers to include in error
+    ///   - message: Optional associated message
+    public init(_ status: HTTPResponse.Status, headers: HTTPFields, message: String? = nil) {
+        self.status = status
+        self.headers = headers
         self.body = message
     }
 

--- a/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
+++ b/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
@@ -29,7 +29,8 @@ public actor MemoryPersistDriver<C: Clock>: PersistDriver where C.Duration == Du
     }
 
     public func set(key: String, value: some Codable & Sendable, expires: Duration?) async throws {
-        self.values[key] = .init(value: value, expires: expires.map { self.clock.now.advanced(by: $0) })
+        let expiresAt = expires.map { self.clock.now.advanced(by: $0) } ?? self.values[key]?.expires
+        self.values[key] = .init(value: value, expires: expiresAt)
     }
 
     public func get<Object: Codable & Sendable>(key: String, as: Object.Type) async throws -> Object? {

--- a/Sources/Hummingbird/Storage/PersistDriver.swift
+++ b/Sources/Hummingbird/Storage/PersistDriver.swift
@@ -31,7 +31,8 @@ public protocol PersistDriver: Service {
     /// - Parameters:
     ///   - key: Key to store value against
     ///   - value: Codable value to store
-    ///   - expires: If non-nil defines time that value will expire
+    ///   - expires: If non-nil defines time that value will expire in. If nil and value already exists
+    ///      and it already has an expiration time then original expiration time should be conserved.
     func set<Object: Codable & Sendable>(key: String, value: Object, expires: Duration?) async throws
 
     /// get value for key

--- a/Sources/HummingbirdRouter/RouteController.swift
+++ b/Sources/HummingbirdRouter/RouteController.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023-2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+
+// MARK: - RouteController
+
+/// A type that defines a body of routes.
+///
+/// You can create custom controllers by declaring types that conform to the `RouteController`
+/// protocol. Implement the required ``RouteController/body`` computed property and provide a
+/// type for the controller's `Context`.
+///
+///     struct UsersController {
+///         typealias Context = BasicRouterRequestContext
+///
+///         var body: some RouterMiddleware<Context> {
+///             RouteGroup("/users") {
+///                 ...
+///             }
+///         }
+///     }
+///
+/// Assemble the controller's body by combining one or more components together to create
+/// a route. By nesting controllers within each other, you can compose large and complex
+/// routes from smaller more mangeable components.
+public protocol RouteController<Context> where Context == Body.Context {
+    associatedtype Context: RouterRequestContext
+    associatedtype Body: MiddlewareProtocol
+    @MiddlewareFixedTypeBuilder<Body.Input, Body.Output, Body.Context> var body: Body { get }
+}
+
+// MARK: - MiddlewareFixedTypeBuilder + RouteController
+
+/// Middleware stack result builder
+///
+/// Generates a middleware stack from the elements inside the result builder. The input,
+/// context and output types passed through the middleware stack are fixed and cannot be changed.
+extension MiddlewareFixedTypeBuilder {
+    public static func buildExpression<C0: RouteController>(_ c0: C0) -> C0.Body where C0.Body.Input == Input, C0.Body.Output == Output, C0.Body.Context == Context {
+        return c0.body
+    }
+
+    public static func buildBlock<C0: RouteController>(_ c0: C0) -> C0.Body {
+        return c0.body
+    }
+
+    public static func buildPartialBlock<C0: RouteController>(first: C0) -> C0.Body {
+        first.body
+    }
+
+    public static func buildPartialBlock<M0: MiddlewareProtocol, C0: RouteController>(
+        accumulated m0: M0,
+        next c0: C0
+    ) -> _Middleware2<M0, C0.Body> where M0.Input == C0.Body.Input, M0.Output == C0.Body.Output, M0.Context == C0.Body.Context {
+        _Middleware2(m0, c0.body)
+    }
+}
+
+// MARK: - RouteBuilder + RouteController
+
+extension RouteBuilder {
+    public static func buildExpression<C0: RouteController>(_ c0: C0) -> C0.Body where C0.Body.Input == Request, C0.Body.Output == Response, C0.Body.Context == Context {
+        c0.body
+    }
+
+    public static func buildPartialBlock<C0: RouteController>(first: C0) -> C0.Body {
+        first.body
+    }
+}

--- a/Tests/HummingbirdRouterTests/RouteControllerTests.swift
+++ b/Tests/HummingbirdRouterTests/RouteControllerTests.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+import HummingbirdRouter
+import HummingbirdTesting
+import XCTest
+
+final class RouteControllerTests: XCTestCase {
+    /// Test using a controller inside a router builder.
+    func testRouteControllerBody() async throws {
+        struct TestController: RouteController {
+            typealias Context = BasicRouterRequestContext
+            var body: some RouterMiddleware<Context> {
+                Get("/test") { _,_ in "xxx" }
+            }
+        }
+
+        let router = RouterBuilder(context: BasicRouterRequestContext.self) {
+            TestController()
+        }
+
+        let app = Application(responder: router)
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/test", method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), "xxx")
+            }
+        }
+    }
+
+    /// Test nesting controllers inside a router builder.
+    func testRouteControllerBodyWithNestedControllers() async throws {
+        struct ChildAController: RouteController {
+            typealias Context = BasicRouterRequestContext
+            var body: some RouterMiddleware<Context> {
+                RouteGroup("/child_a") {
+                    Get { _,_ in "child_a" }
+                }
+            }
+        }
+
+        struct ChildBController: RouteController {
+            typealias Context = BasicRouterRequestContext
+            var body: some RouterMiddleware<Context> {
+                RouteGroup("/child_b") {
+                    Get { _,_ in "child_b" }
+                }
+            }
+        }
+
+        struct ParentController: RouteController {
+            typealias Context = BasicRouterRequestContext
+            var body: some RouterMiddleware<Context> {
+                RouteGroup("/parent") {
+                    Get { _,_ in return "parent" }
+                    ChildAController()
+                    ChildBController()
+                    Get("child_c") { _,_ in "child_c" }
+                }
+            }
+        }
+
+        let router = RouterBuilder(context: BasicRouterRequestContext.self) {
+            ParentController()
+        }
+
+        let app = Application(responder: router)
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/parent", method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), "parent")
+            }
+        }
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/parent/child_a", method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), "child_a")
+            }
+        }
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/parent/child_b", method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), "child_b")
+            }
+        }
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/parent/child_c", method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), "child_c")
+            }
+        }
+    }
+}

--- a/Tests/HummingbirdTests/URLEncodedForm/Application+URLEncodedFormTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/Application+URLEncodedFormTests.swift
@@ -71,4 +71,19 @@ final class HummingBirdURLEncodedTests: XCTestCase {
             }
         }
     }
+
+    func testError() async throws {
+        let router = Router(context: URLEncodedCodingRequestContext.self)
+        router.get("/error") { _, _ -> User in
+            throw HTTPError(.badRequest, message: "Bad Request")
+        }
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/error", method: .get) { response in
+                XCTAssertEqual(response.status, .badRequest)
+                XCTAssertEqual(response.headers[.contentType], "application/x-www-form-urlencoded")
+                XCTAssertEqual(String(buffer: response.body), "error[message]=Bad%20Request")
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Description

Adds `RouteController` to improve the composability of routes when using `HummingbirdRouter`

Conforming to `RouteController` allows you to create composable routes in a more `SwiftUI` result builder style.

```swift
struct ChildAController: RouteController {
    typealias Context = BasicRouterRequestContext
    var body: some RouterMiddleware<Context> {
        RouteGroup("/child_a") {
            Get { _,_ in "child_a" }
        }
    }
}

struct ChildBController: RouteController {
    typealias Context = BasicRouterRequestContext
    var body: some RouterMiddleware<Context> {
        RouteGroup("/child_b") {
            Get { _,_ in "child_b" }
        }
    }
}

struct ParentController: RouteController {
    typealias Context = BasicRouterRequestContext
    var body: some RouterMiddleware<Context> {
        RouteGroup("/parent") {
            Get { _,_ in return "parent" }
            ChildAController()
            ChildBController()
            Get("child_c") { _,_ in "child_c" }
        }
    }
}
```