### PR TITLE
Remove async from dotEnv.

### DIFF
--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -132,13 +132,13 @@ public struct Environment: Sendable, Decodable, ExpressibleByDictionaryLiteral {
     }
 
     /// Create Environment initialised from the `.env` file
-    public static func dotEnv(_ dovEnvPath: String = ".env") async throws -> Self {
-        guard let dotEnv = await loadDotEnv(dovEnvPath) else { return [:] }
+    public static func dotEnv(_ dovEnvPath: String = ".env") throws -> Self {
+        guard let dotEnv = loadDotEnv(dovEnvPath) else { return [:] }
         return try .init(rawValues: self.parseDotEnv(dotEnv))
     }
 
     /// Load `.env` file into string
-    internal static func loadDotEnv(_ dovEnvPath: String = ".env") async -> String? {
+    internal static func loadDotEnv(_ dovEnvPath: String = ".env") -> String? {
         do {
             let fileHandle = try NIOFileHandle(path: dovEnvPath)
             defer {

--- a/Tests/HummingbirdTests/EnvironmentTests.swift
+++ b/Tests/HummingbirdTests/EnvironmentTests.swift
@@ -63,7 +63,7 @@ final class EnvironmentTests: XCTestCase {
         XCTAssertEqual(env.get("test_var"), "testSetFromEnvironment")
     }
 
-    func testDotEnvLoading() async throws {
+    func testDotEnvLoading() throws {
         let dotenv = """
         TEST=this
         CREDENTIALS=sdkfjh
@@ -75,7 +75,7 @@ final class EnvironmentTests: XCTestCase {
             try? FileManager.default.removeItem(at: envURL)
         }
 
-        let result = try await Environment.dotEnv()
+        let result = try Environment.dotEnv()
         XCTAssertEqual(result.get("test"), "this")
         XCTAssertEqual(result.get("credentials"), "sdkfjh")
     }
@@ -157,7 +157,7 @@ final class EnvironmentTests: XCTestCase {
         }
         XCTAssertEqual(setenv("TEST_VAR", "testSetFromEnvironment", 1), 0)
         XCTAssertEqual(setenv("TEST_VAR2", "testSetFromEnvironment2", 1), 0)
-        let env = try await Environment().merging(with: .dotEnv(".override.env"))
+        let env = try Environment().merging(with: .dotEnv(".override.env"))
         XCTAssertEqual(env.get("TEST_VAR"), "testDotEnvOverridingEnvironment")
         XCTAssertEqual(env.get("TEST_VAR2"), "testSetFromEnvironment2")
     }


### PR DESCRIPTION
The `dotEnv` function doesn't contain any asynchronous operations. Removing it allows consumers to load their environment in a non-asynchronous context.