### PR TITLE
Add ability for developers to support additional MIME types in FileMiddleware

### DIFF
--- a/Sources/Hummingbird/Middleware/FileMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/FileMiddleware.swift
@@ -52,7 +52,7 @@ where Provider.FileAttributes: FileMiddlewareFileAttributes {
     let searchForIndexHtml: Bool
     let urlBasePath: String?
     let fileProvider: Provider
-    let additionalMediaTypeExtensions: [String: MediaType]
+    let mediaTypeFileExtensionMap: [String: MediaType]
 
     /// Create FileMiddleware
     /// - Parameters:
@@ -79,7 +79,7 @@ where Provider.FileAttributes: FileMiddlewareFileAttributes {
             urlBasePath: urlBasePath,
             cacheControl: cacheControl,
             searchForIndexHtml: searchForIndexHtml,
-            additionalMediaTypeExtensions: [:]
+            mediaTypeFileExtensionMap: [:]
         )
     }
 
@@ -100,7 +100,7 @@ where Provider.FileAttributes: FileMiddlewareFileAttributes {
             urlBasePath: urlBasePath,
             cacheControl: cacheControl,
             searchForIndexHtml: searchForIndexHtml,
-            additionalMediaTypeExtensions: [:]
+            mediaTypeFileExtensionMap: [:]
         )
     }
 
@@ -109,24 +109,24 @@ where Provider.FileAttributes: FileMiddlewareFileAttributes {
         urlBasePath: String? = nil,
         cacheControl: CacheControl = .init([]),
         searchForIndexHtml: Bool = false,
-        additionalMediaTypeExtensions: [String: MediaType]
+        mediaTypeFileExtensionMap: [String: MediaType]
     ) {
         self.cacheControl = cacheControl
         self.searchForIndexHtml = searchForIndexHtml
         self.urlBasePath = urlBasePath.map { String($0.dropSuffix("/")) }
         self.fileProvider = fileProvider
-        self.additionalMediaTypeExtensions = additionalMediaTypeExtensions
+        self.mediaTypeFileExtensionMap = mediaTypeFileExtensionMap
     }
 
