### PR TITLE
Removed default additionalChannelHandlers from HTTP1Channel

### DIFF
--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -51,7 +51,7 @@ public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
     @available(*, deprecated, renamed: "HTTP1Channel(responder:configuration:)")
     public init(
         responder: @escaping HTTPChannelHandler.Responder,
-        additionalChannelHandlers: @escaping @Sendable () -> [any RemovableChannelHandler] = { [] }
+        additionalChannelHandlers: @escaping @Sendable () -> [any RemovableChannelHandler]
     ) {
         self.configuration = .init(additionalChannelHandlers: additionalChannelHandlers())
         self.responder = responder


### PR DESCRIPTION
I was meant to remove the default parameter here when I added the version with a default configuration. This is going to be tagged as a breaking change event though it isn't really. It ends up calling the same code. At the moment if you init a `HTTP1Channel` with only a responder it doesn't know whether to use `HTTP1Channel(responder:additionalChannelHandlers:)` or `HTTP1Channel(responder:configuration:)`. I could use `@_disfavoredOverload` but would prefer not to.

I did the equivalent for `HTTPServerBuilder.http1` already.
