### PR TITLE
Fix iOS build: NIOTSEventLoopGroup's module is not imported

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -17,6 +17,7 @@ import Logging
 import NIOCore
 import NIOHTTPTypes
 import NIOPosix
+import NIOTransportServices
 import ServiceLifecycle
 import UnixSignals
 

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -17,9 +17,14 @@ import Logging
 import NIOCore
 import NIOHTTPTypes
 import NIOPosix
-import NIOTransportServices
 import ServiceLifecycle
 import UnixSignals
+
+#if os(iOS) && canImport(NIOTransportServices)
+// Import for NIOTSEventLoopGroup, which we're accessing
+// with #if os(iOS), below.
+import NIOTransportServices
+#endif
 
 /// Where should the application get its EventLoopGroup from
 public enum EventLoopGroupProvider {

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -20,9 +20,7 @@ import NIOPosix
 import ServiceLifecycle
 import UnixSignals
 
-#if os(iOS) && canImport(NIOTransportServices)
-// Import for NIOTSEventLoopGroup, which we're accessing
-// with #if os(iOS), below.
+#if os(iOS)
 import NIOTransportServices
 #endif
 
@@ -36,7 +34,7 @@ public enum EventLoopGroupProvider {
     public var eventLoopGroup: EventLoopGroup {
         switch self {
         case .singleton:
-            #if os(iOS) && canImport(NIOTransportServices)
+            #if os(iOS)
             return NIOTSEventLoopGroup.singleton
             #else
             return MultiThreadedEventLoopGroup.singleton

--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -36,7 +36,7 @@ public enum EventLoopGroupProvider {
     public var eventLoopGroup: EventLoopGroup {
         switch self {
         case .singleton:
-            #if os(iOS)
+            #if os(iOS) && canImport(NIOTransportServices)
             return NIOTSEventLoopGroup.singleton
             #else
             return MultiThreadedEventLoopGroup.singleton


### PR DESCRIPTION
Building for iOS fails with a single error in this file.

Fix by explicitly using `import NIOTransportServices` on use.