### PR TITLE
Fixes for Swift 6 mode with latest SwiftNIO

### DIFF
--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -214,27 +214,26 @@ extension Channel {
         http1ConnectionInitializer: @escaping NIOChannelInitializerWithOutput<HTTP1Output>,
         http2ConnectionInitializer: @escaping NIOChannelInitializerWithOutput<HTTP2Output>
     ) -> EventLoopFuture<EventLoopFuture<NIONegotiatedHTTPVersion<HTTP1Output, HTTP2Output>>> {
-        let alpnHandler = NIOTypedApplicationProtocolNegotiationHandler<NIONegotiatedHTTPVersion<HTTP1Output, HTTP2Output>>() { result in
-            switch result {
-            case .negotiated("h2"):
-                // Successful upgrade to HTTP/2. Let the user configure the pipeline.
-                return http2ConnectionInitializer(self).map { http2Output in .http2(http2Output) }
-            case .negotiated("http/1.1"), .fallback:
-                // Explicit or implicit HTTP/1.1 choice.
-                return http1ConnectionInitializer(self).map { http1Output in .http1_1(http1Output) }
-            case .negotiated:
-                // We negotiated something that isn't HTTP/1.1. This is a bad scene, and is a good indication
-                // of a user configuration error. We're going to close the connection directly.
-                return self.close().flatMap { self.eventLoop.makeFailedFuture(NIOHTTP2Errors.invalidALPNToken()) }
-            }
-        }
-
-        return self.pipeline
-            .addHandler(alpnHandler)
-            .flatMap { _ in
-                self.pipeline.handler(type: NIOTypedApplicationProtocolNegotiationHandler<NIONegotiatedHTTPVersion<HTTP1Output, HTTP2Output>>.self).map { alpnHandler in
-                    alpnHandler.protocolNegotiationResult
+        return self.eventLoop.makeCompletedFuture {
+            let alpnHandler = NIOTypedApplicationProtocolNegotiationHandler<NIONegotiatedHTTPVersion<HTTP1Output, HTTP2Output>>() { result in
+                switch result {
+                case .negotiated("h2"):
+                    // Successful upgrade to HTTP/2. Let the user configure the pipeline.
+                    return http2ConnectionInitializer(self).map { http2Output in .http2(http2Output) }
+                case .negotiated("http/1.1"), .fallback:
+                    // Explicit or implicit HTTP/1.1 choice.
+                    return http1ConnectionInitializer(self).map { http1Output in .http1_1(http1Output) }
+                case .negotiated:
+                    // We negotiated something that isn't HTTP/1.1. This is a bad scene, and is a good indication
+                    // of a user configuration error. We're going to close the connection directly.
+                    return self.close().flatMap { self.eventLoop.makeFailedFuture(NIOHTTP2Errors.invalidALPNToken()) }
                 }
             }
+            try self.pipeline.syncOperations.addHandler(alpnHandler)
+        }.flatMap { _ in
+            self.pipeline.handler(type: NIOTypedApplicationProtocolNegotiationHandler<NIONegotiatedHTTPVersion<HTTP1Output, HTTP2Output>>.self).map { alpnHandler in
+                alpnHandler.protocolNegotiationResult
+            }
+        }
     }
 }

--- a/Sources/HummingbirdTLS/TLSChannel.swift
+++ b/Sources/HummingbirdTLS/TLSChannel.swift
@@ -37,7 +37,9 @@ public struct TLSChannel<BaseChannel: ServerChildChannel>: ServerChildChannel {
     /// - Returns: Object to process input/output on child channel
     @inlinable
     public func setup(channel: Channel, logger: Logger) -> EventLoopFuture<Value> {
-        return channel.pipeline.addHandler(NIOSSLServerHandler(context: self.sslContext)).flatMap {
+        return channel.eventLoop.makeCompletedFuture {
+            try channel.pipeline.syncOperations.addHandler(NIOSSLServerHandler(context: self.sslContext))
+        }.flatMap {
             self.baseChannel.setup(channel: channel, logger: logger)
         }
     }

--- a/Sources/HummingbirdTesting/TestClient.swift
+++ b/Sources/HummingbirdTesting/TestClient.swift
@@ -83,14 +83,14 @@ public struct TestClient: Sendable {
                 .channelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)
                 .channelInitializer { channel in
                     return channel.pipeline.addHTTPClientHandlers()
-                        .flatMap {
+                        .flatMapThrowing {
                             let handlers: [ChannelHandler] = [
                                 HTTP1ToHTTPClientCodec(),
                                 HTTPClientRequestSerializer(),
                                 HTTPClientResponseHandler(),
                                 HTTPTaskHandler(),
                             ]
-                            return channel.pipeline.addHandlers(handlers)
+                            return try channel.pipeline.syncOperations.addHandlers(handlers)
                         }
                 }
                 .connectTimeout(.seconds(5))


### PR DESCRIPTION
SwiftNIO are doing a lot of work to get themselves Swift 6 ready
This impacts Hummingbird when compiling in Swift 6 mode. It is not possible anymore to call addHandler with a non-Sendable ChannelHandler.

This PR fixes this by using the syncOperations instead

FYI @lukasa, @FranzBusch 