### PR TITLE
Add route controller for better composability. (#565)

### DIFF
--- a/Sources/Hummingbird/Middleware/MiddlewareModule/MiddlewareStack.swift
+++ b/Sources/Hummingbird/Middleware/MiddlewareModule/MiddlewareStack.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// MARK: - Middleware2
+
 public struct _Middleware2<M0: MiddlewareProtocol, M1: MiddlewareProtocol>: MiddlewareProtocol where M0.Input == M1.Input, M0.Context == M1.Context, M0.Output == M1.Output {
     public typealias Input = M0.Input
     public typealias Output = M0.Output
@@ -33,6 +35,10 @@ public struct _Middleware2<M0: MiddlewareProtocol, M1: MiddlewareProtocol>: Midd
         }
     }
 }
+
+extension _Middleware2: RouterMiddleware where M0.Input == Request, M0.Output == Response {}
+
+// MARK: - MiddlewareFixedTypeBuilder
 
 /// Middleware stack result builder
 ///

--- a/Sources/HummingbirdRouter/RouterController.swift
+++ b/Sources/HummingbirdRouter/RouterController.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023-2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+
+// MARK: - RouterController
+
+/// A type that represents part of your app's middleware and routes
+///
+/// You create custom controllers by declaring types that conform to the `RouterController`
+/// protocol. Implement the required ``RouterController/body-swift.property`` computed
+/// property to provide the content for your custom controller.
+///
+///     struct MyController: RouterController {
+///         typealias Context = BasicRouterRequestContext
+///
+///         var body: some RouterMiddleware<Context> {
+///             Get("foo") { _,_ in "foo" }
+///         }
+///    }
+///
+/// Assemble the controller's body by combining one or more of the built-in controllers or middleware.
+/// provided by Hummingbird, plus other custom controllers that you define, into a hierarchy of controllers.
+public protocol RouterController<Context> {
+    associatedtype Context
+    associatedtype Body: RouterMiddleware<Context>
+    @MiddlewareFixedTypeBuilder<Request, Response, Context> var body: Body { get }
+}
+
+// MARK: MiddlewareFixedTypeBuilder + RouterController Builders
+
+extension MiddlewareFixedTypeBuilder {
+    public static func buildExpression<C0: RouterController>(_ c0: C0) -> C0.Body where C0.Body.Input == Input, C0.Body.Output == Output, C0.Body.Context == Context {
+        return c0.body
+    }
+}