-    public func withAdditionalMediaType(_ mediaType: MediaType, forFileExtension fileExtension: String) -> FileMiddleware {
-        var extensions = additionalMediaTypeExtensions
+    public func withAdditionalMediaType(_ mediaType: MediaType, mappedToFileExtension fileExtension: String) -> FileMiddleware {
+        var extensions = mediaTypeFileExtensionMap
         extensions[fileExtension] = mediaType
         return FileMiddleware(
             fileProvider: fileProvider,
             urlBasePath: urlBasePath,
             cacheControl: cacheControl,
             searchForIndexHtml: searchForIndexHtml,
-            additionalMediaTypeExtensions: extensions
+            mediaTypeFileExtensionMap: extensions
         )
     }
 
@@ -253,7 +253,7 @@ extension FileMiddleware {
 
         // content-type
         if let ext = self.fileExtension(for: path) {
-            if let contentType = additionalMediaTypeExtensions[ext] ?? MediaType.getMediaType(forExtension: ext) {
+            if let contentType = mediaTypeFileExtensionMap[ext] ?? MediaType.getMediaType(forExtension: ext) {
                 headers[.contentType] = contentType.description
             }
         }

--- a/Sources/Hummingbird/Middleware/FileMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/FileMiddleware.swift
@@ -123,11 +123,11 @@ where Provider.FileAttributes: FileMiddlewareFileAttributes {
     }
 
     public func withAdditionalMediaTypes(forFileExtensions extensionToMediaTypeMap: [String: MediaType]) -> FileMiddleware {
-        let extensions =
-            extensionToMediaTypeMap
-            .reduce(into: mediaTypeFileExtensionMap) {
-                $0[$1.key.lowercased()] = $1.value
-            }
+        let extensions = extensionToMediaTypeMap.reduce(
+            into: mediaTypeFileExtensionMap
+        ) {
+            $0[$1.key.lowercased()] = $1.value
+        }
 
         return FileMiddleware(
             fileProvider: fileProvider,

--- a/Sources/Hummingbird/Middleware/FileMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/FileMiddleware.swift
@@ -119,8 +119,15 @@ where Provider.FileAttributes: FileMiddlewareFileAttributes {
     }
 
     public func withAdditionalMediaType(_ mediaType: MediaType, mappedToFileExtension fileExtension: String) -> FileMiddleware {
-        var extensions = mediaTypeFileExtensionMap
-        extensions[fileExtension] = mediaType
+        withAdditionalMediaTypes(forFileExtensions: [fileExtension: mediaType])
+    }
+
+    public func withAdditionalMediaTypes(forFileExtensions extensionToMediaTypeMap: [String: MediaType]) -> FileMiddleware {
+        let extensions = extensionToMediaTypeMap
+            .reduce(into: mediaTypeFileExtensionMap) {
+                $0[$1.key.lowercased()] = $1.value
+            }
+
         return FileMiddleware(
             fileProvider: fileProvider,
             urlBasePath: urlBasePath,

--- a/Sources/Hummingbird/Middleware/FileMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/FileMiddleware.swift
@@ -52,7 +52,7 @@ where Provider.FileAttributes: FileMiddlewareFileAttributes {
     let searchForIndexHtml: Bool
     let urlBasePath: String?
     let fileProvider: Provider
-    let mediaTypeFileExtensionMap: [String: MediaType]
+    public let mediaTypeFileExtensionMap: [String: MediaType]
 
     /// Create FileMiddleware
     /// - Parameters:

--- a/Sources/Hummingbird/Middleware/FileMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/FileMiddleware.swift
@@ -52,7 +52,7 @@ where Provider.FileAttributes: FileMiddlewareFileAttributes {
     let searchForIndexHtml: Bool
     let urlBasePath: String?
     let fileProvider: Provider
-    public let mediaTypeFileExtensionMap: [String: MediaType]
+    let mediaTypeFileExtensionMap: [String: MediaType]
 
     /// Create FileMiddleware
     /// - Parameters:

--- a/Sources/Hummingbird/Middleware/FileMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/FileMiddleware.swift
@@ -123,7 +123,8 @@ where Provider.FileAttributes: FileMiddlewareFileAttributes {
     }
 
     public func withAdditionalMediaTypes(forFileExtensions extensionToMediaTypeMap: [String: MediaType]) -> FileMiddleware {
-        let extensions = extensionToMediaTypeMap
+        let extensions =
+            extensionToMediaTypeMap
             .reduce(into: mediaTypeFileExtensionMap) {
                 $0[$1.key.lowercased()] = $1.value
             }

--- a/Tests/HummingbirdTests/FileMiddlewareTests.swift
+++ b/Tests/HummingbirdTests/FileMiddlewareTests.swift
@@ -516,7 +516,7 @@ final class FileMiddlewareTests: XCTestCase {
     func testCustomMIMEType() async throws {
         let hlsStream = try XCTUnwrap(MediaType(from: "application/x-mpegURL"))
         let router = Router()
-        router.middlewares.add(FileMiddleware(".").withAdditionalMediaType(hlsStream, forFileExtension: "m3u8"))
+        router.middlewares.add(FileMiddleware(".").withAdditionalMediaType(hlsStream, mappedToFileExtension: "m3u8"))
         let app = Application(responder: router.buildResponder())
 
         let filename = "\(#function).m3u8"

--- a/Tests/HummingbirdTests/FileMiddlewareTests.swift
+++ b/Tests/HummingbirdTests/FileMiddlewareTests.swift
@@ -546,4 +546,44 @@ final class FileMiddlewareTests: XCTestCase {
             }
         }
     }
+
+    func testCustomMIMETypes() async throws {
+        let hlsStream = try XCTUnwrap(MediaType(from: "application/x-mpegURL"))
+        let router = Router()
+        let fileMiddleware = FileMiddleware<BasicRequestContext, LocalFileSystem>(".")
+            .withAdditionalMediaType(hlsStream, mappedToFileExtension: "m3u8")
+            .withAdditionalMediaTypes(forFileExtensions: [
+                "foo": MediaType(type: .any, subType: "x-foo"),
+                "M3U8": MediaType(type: .application, subType: "vnd.apple.mpegURL"),
+            ])
+        router.middlewares.add(fileMiddleware)
+        let app = Application(responder: router.buildResponder())
+
+        let filename = "\(#function).m3u8"
+        let content = """
+            #EXTM3U
+            #EXT-X-VERSION:7
+            #EXT-X-ALLOW-CACHE:YES
+            #EXT-X-TARGETDURATION:0
+            #EXT-X-MEDIA-SEQUENCE:10
+            #EXT-X-PLAYLIST-TYPE:EVENT
+            #EXT-X-MAP:URI="init.mp4"
+            #EXT-X-DISCONTINUITY
+            #EXTINF:0.000000,
+            live000010.m4s
+            """
+        let data = Data(content.utf8)
+        let fileURL = URL(fileURLWithPath: filename)
+        XCTAssertNoThrow(try data.write(to: fileURL))
+        defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL)) }
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: filename, method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), content)
+                let contentType = try XCTUnwrap(response.headers[.contentType])
+                let validTypes = Set(["application/vnd.apple.mpegurl", "application/vnd.apple.mpegURL"])
+                XCTAssert(validTypes.contains(contentType))
+            }
+        }
+    }
 }

--- a/Tests/HummingbirdTests/FileMiddlewareTests.swift
+++ b/Tests/HummingbirdTests/FileMiddlewareTests.swift
@@ -512,4 +512,38 @@ final class FileMiddlewareTests: XCTestCase {
             }
         }
     }
