### PR TITLE
Mark RequestContextSource as Sendable

### DIFF
--- a/Sources/Hummingbird/Server/RequestContextSource.swift
+++ b/Sources/Hummingbird/Server/RequestContextSource.swift
@@ -16,7 +16,7 @@ import Logging
 import NIOCore
 
 /// Protocol for source of request contexts
-public protocol RequestContextSource {
+public protocol RequestContextSource: Sendable {
     /// Request Logger
     var logger: Logger { get }
 }


### PR DESCRIPTION
This PR adds Sendable conformance to the `RequestContextSource` protocol and ensures that `ApplicationRequestContextSource` properties are Sendable. 

- #621