### PR TITLE
Storing underlying request part iterator with RequestBody

### DIFF
--- a/Sources/HummingbirdCore/Request/RequestBody+inboundClose.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody+inboundClose.swift
@@ -107,7 +107,7 @@ extension RequestBody {
         }
     }
 
-    func withInboundCloseHandler<Value: Sendable, AsyncIterator: AsyncIteratorProtocol>(
+    fileprivate func withInboundCloseHandler<Value: Sendable, AsyncIterator: AsyncIteratorProtocol>(
         isolation: isolated (any Actor)? = #isolation,
         iterator: AsyncIterator,
         source: RequestBody.Source,
@@ -136,7 +136,7 @@ extension RequestBody {
         case nextRequestReady
     }
 
-    func iterate<AsyncIterator: AsyncIteratorProtocol>(
+    fileprivate func iterate<AsyncIterator: AsyncIteratorProtocol>(
         iterator: AsyncIterator,
         source: RequestBody.Source
     ) async throws -> IterateResult where AsyncIterator.Element == HTTPRequestPart {

--- a/Sources/HummingbirdCore/Request/RequestBodyMergedWithUnderlyingRequestPartIterator.swift
+++ b/Sources/HummingbirdCore/Request/RequestBodyMergedWithUnderlyingRequestPartIterator.swift
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2023-2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOHTTPTypes
+
+struct RequestBodyMergedWithUnderlyingRequestPartIterator<Base: AsyncSequence>: AsyncSequence where Base.Element == ByteBuffer {
+    typealias Element = HTTPRequestPart
+    let base: Base
+    let underlyingIterator: NIOAsyncChannelInboundStream<HTTPRequestPart>.AsyncIterator
+
+    struct AsyncIterator: AsyncIteratorProtocol {
+        enum CurrentAsyncIterator {
+            case base(Base.AsyncIterator, underlying: NIOAsyncChannelInboundStream<HTTPRequestPart>.AsyncIterator)
+            case underlying(NIOAsyncChannelInboundStream<HTTPRequestPart>.AsyncIterator)
+        }
+        var current: CurrentAsyncIterator
+
+        init(iterator: Base.AsyncIterator, underlying: NIOAsyncChannelInboundStream<HTTPRequestPart>.AsyncIterator) {
+            self.current = .base(iterator, underlying: underlying)
+        }
+
+        mutating func next() async throws -> HTTPRequestPart? {
+            switch self.current {
+            case .base(var base, let underlying):
+                if let element = try await base.next() {
+                    self.current = .base(base, underlying: underlying)
+                    return .body(element)
+                } else {
+                    self.current = .underlying(underlying)
+                    return .end(nil)
+                }
+            case .underlying(var underlying):
+                let element = try await underlying.next()
+                self.current = .underlying(underlying)
+                return element
+            }
+        }
+    }
+
+    func makeAsyncIterator() -> AsyncIterator {
+        .init(iterator: base.makeAsyncIterator(), underlying: underlyingIterator)
+    }
+}
+
+extension RequestBody {
+    func mergeWithUnderlyingRequestPartIterator(
+        _ iterator: NIOAsyncChannelInboundStream<HTTPRequestPart>.AsyncIterator
+    ) -> RequestBodyMergedWithUnderlyingRequestPartIterator<Self> {
+        .init(base: self, underlyingIterator: iterator)
+    }
+}

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -894,7 +894,7 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    /// Test consumeWithInboundHandler
+    /// Test consumeWithInboundHandler after having collected the Request body
     @available(macOS 15, iOS 18, tvOS 18, *)
     func testConsumeWithInboundHandlerAfterCollect() async throws {
         let router = Router()
@@ -924,7 +924,7 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    /// Test consumeWithInboundHandler
+    /// Test consumeWithInboundHandler after having replaced Request.body with a new streamed RequestBody
     @available(macOS 15, iOS 18, tvOS 18, *)
     func testConsumeWithInboundHandlerAfterReplacingBody() async throws {
         let router = Router()
@@ -932,7 +932,7 @@ final class ApplicationTests: XCTestCase {
             var request = request
             request.body = .init(
                 asyncSequence: request.body.map {
-                    var view = $0.readableBytesView.map { $0 ^ 255 }
+                    let view = $0.readableBytesView.map { $0 ^ 255 }
                     return ByteBuffer(bytes: view)
                 }
             )


### PR DESCRIPTION
If you try to run `withInboundCloseHandler` on a request body that has been edited, there is a good chance you won't have a reference to the original request part iterator that is used to tell if the connection has been closed. If you did have a reference to the original iterator either it had iterated past the request body so couldn't be used to feed the request body in `withInboundCloseHandler` or it would provide the buffers from the original request and not the edited buffers.

To get around this we
- Store HTTPRequestPart iterator from original RequestBody with any subsequent request body setup.
- Using `RequestBody.mergeWithUnderlyingRequestPartIterator` we combine the current RequestBody with the original RequestPart iterator. With this we can supply the RequestBody buffer stream, but then also verify if the connection has been closed. 