+
+    func testCustomMIMEType() async throws {
+        let hlsStream = try XCTUnwrap(MediaType(from: "application/x-mpegURL"))
+        let router = Router()
+        router.middlewares.add(FileMiddleware(".").withAdditionalMediaType(hlsStream, forFileExtension: "m3u8"))
+        let app = Application(responder: router.buildResponder())
+
+        let filename = "\(#function).m3u8"
+        let content = """
+            #EXTM3U
+            #EXT-X-VERSION:7
+            #EXT-X-ALLOW-CACHE:YES
+            #EXT-X-TARGETDURATION:0
+            #EXT-X-MEDIA-SEQUENCE:10
+            #EXT-X-PLAYLIST-TYPE:EVENT
+            #EXT-X-MAP:URI="init.mp4"
+            #EXT-X-DISCONTINUITY
+            #EXTINF:0.000000,
+            live000010.m4s
+            """
+        let data = Data(content.utf8)
+        let fileURL = URL(fileURLWithPath: filename)
+        XCTAssertNoThrow(try data.write(to: fileURL))
+        defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL)) }
+
+        try await app.test(.router) { client in
+            try await client.execute(uri: filename, method: .get) { response in
+                XCTAssertEqual(String(buffer: response.body), content)
+                let contentType = try XCTUnwrap(response.headers[.contentType])
+                let validTypes = Set(["application/vnd.apple.mpegurl", "application/x-mpegurl"])
+                XCTAssert(validTypes.contains(contentType))
+            }
+        }
+    }
 }


### PR DESCRIPTION
Added `additionalMediaTypeExtensions` to `FileMiddleware` with a `withAdditionalMediaType` method, adding additional media types, to retain object immutability.

I also went out on a limb and funneled the `FileMiddleware` inits through a single initializer as that better supports this pattern.

This would resolve #656

A test case was added to confirm expected behavior.