### PR TITLE
EventLoopGroupProvider.createNew has been deprecated

### DIFF
--- a/Sources/HummingbirdTesting/LiveTestFramework.swift
+++ b/Sources/HummingbirdTesting/LiveTestFramework.swift
@@ -64,8 +64,7 @@ final class LiveTestFramework<App: ApplicationProtocol>: ApplicationTestFramewor
             let client = TestClient(
                 host: "localhost",
                 port: port,
-                configuration: .init(timeout: self.timeout),
-                eventLoopGroupProvider: .createNew
+                configuration: .init(timeout: self.timeout)
             )
             client.connect()
             do {

--- a/Sources/HummingbirdTesting/TestClient.swift
+++ b/Sources/HummingbirdTesting/TestClient.swift
@@ -61,7 +61,7 @@ public struct TestClient: Sendable {
         host: String,
         port: Int,
         configuration: Configuration = .init(),
-        eventLoopGroupProvider: NIOEventLoopGroupProvider
+        eventLoopGroupProvider: NIOEventLoopGroupProvider = .shared(MultiThreadedEventLoopGroup.singleton)
     ) {
         self.eventLoopGroupProvider = eventLoopGroupProvider
         switch eventLoopGroupProvider {

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -82,8 +82,7 @@ final class HummingbirdCoreTests: XCTestCase {
                         let client = TestClient(
                             host: "localhost",
                             port: port,
-                            configuration: .init(),
-                            eventLoopGroupProvider: .createNew
+                            configuration: .init()
                         )
                         client.connect()
                         let response = try await client.post("/", body: ByteBuffer(string: "Hello"))
@@ -144,8 +143,7 @@ final class HummingbirdCoreTests: XCTestCase {
                         let client = TestClient(
                             host: "localhost",
                             port: port,
-                            configuration: .init(),
-                            eventLoopGroupProvider: .createNew
+                            configuration: .init()
                         )
                         client.connect()
                         let response = try await client.post("/", body: ByteBuffer(string: "Hello"))
@@ -535,8 +533,7 @@ final class HummingbirdCoreTests: XCTestCase {
             let client = await TestClient(
                 host: "localhost",
                 port: portPromise.wait(),
-                configuration: .init(),
-                eventLoopGroupProvider: .createNew
+                configuration: .init()
             )
             group.addTask {
                 do {

--- a/Tests/HummingbirdCoreTests/TestUtils.swift
+++ b/Tests/HummingbirdCoreTests/TestUtils.swift
@@ -104,8 +104,7 @@ public func testServer<Value: Sendable>(
         let client = TestClient(
             host: "localhost",
             port: port,
-            configuration: clientConfiguration,
-            eventLoopGroupProvider: .createNew
+            configuration: clientConfiguration
         )
         client.connect()
         let value = try await test(client)


### PR DESCRIPTION
Replace all usages with `.shared`