### PR TITLE
Throw error on failed persist value conversion

### DIFF
--- a/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
+++ b/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
@@ -38,7 +38,7 @@ public actor MemoryPersistDriver<C: Clock>: PersistDriver where C.Duration == Du
         if let expires = item.expires {
             guard self.clock.now <= expires else { return nil }
         }
-        guard let object = item.value as? Object else { throw PersistError.invalidType }
+        guard let object = item.value as? Object else { throw PersistError.invalidConversion }
         return object
     }
 

--- a/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
+++ b/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
@@ -35,9 +35,11 @@ public actor MemoryPersistDriver<C: Clock>: PersistDriver where C.Duration == Du
 
     public func get<Object: Codable & Sendable>(key: String, as: Object.Type) async throws -> Object? {
         guard let item = self.values[key] else { return nil }
-        guard let expires = item.expires else { return item.value as? Object }
-        guard self.clock.now <= expires else { return nil }
-        return item.value as? Object
+        if let expires = item.expires {
+            guard self.clock.now <= expires else { return nil }
+        }
+        guard let object = item.value as? Object else { throw PersistError.invalidType }
+        return object
     }
 
     public func remove(key: String) async throws {

--- a/Sources/Hummingbird/Storage/PersistError.swift
+++ b/Sources/Hummingbird/Storage/PersistError.swift
@@ -16,7 +16,7 @@
 public struct PersistError: Error, Equatable {
     private enum Internal {
         case duplicate
-        case invalidType
+        case invalidConversion
     }
 
     private let value: Internal
@@ -27,5 +27,5 @@ public struct PersistError: Error, Equatable {
     /// Failed to creating a persist entry as it already exists
     public static var duplicate: Self { .init(value: .duplicate) }
     /// Failed to convert a persist value to the requested type
-    public static var invalidType: Self { .init(value: .invalidType) }
+    public static var invalidConversion: Self { .init(value: .invalidConversion) }
 }

--- a/Sources/Hummingbird/Storage/PersistError.swift
+++ b/Sources/Hummingbird/Storage/PersistError.swift
@@ -16,6 +16,7 @@
 public struct PersistError: Error, Equatable {
     private enum Internal {
         case duplicate
+        case invalidType
     }
 
     private let value: Internal
@@ -23,5 +24,8 @@ public struct PersistError: Error, Equatable {
         self.value = value
     }
 
+    /// Failed to creating a persist entry as it already exists
     public static var duplicate: Self { .init(value: .duplicate) }
+    /// Failed to convert a persist value to the requested type
+    public static var invalidType: Self { .init(value: .invalidType) }
 }

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -140,10 +140,6 @@ final class PersistTests: XCTestCase {
     }
 
     func testCodable() async throws {
-        #if os(macOS)
-        // disable macOS tests in CI. GH Actions are currently running this when they shouldn't
-        guard Environment().get("CI") != "true" else { throw XCTSkip() }
-        #endif
         struct TestCodable: Codable {
             let buffer: String
         }
@@ -167,6 +163,31 @@ final class PersistTests: XCTestCase {
             try await client.execute(uri: "/codable/\(tag)", method: .put, body: ByteBufferAllocator().buffer(string: "Persist")) { _ in }
             try await client.execute(uri: "/codable/\(tag)", method: .get) { response in
                 XCTAssertEqual(String(buffer: response.body), "Persist")
+            }
+        }
+    }
+
+    func testInvalidGetAs() async throws {
+        struct TestCodable: Codable {
+            let buffer: String
+        }
+        let (router, persist) = try createRouter()
+        router.put("/invalid") { _, _ -> HTTPResponse.Status in
+            try await persist.set(key: "test", value: TestCodable(buffer: "hello"))
+            return .ok
+        }
+        router.get("/invalid") { _, _ -> String? in
+            do {
+                return try await persist.get(key: "test", as: String.self)
+            } catch let error as PersistError where error == .invalidType {
+                throw HTTPError(.badRequest)
+            }
+        }
+        let app = Application(router: router)
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/invalid", method: .put)
+            try await client.execute(uri: "/invalid", method: .get) { response in
+                XCTAssertEqual(response.status, .badRequest)
             }
         }
     }

--- a/Tests/HummingbirdTests/PersistTests.swift
+++ b/Tests/HummingbirdTests/PersistTests.swift
@@ -179,7 +179,7 @@ final class PersistTests: XCTestCase {
         router.get("/invalid") { _, _ -> String? in
             do {
                 return try await persist.get(key: "test", as: String.self)
-            } catch let error as PersistError where error == .invalidType {
+            } catch let error as PersistError where error == .invalidConversion {
                 throw HTTPError(.badRequest)
             }
         }


### PR DESCRIPTION
Add `PersistError.invalidConversion`, if you cannot cast/convert to requested type in `PersistDriver.get(key:as:)` then throw error

Up until this point the persist drivers have been inconsistent in how to deal with this situation. I will update others to be consistent with MemoryPersistDriver once this is in.