--- a/Tests/HummingbirdRouterTests/ControllerTests.swift
+++ b/Tests/HummingbirdRouterTests/ControllerTests.swift
@@ -1,0 +1,152 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2023 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+import HummingbirdRouter
+import HummingbirdTesting
+import XCTest
+
+final class ControllerTests: XCTestCase {
+    func testRouterControllerWithSingleRoute() async throws {
+        struct TestController: RouterController {
+            typealias Context = BasicRouterRequestContext
+            var body: some RouterMiddleware<Context> {
+                Get("foo") { _, _ in "foo" }
+            }
+        }
+
+        let router = RouterBuilder(context: BasicRouterRequestContext.self) {
+            TestController()
+        }
+
+        let app = Application(responder: router)
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/foo", method: .get) {
+                XCTAssertEqual(String(buffer: $0.body), "foo")
+            }
+        }
+    }
+
+    func testRouterControllerWithMultipleRoutes() async throws {
+        struct TestController: RouterController {
+            typealias Context = BasicRouterRequestContext
+            var body: some RouterMiddleware<Context> {
+                Get("foo") { _, _ in "foo" }
+                Get("bar") { _, _ in "bar" }
+            }
+        }
+
+        let router = RouterBuilder(context: BasicRouterRequestContext.self) {
+            TestController()
+        }
+
+        let app = Application(responder: router)
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/foo", method: .get) {
+                XCTAssertEqual(String(buffer: $0.body), "foo")
+            }
+
+            try await client.execute(uri: "/bar", method: .get) {
+                XCTAssertEqual(String(buffer: $0.body), "bar")
+            }
+        }
+    }
+
+    func testRouterControllerWithGenericChildren() async throws {
+        struct ChildController: RouterController {
+            typealias Context = BasicRouterRequestContext
+            let name: String
+            var body: some RouterMiddleware<Context> {
+                Get("child_\(self.name)") { _, _ in "child_\(self.name)" }
+            }
+        }
+
+        struct ParentController<Context: RouterRequestContext, Child: RouterMiddleware>: RouterController where Child.Context == Context {
+            var child: Child
+
+            init(@MiddlewareFixedTypeBuilder<Request, Response, Context> _ child: () -> Child) {
+                self.child = child()
+            }
+
+            var body: some RouterMiddleware<Context> {
+                RouteGroup("parent") {
+                    self.child
+                }
+            }
+        }
+
+        let router = RouterBuilder(context: BasicRouterRequestContext.self) {
+            ParentController {
+                Get("child_a") { _, _ in "child_a" }
+                ChildController(name: "b")
+                ChildController(name: "c")
+                Get("child_d") { _, _ in "child_d" }
+            }
+        }
+
+        let app = Application(responder: router)
+        try await app.test(.router) { client in
+            for letter in "abcd" {
+                try await client.execute(uri: "/parent/child_\(letter)", method: .get) {
+                    XCTAssertEqual(String(buffer: $0.body), "child_\(letter)")
+                }
+            }
+        }
+    }
+
+    func testRouterControllerWithMiddleware() async throws {
+        struct TestMiddleware<Context: RequestContext>: RouterMiddleware {
+            func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
+                var response = try await next(request, context)
+                response.headers[.middleware] = "TestMiddleware"
+                return response
+            }
+        }
+
+        struct ChildController: RouterController {
+            typealias Context = BasicRouterRequestContext
+            var body: some RouterMiddleware<Context> {
+                Get("foo") { _, _ in "foo" }
+            }
+        }
+
+        struct ParentController: RouterController {
+            typealias Context = BasicRouterRequestContext
+            var body: some RouterMiddleware<Context> {
+                RouteGroup("parent") {
+                    TestMiddleware()
+                    ChildController()
+                    Get("bar") { _, _ in "bar" }
+                }
+            }
+        }
+
+        let router = RouterBuilder(context: BasicRouterRequestContext.self) {
+            ParentController()
+        }
+
+        let app = Application(responder: router)
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/parent/foo", method: .get) {
+                XCTAssertEqual($0.headers[.middleware], "TestMiddleware")
+                XCTAssertEqual(String(buffer: $0.body), "foo")
+            }
+
+            try await client.execute(uri: "/parent/bar", method: .get) {
+                XCTAssertEqual($0.headers[.middleware], "TestMiddleware")
+                XCTAssertEqual(String(buffer: $0.body), "bar")
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR proposes the concept of a `RouterController ` which aims to improve the ergonomics of the `MiddlewareFixedTypeBuilder` result builder style syntax.

Conforming to `RouterController` should allow you to create composable routes in a more `SwiftUI` result builder style.

### Expectations
Here is a list of things that I would expect from the full result builder style syntax.

1. It shouldn't be necessary to call `body` on `RouterController`.
2. It should be possible for a `RouterController` `body` to be composed of `MiddlewareProtocol`, `RouterMiddleware` and other `RouterController` definitions using the appropriate result builder.
3. It should be possible to define a high order `RouterController` that takes a generic content result builder function. This is similar to how things like `VStack` and `Group` work in SwiftUI. This unlocks the ability to make reusable wrappers around nested content. Imagine a `Localized` controller that wraps some arbitrary content inside a specific path and adds a particular middleware.

### Struggles
Things I'm struggling with in the implementation...

1. ~The nuance between `@MiddlewareFixedTypeBuilder` and `@RouteBuilder` is a little lost on me, and I'm unsure which of the result builders `RouteController` should be using.~
2. ~Should `RouteController` itself conform to `RouterMiddleware` or `MiddlewareProtocol` or should additional builder expressions be added to support the varying types. In SwiftUI, the `View` protocol defines a `Body` that itself is a `View`. Working through this problem, separating out the `RouteController` `body` as a different requirement to itself has proved complex. I'm unsure of the pros/cons of each approach.~
3. ~Piping the `Context` through. in such a way that doesn't require the `body` definitions to explicitly define generic types or requiring complex where clauses, has proven quite complex.~

With all this said, I'm hoping for a more complete conversation/assistance with implementation architecture thoguhts before fiddling around more with implementation, I think there are quite a few more nuances/catches than I had anticipated when making my initial attempt. It's been fun to think through this more, but I don't presume to have the full context of where exactly the aim is to take hummingbird as a project.

Looking forward to your input @adam-fowler and @Joannis. 😄 Thanks for the contribution to the conversation so far. 
 