### PR TITLE
Fix active_requests metric name

### DIFF
--- a/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
@@ -29,7 +29,7 @@ public struct MetricsMiddleware<Context: RequestContext>: RouterMiddleware {
 
     public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
         let startTime = DispatchTime.now().uptimeNanoseconds
-        let activeRequestMeter = Meter(label: "cod", dimensions: [("http.request.method", request.method.description)])
+        let activeRequestMeter = Meter(label: "http.server.active_requests", dimensions: [("http.request.method", request.method.description)])
         activeRequestMeter.increment()
         do {
             var response = try await next(request, context)


### PR DESCRIPTION
Err somehow the metric name got set to "cod"?!?