### PR TITLE
Fix the LICENSE link

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ We welcome contributions to Hummingbird! Please read our [contributing guideline
 
 ## License
 
-Hummingbird is released under the [Apache 2.0 license](LICENSE.txt).
+Hummingbird is released under the [Apache 2.0 license](LICENSE).


### PR DESCRIPTION
I didn't check my license link - assumed it had a file extension