### PR TITLE
Request body iteration specialisation

### DIFF
--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -24,7 +24,7 @@ public struct RequestBody: Sendable, AsyncSequence {
     @usableFromInline
     internal enum _Backing: Sendable {
         case byteBuffer(ByteBuffer)
-        case nioAsyncChannelInboundStream(NIOAsyncChannelRequestBody)
+        case nioAsyncChannelRequestBody(NIOAsyncChannelRequestBody)
         case anyAsyncSequence(AnyAsyncSequence<ByteBuffer>)
     }
 
@@ -46,8 +46,8 @@ public struct RequestBody: Sendable, AsyncSequence {
     ///  Initialise ``RequestBody`` from AsyncSequence of ByteBuffers
     /// - Parameter asyncSequence: AsyncSequence
     @inlinable
-    public init(nioAsyncChannelInbound: NIOAsyncChannelRequestBody) {
-        self.init(.nioAsyncChannelInboundStream(nioAsyncChannelInbound))
+    package init(nioAsyncChannelInbound: NIOAsyncChannelRequestBody) {
+        self.init(.nioAsyncChannelRequestBody(nioAsyncChannelInbound))
     }
 
     ///  Initialise ``RequestBody`` from AsyncSequence of ByteBuffers
@@ -66,7 +66,7 @@ extension RequestBody {
         @usableFromInline
         internal enum _Backing {
             case byteBuffer(ByteBuffer)
-            case nioAsyncChannelInboundStream(NIOAsyncChannelRequestBody.AsyncIterator)
+            case nioAsyncChannelRequestBody(NIOAsyncChannelRequestBody.AsyncIterator)
             case anyAsyncSequence(AnyAsyncSequence<ByteBuffer>.AsyncIterator)
             case done
         }
@@ -86,9 +86,9 @@ extension RequestBody {
                 self._backing = .done
                 return buffer
 
-            case .nioAsyncChannelInboundStream(var iterator):
+            case .nioAsyncChannelRequestBody(var iterator):
                 let next = try await iterator.next()
-                self._backing = .nioAsyncChannelInboundStream(iterator)
+                self._backing = .nioAsyncChannelRequestBody(iterator)
                 return next
 
             case .anyAsyncSequence(let iterator):
@@ -105,8 +105,8 @@ extension RequestBody {
         switch self._backing {
         case .byteBuffer(let buffer):
             return .init(.byteBuffer(buffer))
-        case .nioAsyncChannelInboundStream(let requestBody):
-            return .init(.nioAsyncChannelInboundStream(requestBody.makeAsyncIterator()))
+        case .nioAsyncChannelRequestBody(let requestBody):
+            return .init(.nioAsyncChannelRequestBody(requestBody.makeAsyncIterator()))
         case .anyAsyncSequence(let stream):
             return .init(.anyAsyncSequence(stream.makeAsyncIterator()))
         }
@@ -229,7 +229,8 @@ extension RequestBody {
 /// Request body that is a stream of ByteBuffers sourced from a NIOAsyncChannelInboundStream.
 ///
 /// This is a unicast async sequence that allows a single iterator to be created.
-public struct NIOAsyncChannelRequestBody: Sendable, AsyncSequence {
+@usableFromInline
+package struct NIOAsyncChannelRequestBody: Sendable, AsyncSequence {
     public typealias Element = ByteBuffer
     public typealias InboundStream = NIOAsyncChannelInboundStream<HTTPRequestPart>
 

--- a/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTPChannelHandler.swift
@@ -47,7 +47,7 @@ extension HTTPChannelHandler {
 
                     while true {
                         let bodyStream = NIOAsyncChannelRequestBody(iterator: iterator)
-                        let request = Request(head: head, body: .init(asyncSequence: bodyStream))
+                        let request = Request(head: head, body: .init(nioAsyncChannelInbound: bodyStream))
                         let responseWriter = ResponseWriter(outbound: outbound)
                         do {
                             try await self.responder(request, responseWriter, asyncChannel.channel)

--- a/Sources/HummingbirdHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2StreamChannel.swift
@@ -72,7 +72,7 @@ struct HTTP2StreamChannel: ServerChildChannel {
                         throw HTTPChannelError.unexpectedHTTPPart(part)
                     }
                     let bodyStream = NIOAsyncChannelRequestBody(iterator: iterator)
-                    let request = Request(head: head, body: .init(asyncSequence: bodyStream))
+                    let request = Request(head: head, body: .init(nioAsyncChannelInbound: bodyStream))
                     let responseWriter = ResponseWriter(outbound: outbound)
                     try await self.responder(request, responseWriter, asyncChannel.channel)
                 }


### PR DESCRIPTION
The majority of time the request body is a `NIOAsyncChannelRequestBody`. This PR adds a specialisation for this type. So instead of going through `AnyAsyncSequence` it calls the NIOAsyncChannelRequestBody iterator next() function directly. The results are a slight improvement in performance, when parsing small request buffers, although not that much 64K - 65K requests.

I mistakenly made `NIOAsyncChannelRequestBody` public with the HTTP2 changes. In this PR I make it a struct to avoid an additional allocation. I have also changed the public to package. In theory these changes are breaking. But they will affect basically no one, unless they decided to write their own HTTP1 channel handling code in the last 3 days.