### PR TITLE
Remove @discardableResult from RouterMethods.group functions

### DIFF
--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -50,7 +50,7 @@ extension RouterMethods {
 
     /// Return a group inside the current group
     /// - Parameter path: path prefix to add to routes inside this group
-    @discardableResult public func group(_ path: RouterPath = "") -> RouterGroup<Context> {
+    public func group(_ path: RouterPath = "") -> RouterGroup<Context> {
         return RouterGroup(
             path: path,
             parent: self
@@ -73,7 +73,7 @@ extension RouterMethods {
     /// - Parameters
     ///   - path: path prefix to add to routes inside this group
     ///   - convertContext: Function converting context
-    @discardableResult public func group<TargetContext>(
+    public func group<TargetContext>(
         _ path: RouterPath = "",
         context: TargetContext.Type
     ) -> RouterGroup<TargetContext> where TargetContext.Source == Context {
@@ -99,7 +99,7 @@ extension RouterMethods {
     /// - Parameters
     ///   - path: path prefix to add to routes inside this group
     ///   - convertContext: Function converting context
-    @discardableResult public func group<TargetContext: ChildRequestContext>(
+    public func group<TargetContext: ChildRequestContext>(
         _ path: RouterPath = "",
         context: TargetContext.Type
     ) -> RouterGroup<TargetContext> where TargetContext.ParentContext == Context {


### PR DESCRIPTION
It doesn't make sense to create a router group and do nothing with it and this shouldn't be encouraged
This is a breaking change, but any code relying on this is already broken.