### PR TITLE
Change consumeWithCancellationOnInboundClose handler to be non-escaping

### DIFF
--- a/Sources/HummingbirdCore/Request/RequestBody+inboundClose.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody+inboundClose.swift
@@ -117,12 +117,11 @@ extension RequestBody {
         onInboundClosed: @Sendable @escaping () -> Void
     ) async throws -> Value where AsyncIterator.Element == HTTPRequestPart {
         let unsafeIterator = UnsafeTransfer(iterator)
-        let unsafeOnInboundClosed = UnsafeTransfer(onInboundClosed)
         let value = try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 do {
                     if try await self.iterate(iterator: unsafeIterator.wrappedValue, source: source) == .inboundClosed {
-                        unsafeOnInboundClosed.wrappedValue()
+                        onInboundClosed()
                     }
                 } catch is CancellationError {}
             }

--- a/Sources/HummingbirdCore/Request/RequestBody+inboundClose.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody+inboundClose.swift
@@ -81,29 +81,31 @@ extension RequestBody {
     ///   - operation: The actual operation to run
     /// - Returns: Return value of operation
     public func consumeWithCancellationOnInboundClose<Value: Sendable>(
-        _ operation: sending @escaping (RequestBody) async throws -> Value
+        _ operation: (RequestBody) async throws -> Value
     ) async throws -> Value {
-        let (barrier, source) = AsyncStream<Void>.makeStream()
-        return try await consumeWithInboundCloseHandler { body in
-            try await withThrowingTaskGroup(of: Value.self) { group in
-                let unsafeOperation = UnsafeTransfer(operation)
-                group.addTask {
-                    var iterator = barrier.makeAsyncIterator()
-                    _ = await iterator.next()
+        try await withoutActuallyEscaping(operation) { operation in
+            let (barrier, source) = AsyncStream<Void>.makeStream()
+            return try await consumeWithInboundCloseHandler { body in
+                try await withThrowingTaskGroup(of: Value.self) { group in
+                    let unsafeOperation = UnsafeTransfer(operation)
+                    group.addTask {
+                        var iterator = barrier.makeAsyncIterator()
+                        _ = await iterator.next()
+                        throw CancellationError()
+                    }
+                    group.addTask {
+                        try await unsafeOperation.wrappedValue(body)
+                    }
+                    if case .some(let value) = try await group.next() {
+                        source.finish()
+                        return value
+                    }
+                    group.cancelAll()
                     throw CancellationError()
                 }
-                group.addTask {
-                    try await unsafeOperation.wrappedValue(body)
-                }
-                if case .some(let value) = try await group.next() {
-                    source.finish()
-                    return value
-                }
-                group.cancelAll()
-                throw CancellationError()
+            } onInboundClosed: {
+                source.finish()
             }
-        } onInboundClosed: {
-            source.finish()
         }
     }
 

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -24,7 +24,7 @@ import NIOPosix
 import ServiceLifecycle
 import XCTest
 
-final class HummingBirdCoreTests: XCTestCase {
+final class HummingbirdCoreTests: XCTestCase {
     static let eventLoopGroup: EventLoopGroup = {
         #if os(iOS)
         NIOTSEventLoopGroup.singleton


### PR DESCRIPTION
I also had to remove any Sendable/sending annotations. I'm not sure what it means for a non-escaping closure to be sendable or not given you can't keep a reference to it.

@sliemeobn 