### PR TITLE
Add application/wasm MediaType

### DIFF
--- a/Sources/Hummingbird/HTTP/MediaType.swift
+++ b/Sources/Hummingbird/HTTP/MediaType.swift
@@ -281,6 +281,8 @@ extension MediaType {
     public static var applicationTar: Self { .init(type: .application, subType: "x-tar") }
     /// Microsoft Visio
     public static var applicationVsd: Self { .init(type: .application, subType: "vnd.visio") }
+    /// WebAssembly
+    public static var applicationWasm: Self { .init(type: .application, subType: "wasm") }
     /// XHTML
     public static var applicationXhtml: Self { .init(type: .application, subType: "xhtml+xml") }
     /// Microsoft Excel
@@ -445,6 +447,7 @@ extension MediaType {
         "ttf": .fontTtf,
         "txt": .textPlain,
         "vsd": .applicationVsd,
+        "wasm": .applicationWasm,
         "wav": .audioWave,
         "weba": .audioWebm,
         "webm": .videoWebm,


### PR DESCRIPTION
Adds the [application/wasm](https://www.iana.org/assignments/media-types/application/wasm) media type and file extension lookup. This will [allow browsers to compile WASM](https://webassembly.github.io/spec/web-api/index.html#streaming-modules:~:text=If%20mimeType%20is%20not%20a%20byte%2Dcase%2Dinsensitive%20match%20for%20%60application/wasm%60%2C%20reject%20returnValue%20with%20a%20TypeError%20and%20abort%20these%20substeps.) served from Hummingbird's FileMiddleware without modification.