### PR TITLE
Renamed SameSite.secure to .strict

### DIFF
--- a/Sources/Hummingbird/HTTP/Cookie.swift
+++ b/Sources/Hummingbird/HTTP/Cookie.swift
@@ -18,8 +18,11 @@ import Foundation
 public struct Cookie: Sendable, CustomStringConvertible {
     public enum SameSite: String, Sendable {
         case lax = "Lax"
-        case secure = "Secure"
+        case strict = "Strict"
         case none = "None"
+
+        @available(*, deprecated, renamed: "strict", message: "Secure is not a valid value for SameSite, use strict instead")
+        static var secure: Self { .strict }
     }
 
     /// Cookie name

--- a/Tests/HummingbirdTests/CookiesTests.swift
+++ b/Tests/HummingbirdTests/CookiesTests.swift
@@ -60,8 +60,8 @@ final class CookieTests: XCTestCase {
     }
 
     func testSameSite() {
-        let cookie = Cookie(from: "name=value; SameSite=Secure")
-        XCTAssertEqual(cookie?.sameSite, .secure)
+        let cookie = Cookie(from: "name=value; SameSite=Strict")
+        XCTAssertEqual(cookie?.sameSite, .strict)
     }
 
     func testSetCookie() async throws {


### PR DESCRIPTION
Realised that `secure` is not a valid value for the SameSite parameter