### PR TITLE
Replace import Foundation with import FoundationEssentials where possible

### DIFF
--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import HummingbirdCore
 import NIOCore
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 #if canImport(Glibc)
 import Glibc

--- a/Sources/Hummingbird/Files/LocalFileSystem.swift
+++ b/Sources/Hummingbird/Files/LocalFileSystem.swift
@@ -12,9 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Logging
 import NIOPosix
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Local file system file provider used by FileMiddleware. All file accesses are relative to a root folder
 public struct LocalFileSystem: FileProvider {

--- a/Sources/Hummingbird/HTTP/Cookie.swift
+++ b/Sources/Hummingbird/HTTP/Cookie.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// Structure holding a single cookie
 public struct Cookie: Sendable, CustomStringConvertible {

--- a/Sources/Hummingbird/Middleware/FileMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/FileMiddleware.swift
@@ -12,12 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import HTTPTypes
 import HummingbirdCore
 import Logging
 import NIOCore
 import NIOPosix
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Protocol for all the file attributes required by ``FileMiddleware``
 ///

--- a/Sources/Hummingbird/Router/Parameters+UUID.swift
+++ b/Sources/Hummingbird/Router/Parameters+UUID.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// It is common for UUID's to be passed in as parameters. So lets add helper
 /// functions to extract them from Parameters

--- a/Sources/Hummingbird/Server/RequestContext.swift
+++ b/Sources/Hummingbird/Server/RequestContext.swift
@@ -13,11 +13,16 @@
 //===----------------------------------------------------------------------===//
 
 import Atomics
-import Foundation
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
 import Tracing
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Endpoint path storage
 public struct EndpointPath: Sendable {


### PR DESCRIPTION
This PR is mainly to isolate the areas where we would need to change code to remove the Foundation requirement from Hummingbird.

- URLEncodedForm uses character sets, percent encoding, old iso8601 decoder.
- FileMiddleware uses DateFormatter to decode/encode http dates
- Cookies use DateFormatter to decode/encode http dates

I will deal with these in separate PRs