### PR TITLE
Use Foundation.ProcessInfo for environment parsing

### DIFF
--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -112,8 +112,8 @@ public struct Environment: Sendable, Decodable, ExpressibleByDictionaryLiteral {
     /// Construct environment variable map
     static func getEnvironment() -> [String: String] {
         var values: [String: String] = [:]
-        for key in ProcessInfo.processInfo.environment.keys {
-            values[key.lowercased()] = ProcessInfo.processInfo.environment[key]
+        for item in ProcessInfo.processInfo.environment {
+            values[item.key.lowercased()] = item.value
         }
         return values
     }

--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -21,6 +21,7 @@ import Darwin.C
 #else
 #error("Unsupported platform")
 #endif
+import Foundation
 import HummingbirdCore
 import NIOCore
 
@@ -111,22 +112,8 @@ public struct Environment: Sendable, Decodable, ExpressibleByDictionaryLiteral {
     /// Construct environment variable map
     static func getEnvironment() -> [String: String] {
         var values: [String: String] = [:]
-        let equalSign = Character("=")
-        #if canImport(Musl)
-        guard let envp = environ else { return [:] }
-        #else
-        let envp = environ
-        #endif
-        var idx = 0
-
-        while let entry = envp.advanced(by: idx).pointee {
-            let entry = String(cString: entry)
-            if let i = entry.firstIndex(of: equalSign) {
-                let key = String(entry.prefix(upTo: i))
-                let value = String(entry.suffix(from: i).dropFirst())
-                values[key.lowercased()] = value
-            }
-            idx += 1
+        for key in ProcessInfo.processInfo.environment.keys {
+            values[key.lowercased()] = ProcessInfo.processInfo.environment[key]
         }
         return values
     }

--- a/Tests/HummingbirdTests/EnvironmentTests.swift
+++ b/Tests/HummingbirdTests/EnvironmentTests.swift
@@ -43,9 +43,9 @@ final class EnvironmentTests: XCTestCase {
 
     func testSetForAllEnvironments() {
         var env = Environment()
-        env.set("TEST_VAR", value: "testSet")
+        env.set("TEST_VAR_E1", value: "testSet")
         let env2 = Environment()
-        XCTAssertEqual(env2.get("TEST_VAR"), "testSet")
+        XCTAssertEqual(env2.get("TEST_VAR_E1"), "testSet")
     }
 
     func testLogLevel() {


### PR DESCRIPTION
Resolves #571 

- Simply replaces use of `environ` with `Foundation.ProcessInfo`
