### PR TITLE
Bump swift-nio-http2 from 1.28.0 to 1.34.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.1"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.20.0"),
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.34.1"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.20.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),


### PR DESCRIPTION
Bump swift-nio-http2 dependency from 1.28.0 to 1.34.1, due to `HTTP2Channel` can't be compiled after split HTTP2 channel out from upgrade channel