### PR TITLE
BREAKING CHANGE: Remove inout from writer in ResponseBody.init closure

### DIFF
--- a/Sources/HummingbirdCore/Response/ResponseBodyWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBodyWriter.swift
@@ -19,10 +19,10 @@ import NIOCore
 public protocol ResponseBodyWriter {
     /// Write a single ByteBuffer
     /// - Parameter buffer: single buffer to write
-    mutating func write(_ buffer: ByteBuffer) async throws
+    func write(_ buffer: ByteBuffer) async throws
     /// Write a sequence of ByteBuffers
     /// - Parameter buffers: Sequence of buffers
-    mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws
+    func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws
     /// Finish writing body
     /// - Parameter trailingHeaders: Any trailing headers you want to include at end
     consuming func finish(_ trailingHeaders: HTTPFields?) async throws
@@ -31,7 +31,7 @@ public protocol ResponseBodyWriter {
 extension ResponseBodyWriter {
     /// Default implementation of writing a sequence of ByteBuffers
     @inlinable
-    public mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
+    public func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
         for part in buffers {
             try await self.write(part)
         }
@@ -40,7 +40,7 @@ extension ResponseBodyWriter {
     ///  Write AsyncSequence of ByteBuffers
     /// - Parameter buffers: ByteBuffer AsyncSequence
     @inlinable
-    public mutating func write<BufferSequence: AsyncSequence>(_ buffers: BufferSequence) async throws where BufferSequence.Element == ByteBuffer {
+    public func write<BufferSequence: AsyncSequence>(_ buffers: BufferSequence) async throws where BufferSequence.Element == ByteBuffer {
         for try await buffer in buffers {
             try await self.write(buffer)
         }
@@ -48,18 +48,18 @@ extension ResponseBodyWriter {
 }
 
 struct MappedResponseBodyWriter<ParentWriter: ResponseBodyWriter>: ResponseBodyWriter {
-    fileprivate var parentWriter: ParentWriter
+    fileprivate let parentWriter: ParentWriter
     fileprivate let transform: @Sendable (ByteBuffer) async throws -> ByteBuffer
 
     /// Write a single ByteBuffer
     /// - Parameter buffer: single buffer to write
-    mutating func write(_ buffer: ByteBuffer) async throws {
+    func write(_ buffer: ByteBuffer) async throws {
         try await self.parentWriter.write(self.transform(buffer))
     }
 
     /// Write a sequence of ByteBuffers
     /// - Parameter buffers: Sequence of buffers
-    mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
+    func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
         for part in buffers {
             try await self.parentWriter.write(self.transform(part))
         }

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -126,7 +126,7 @@ final class HummingBirdCoreTests: XCTestCase {
         @Sendable func helloResponder(to request: Request, responseWriter: consuming ResponseWriter, channel: Channel) async throws {
             try? await Task.sleep(for: .milliseconds(10))
             let responseBody = channel.allocator.buffer(string: "Hello")
-            var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+            let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
             try await bodyWriter.write(responseBody)
             try await bodyWriter.finish(nil)
         }
@@ -171,7 +171,7 @@ final class HummingBirdCoreTests: XCTestCase {
                     try await responseWriter.writeResponse(.init(status: .contentTooLarge))
                     return
                 }
-                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(buffer)
                 try await bodyWriter.finish(nil)
             },
@@ -191,7 +191,7 @@ final class HummingBirdCoreTests: XCTestCase {
         try await testServer(
             responder: { (_, responseWriter: consuming ResponseWriter, _) in
                 let buffer = Self.randomBuffer(size: 1_140_000)
-                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(buffer)
                 try await bodyWriter.finish(nil)
             },
@@ -209,7 +209,7 @@ final class HummingBirdCoreTests: XCTestCase {
     func testStreamBody() async throws {
         try await testServer(
             responder: { (request, responseWriter: consuming ResponseWriter, _) in
-                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(request.body)
                 try await bodyWriter.finish(nil)
             },
@@ -228,7 +228,7 @@ final class HummingBirdCoreTests: XCTestCase {
     func testStreamBodyWriteSlow() async throws {
         try await testServer(
             responder: { (request, responseWriter: consuming ResponseWriter, _) in
-                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(request.body.delayed())
                 try await bodyWriter.finish(nil)
             },
@@ -259,7 +259,7 @@ final class HummingBirdCoreTests: XCTestCase {
         }
         try await testServer(
             responder: { (request, responseWriter: consuming ResponseWriter, _) in
-                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(request.body.delayed())
                 try await bodyWriter.finish(nil)
             },
@@ -515,7 +515,7 @@ final class HummingBirdCoreTests: XCTestCase {
             ) { (request, responseWriter: consuming ResponseWriter, _) in
                 await handlerPromise.complete(())
                 try? await Task.sleep(for: .milliseconds(500))
-                var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+                let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
                 try await bodyWriter.write(request.body.delayed())
                 try await bodyWriter.finish(nil)
             } onServerRunning: {

--- a/Tests/HummingbirdCoreTests/TestUtils.swift
+++ b/Tests/HummingbirdCoreTests/TestUtils.swift
@@ -27,7 +27,7 @@ public enum TestErrors: Error {
 /// Basic responder that just returns "Hello" in body
 @Sendable public func helloResponder(to request: Request, responseWriter: consuming ResponseWriter, channel: Channel) async throws {
     let responseBody = channel.allocator.buffer(string: "Hello")
-    var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+    let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
     try await bodyWriter.write(responseBody)
     try await bodyWriter.finish(nil)
 }

--- a/Tests/HummingbirdHTTP2Tests/TestUtils.swift
+++ b/Tests/HummingbirdHTTP2Tests/TestUtils.swift
@@ -29,7 +29,7 @@ public enum TestErrors: Error {
 /// Basic responder that just returns "Hello" in body
 @Sendable public func helloResponder(to request: Request, responseWriter: consuming ResponseWriter, channel: Channel) async throws {
     let responseBody = channel.allocator.buffer(string: "Hello")
-    var bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
+    let bodyWriter = try await responseWriter.writeHead(.init(status: .ok))
     try await bodyWriter.write(responseBody)
     try await bodyWriter.finish(nil)
 }

--- a/Tests/HummingbirdRouterTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdRouterTests/MiddlewareTests.swift
@@ -130,10 +130,15 @@ final class MiddlewareTests: XCTestCase {
     }
 
     func testMiddlewareResponseBodyWriter() async throws {
-        struct TransformWriter: ResponseBodyWriter {
+        // Test non-sendable ResponseBodyWriter
+        final class TransformWriter: ResponseBodyWriter {
             var parentWriter: any ResponseBodyWriter
 
-            mutating func write(_ buffer: ByteBuffer) async throws {
+            init(parentWriter: any ResponseBodyWriter) {
+                self.parentWriter = parentWriter
+            }
+
+            func write(_ buffer: ByteBuffer) async throws {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
                 try await self.parentWriter.write(output)
             }

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -146,9 +146,9 @@ final class MiddlewareTests: XCTestCase {
 
     func testMiddlewareResponseBodyWriter() async throws {
         struct TransformWriter: ResponseBodyWriter {
-            var parentWriter: any ResponseBodyWriter
+            let parentWriter: any ResponseBodyWriter
 
-            mutating func write(_ buffer: ByteBuffer) async throws {
+            func write(_ buffer: ByteBuffer) async throws {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
                 try await self.parentWriter.write(output)
             }
@@ -187,9 +187,9 @@ final class MiddlewareTests: XCTestCase {
 
     func testMappedResponseBodyWriter() async throws {
         struct TransformWriter: ResponseBodyWriter {
-            var parentWriter: any ResponseBodyWriter
+            let parentWriter: any ResponseBodyWriter
 
-            mutating func write(_ buffer: ByteBuffer) async throws {
+            func write(_ buffer: ByteBuffer) async throws {
                 let output = ByteBuffer(bytes: buffer.readableBytesView.map { $0 ^ 255 })
                 try await self.parentWriter.write(output)
             }


### PR DESCRIPTION
Also use `sending` in swift 6 to pass ResponseBodyWriter into function so it can be used in a sending closure. 

This change is needed to make the `cancelOnInboundClosure` PR #627 useful. Without this you are not able to pass the ResponseBodyWriter into the `cancelOnInboundClosure` closure, without nasty unsafe wrapping of the type.

As this is a breaking change I have separated it out into its own PR. This change will most likely not affect anyone as I don't think many people are writing their own `ResponseBodyWriter`. There are a couple of minor changes in hummingbird-compression but it doesn't break it.