### PR TITLE
Add URLEncodedFormDe/Encoder exception for URL to format as string

### DIFF
--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -524,6 +524,19 @@ extension _URLEncodedFormDecoder {
         return value2.value
     }
 
+    func unbox(_ node: URLEncodedFormNode, as type: URL.Type) throws -> URL {
+        guard case .leaf(let value) = node else {
+            throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Expect value not array of dictionary"))
+        }
+        guard let value2 = value else {
+            throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Expected value not empty string"))
+        }
+        guard let url = URL(string: value2.value) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Invalid URL String"))
+        }
+        return url
+    }
+
     func unbox(_ node: URLEncodedFormNode, as type: Double.Type) throws -> Double {
         guard let unboxValue = try Double(unbox(node, as: String.self)) else {
             throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Expected Double"))
@@ -662,6 +675,8 @@ extension _URLEncodedFormDecoder {
             return try self.unbox(node, as: Data.self)
         } else if type == Date.self {
             return try self.unbox(node, as: Date.self)
+        } else if type == URL.self {
+            return try self.unbox(node, as: URL.self)
         } else {
             self.storage.push(container: node)
             defer { self.storage.popContainer() }

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormEncoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormEncoder.swift
@@ -348,12 +348,19 @@ extension _URLEncodedFormEncoder {
         return self.storage.popContainer()
     }
 
+    func box(_ url: URL) throws -> URLEncodedFormNode {
+        try self.encode(url.absoluteString)
+        return self.storage.popContainer()
+    }
+
     func box(_ value: Encodable) throws -> URLEncodedFormNode {
         let type = Swift.type(of: value)
         if type == Data.self {
             return try self.box(value as! Data)
         } else if type == Date.self {
             return try self.box(value as! Date)
+        } else if type == URL.self {
+            return try self.box(value as! URL)
         } else {
             try value.encode(to: self)
             return self.storage.popContainer()

--- a/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
@@ -264,4 +264,14 @@ final class URLDecodedFormDecoderTests: XCTestCase {
         let test = Test(name: "John", age: nil)
         self.testForm(test, query: "name=John")
     }
+
+    func testURLDecode() throws {
+        struct URLForm: Decodable, Equatable {
+            let site: URL
+        }
+
+        let test = URLForm(site: URL(string: "https://hummingbird.codes")!)
+
+        self.testForm(test, query: "site=https://hummingbird.codes".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!)
+    }
 }

--- a/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
@@ -190,4 +190,27 @@ final class URLEncodedFormEncoderTests: XCTestCase {
         let test = Test(name: "John", age: nil)
         self.testForm(test, query: "name=John")
     }
+
+    func testURLEncode() throws {
+        struct URLForm: Encodable, Equatable {
+            let site: URL
+
+            init(site: URL) {
+                self.site = site
+            }
+
+            enum CodingKeys: CodingKey {
+                case site
+            }
+
+            func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(self.site, forKey: .site)
+            }
+        }
+
+        let test = URLForm(site: URL(string: "https://hummingbird.codes")!)
+
+        self.testForm(test, query: "site=https://hummingbird.codes".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!)
+    }
 }


### PR DESCRIPTION
Added `URL` alongside `Date` and `Data` as exceptions to the processing of URLEncodedFormDe/Encoders. Instead of treating a URL as a dictionary, it now matches the current behaviors of JSONDe/Encoder.

Tests were added and run before and after to confirm changes were successful.