### PR TITLE
Show URLFormCoding test case errors in test case

### DIFF
--- a/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
@@ -17,12 +17,18 @@ import XCTest
 @testable import Hummingbird
 
 final class URLDecodedFormDecoderTests: XCTestCase {
-    func testForm<Input: Decodable & Equatable>(_ value: Input, query: String, decoder: URLEncodedFormDecoder = .init()) {
+    func testForm<Input: Decodable & Equatable>(
+        _ value: Input,
+        query: String,
+        decoder: URLEncodedFormDecoder = .init(),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
         do {
             let value2 = try decoder.decode(Input.self, from: query)
-            XCTAssertEqual(value, value2)
+            XCTAssertEqual(value, value2, file: file, line: line)
         } catch {
-            XCTFail("\(error)")
+            XCTFail("\(error)", file: file, line: line)
         }
     }
 

--- a/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
@@ -16,22 +16,22 @@ import Hummingbird
 import XCTest
 
 final class URLEncodedFormEncoderTests: XCTestCase {
-    static func XCTAssertEncodedEqual(_ lhs: String, _ rhs: String) {
+    static func XCTAssertEncodedEqual(_ lhs: String, _ rhs: String, file: StaticString = #filePath, line: UInt = #line) {
         let lhs = lhs.split(separator: "&")
             .sorted { $0 < $1 }
             .joined(separator: "&")
         let rhs = rhs.split(separator: "&")
             .sorted { $0 < $1 }
             .joined(separator: "&")
-        XCTAssertEqual(lhs, rhs)
+        XCTAssertEqual(lhs, rhs, file: file, line: line)
     }
 
-    func testForm(_ value: some Encodable, query: String, encoder: URLEncodedFormEncoder = .init()) {
+    func testForm(_ value: some Encodable, query: String, encoder: URLEncodedFormEncoder = .init(), file: StaticString = #filePath, line: UInt = #line) {
         do {
             let query2 = try encoder.encode(value)
-            Self.XCTAssertEncodedEqual(query2, query)
+            Self.XCTAssertEncodedEqual(query2, query, file: file, line: line)
         } catch {
-            XCTFail("\(error)")
+            XCTFail("\(error)", file: file, line: line)
         }
     }
 

--- a/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
@@ -16,7 +16,12 @@ import Hummingbird
 import XCTest
 
 final class URLEncodedFormEncoderTests: XCTestCase {
-    static func XCTAssertEncodedEqual(_ lhs: String, _ rhs: String, file: StaticString = #filePath, line: UInt = #line) {
+    static func XCTAssertEncodedEqual(
+        _ lhs: String,
+        _ rhs: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
         let lhs = lhs.split(separator: "&")
             .sorted { $0 < $1 }
             .joined(separator: "&")
@@ -26,7 +31,13 @@ final class URLEncodedFormEncoderTests: XCTestCase {
         XCTAssertEqual(lhs, rhs, file: file, line: line)
     }
 
-    func testForm(_ value: some Encodable, query: String, encoder: URLEncodedFormEncoder = .init(), file: StaticString = #filePath, line: UInt = #line) {
+    func testForm(
+        _ value: some Encodable,
+        query: String,
+        encoder: URLEncodedFormEncoder = .init(),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
         do {
             let query2 = try encoder.encode(value)
             Self.XCTAssertEncodedEqual(query2, query, file: file, line: line)


### PR DESCRIPTION
While making the URL en/decoding PR, I noticed that test failures showed inline alerts at the top of the code file, not in the test case itself, due to the convenience methods designed for the tests.

I adjusted the definitions of these convenience methods to instead pass the file and line of the actual test and forward that to `XCTAssert*`, showing errors inline at the call site instead of stacking failures in a single location.



Incidentally, I also noticed that all the tests are still using the XCTest framework. Is there interest in migrating to Swift Testing? That would be a much more time consuming undertaking, so I don't want to make any PRs on that without any demonstrated interest.