### PR TITLE
Use TaskLocals to isolate metrics/tracing tests from each other

### DIFF
--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -20,19 +20,24 @@ import XCTest
 
 final class TestMetrics: MetricsFactory {
     private let lock = NIOLock()
-    let counters = NIOLockedValueBox([String: CounterHandler]())
-    let meters = NIOLockedValueBox([String: MeterHandler]())
-    let recorders = NIOLockedValueBox([String: RecorderHandler]())
-    let timers = NIOLockedValueBox([String: TimerHandler]())
+    private let _counters = NIOLockedValueBox([String: CounterHandler]())
+    private let _meters = NIOLockedValueBox([String: MeterHandler]())
+    private let _recorders = NIOLockedValueBox([String: RecorderHandler]())
+    private let _timers = NIOLockedValueBox([String: TimerHandler]())
+
+    public var counters: [String: CounterHandler] { _counters.withLockedValue { $0 } }
+    public var meters: [String: MeterHandler] { _meters.withLockedValue { $0 } }
+    public var recorders: [String: RecorderHandler] { _recorders.withLockedValue { $0 } }
+    public var timers: [String: TimerHandler] { _timers.withLockedValue { $0 } }
 
     public func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
-        self.counters.withLockedValue { counters in
+        self._counters.withLockedValue { counters in
             self.make(label: label, dimensions: dimensions, registry: &counters, maker: TestCounter.init)
         }
     }
 
     public func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler {
-        self.meters.withLockedValue { counters in
+        self._meters.withLockedValue { counters in
             self.make(label: label, dimensions: dimensions, registry: &counters, maker: TestMeter.init)
         }
     }
@@ -41,13 +46,13 @@ final class TestMetrics: MetricsFactory {
         let maker = { (label: String, dimensions: [(String, String)]) -> RecorderHandler in
             TestRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
         }
-        return self.recorders.withLockedValue { recorders in
+        return self._recorders.withLockedValue { recorders in
             self.make(label: label, dimensions: dimensions, registry: &recorders, maker: maker)
         }
     }
 
     public func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
-        self.timers.withLockedValue { timers in
+        self._timers.withLockedValue { timers in
             self.make(label: label, dimensions: dimensions, registry: &timers, maker: TestTimer.init)
         }
     }
@@ -65,7 +70,7 @@ final class TestMetrics: MetricsFactory {
 
     func destroyCounter(_ handler: CounterHandler) {
         if let testCounter = handler as? TestCounter {
-            _ = self.counters.withLockedValue { counters in
+            _ = self._counters.withLockedValue { counters in
                 counters.removeValue(forKey: testCounter.label)
             }
         }
@@ -73,7 +78,7 @@ final class TestMetrics: MetricsFactory {
 
     func destroyMeter(_ handler: MeterHandler) {
         if let testMeter = handler as? TestMeter {
-            _ = self.counters.withLockedValue { counters in
+            _ = self._counters.withLockedValue { counters in
                 counters.removeValue(forKey: testMeter.label)
             }
         }
@@ -81,7 +86,7 @@ final class TestMetrics: MetricsFactory {
 
     func destroyRecorder(_ handler: RecorderHandler) {
         if let testRecorder = handler as? TestRecorder {
-            _ = self.recorders.withLockedValue { recorders in
+            _ = self._recorders.withLockedValue { recorders in
                 recorders.removeValue(forKey: testRecorder.label)
             }
         }
@@ -89,7 +94,7 @@ final class TestMetrics: MetricsFactory {
 
     func destroyTimer(_ handler: TimerHandler) {
         if let testTimer = handler as? TestTimer {
-            _ = self.timers.withLockedValue { timers in
+            _ = self._timers.withLockedValue { timers in
                 timers.removeValue(forKey: testTimer.label)
             }
         }
@@ -248,148 +253,210 @@ internal final class TestTimer: TimerHandler, Equatable {
     }
 }
 
-final class MetricsTests: XCTestCase {
-    static let testMetrics = TestMetrics()
-
-    override class func setUp() {
-        MetricsSystem.bootstrap(self.testMetrics)
+final class TaskUniqueTestMetrics: MetricsFactory {
+    @TaskLocal static var current: TestMetrics = .init()
+    func withUnique<Value: Sendable>(
+        isolation: isolated (any Actor)? = #isolation,
+        _ operation: () async throws -> Value
+    ) async throws -> Value {
+        try await TaskUniqueTestMetrics.$current.withValue(TestMetrics()) {
+            try await operation()
+        }
     }
 
-    func testCounter() async throws {
-        let router = Router()
-        router.middlewares.add(MetricsMiddleware())
-        router.get("/hello") { _, _ -> String in
-            "Hello"
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/hello", method: .get) { _ in }
-        }
+    func makeCounter(label: String, dimensions: [(String, String)]) -> any CoreMetrics.CounterHandler {
+        TaskUniqueTestMetrics.current.makeCounter(label: label, dimensions: dimensions)
+    }
 
-        let counter = try XCTUnwrap(Self.testMetrics.counters.withLockedValue { $0 }["hb.requests"] as? TestCounter)
-        XCTAssertEqual(counter.values.withLockedValue { $0 }[0].1, 1)
-        XCTAssertEqual(counter.dimensions[0].0, "http.route")
-        XCTAssertEqual(counter.dimensions[0].1, "/hello")
-        XCTAssertEqual(counter.dimensions[1].0, "http.request.method")
-        XCTAssertEqual(counter.dimensions[1].1, "GET")
+    public func makeMeter(label: String, dimensions: [(String, String)]) -> MeterHandler {
+        TaskUniqueTestMetrics.current.makeMeter(label: label, dimensions: dimensions)
+    }
+
+    func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> any CoreMetrics.RecorderHandler {
+        TaskUniqueTestMetrics.current.makeRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
+    }
+
+    func makeTimer(label: String, dimensions: [(String, String)]) -> any CoreMetrics.TimerHandler {
+        TaskUniqueTestMetrics.current.makeTimer(label: label, dimensions: dimensions)
+    }
+
+    func destroyCounter(_ handler: any CoreMetrics.CounterHandler) {
+        TaskUniqueTestMetrics.current.destroyCounter(handler)
+    }
+
+    func destroyMeter(_ handler: MeterHandler) {
+        TaskUniqueTestMetrics.current.destroyMeter(handler)
+    }
+
+    func destroyRecorder(_ handler: any CoreMetrics.RecorderHandler) {
+        TaskUniqueTestMetrics.current.destroyRecorder(handler)
+    }
+
+    func destroyTimer(_ handler: any CoreMetrics.TimerHandler) {
+        TaskUniqueTestMetrics.current.destroyTimer(handler)
+    }
+
+    public var counters: [String: CounterHandler] { TaskUniqueTestMetrics.current.counters }
+    public var meters: [String: MeterHandler] { TaskUniqueTestMetrics.current.meters }
+    public var recorders: [String: RecorderHandler] { TaskUniqueTestMetrics.current.recorders }
+    public var timers: [String: TimerHandler] { TaskUniqueTestMetrics.current.timers }
+
+}
+
+final class MetricsTests: XCTestCase {
+    static let testMetrics = {
+        let metrics = TaskUniqueTestMetrics()
+        MetricsSystem.bootstrap(metrics)
+        return metrics
+    }()
+
+    func testCounter() async throws {
+        try await Self.testMetrics.withUnique {
+            let router = Router()
+            router.middlewares.add(MetricsMiddleware())
+            router.get("/hello") { _, _ -> String in
+                "Hello"
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/hello", method: .get) { _ in }
+            }
+
+            let counter = try XCTUnwrap(Self.testMetrics.counters["hb.requests"] as? TestCounter)
+            XCTAssertEqual(counter.values.withLockedValue { $0 }[0].1, 1)
+            XCTAssertEqual(counter.dimensions[0].0, "http.route")
+            XCTAssertEqual(counter.dimensions[0].1, "/hello")
+            XCTAssertEqual(counter.dimensions[1].0, "http.request.method")
+            XCTAssertEqual(counter.dimensions[1].1, "GET")
+        }
     }
 
     func testError() async throws {
-        let router = Router()
-        router.middlewares.add(MetricsMiddleware())
-        router.get("/hello") { _, _ -> String in
-            throw HTTPError(.badRequest)
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/hello", method: .get) { _ in }
-        }
+        try await Self.testMetrics.withUnique {
+            let router = Router()
+            router.middlewares.add(MetricsMiddleware())
+            router.get("/hello") { _, _ -> String in
+                throw HTTPError(.badRequest)
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/hello", method: .get) { _ in }
+            }
 
-        let counter = try XCTUnwrap(Self.testMetrics.counters.withLockedValue { $0 }["hb.requests"] as? TestCounter)
-        XCTAssertEqual(counter.values.withLockedValue { $0 }[0].1, 1)
-        XCTAssertEqual(counter.dimensions[0].0, "http.route")
-        XCTAssertEqual(counter.dimensions[0].1, "/hello")
-        XCTAssertEqual(counter.dimensions[1].0, "http.request.method")
-        XCTAssertEqual(counter.dimensions[1].1, "GET")
-        XCTAssertEqual(counter.dimensions[2].0, "http.response.status_code")
-        XCTAssertEqual(counter.dimensions[2].1, "400")
-        let errorCounter = try XCTUnwrap(Self.testMetrics.counters.withLockedValue { $0 }["hb.request.errors"] as? TestCounter)
-        XCTAssertEqual(errorCounter.values.withLockedValue { $0 }.count, 1)
-        XCTAssertEqual(errorCounter.values.withLockedValue { $0 }[0].1, 1)
-        XCTAssertEqual(errorCounter.dimensions[0].0, "http.route")
-        XCTAssertEqual(errorCounter.dimensions[0].1, "/hello")
-        XCTAssertEqual(errorCounter.dimensions[1].0, "http.request.method")
-        XCTAssertEqual(errorCounter.dimensions[1].1, "GET")
+            let counter = try XCTUnwrap(Self.testMetrics.counters["hb.requests"] as? TestCounter)
+            XCTAssertEqual(counter.values.withLockedValue { $0 }[0].1, 1)
+            XCTAssertEqual(counter.dimensions[0].0, "http.route")
+            XCTAssertEqual(counter.dimensions[0].1, "/hello")
+            XCTAssertEqual(counter.dimensions[1].0, "http.request.method")
+            XCTAssertEqual(counter.dimensions[1].1, "GET")
+            XCTAssertEqual(counter.dimensions[2].0, "http.response.status_code")
+            XCTAssertEqual(counter.dimensions[2].1, "400")
+            let errorCounter = try XCTUnwrap(Self.testMetrics.counters["hb.request.errors"] as? TestCounter)
+            XCTAssertEqual(errorCounter.values.withLockedValue { $0 }.count, 1)
+            XCTAssertEqual(errorCounter.values.withLockedValue { $0 }[0].1, 1)
+            XCTAssertEqual(errorCounter.dimensions[0].0, "http.route")
+            XCTAssertEqual(errorCounter.dimensions[0].1, "/hello")
+            XCTAssertEqual(errorCounter.dimensions[1].0, "http.request.method")
+            XCTAssertEqual(errorCounter.dimensions[1].1, "GET")
+        }
     }
 
     func testNotFoundError() async throws {
-        let router = Router()
-        router.middlewares.add(MetricsMiddleware())
-        router.get("/hello") { _, _ -> String in
-            "hello"
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/hello2", method: .get) { _ in }
-        }
+        try await Self.testMetrics.withUnique {
+            let router = Router()
+            router.middlewares.add(MetricsMiddleware())
+            router.get("/hello") { _, _ -> String in
+                "hello"
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/hello2", method: .get) { _ in }
+            }
 
-        let counter = try XCTUnwrap(Self.testMetrics.counters.withLockedValue { $0 }["hb.requests"] as? TestCounter)
-        XCTAssertEqual(counter.values.withLockedValue { $0 }[0].1, 1)
-        XCTAssertEqual(counter.dimensions[0].0, "http.route")
-        XCTAssertEqual(counter.dimensions[0].1, "NotFound")
-        XCTAssertEqual(counter.dimensions[1].0, "http.request.method")
-        XCTAssertEqual(counter.dimensions[1].1, "GET")
-        XCTAssertEqual(counter.dimensions[2].0, "http.response.status_code")
-        XCTAssertEqual(counter.dimensions[2].1, "404")
-        let errorCounter = try XCTUnwrap(Self.testMetrics.counters.withLockedValue { $0 }["hb.request.errors"] as? TestCounter)
-        XCTAssertEqual(errorCounter.values.withLockedValue { $0 }.count, 1)
-        XCTAssertEqual(errorCounter.values.withLockedValue { $0 }[0].1, 1)
-        XCTAssertEqual(errorCounter.dimensions.count, 3)
-        XCTAssertEqual(errorCounter.dimensions[0].0, "http.route")
-        XCTAssertEqual(errorCounter.dimensions[0].1, "NotFound")
-        XCTAssertEqual(errorCounter.dimensions[1].0, "http.request.method")
-        XCTAssertEqual(errorCounter.dimensions[1].1, "GET")
-        XCTAssertEqual(errorCounter.dimensions[2].0, "error.type")
-        XCTAssertEqual(errorCounter.dimensions[2].1, "404")
+            let counter = try XCTUnwrap(Self.testMetrics.counters["hb.requests"] as? TestCounter)
+            XCTAssertEqual(counter.values.withLockedValue { $0 }[0].1, 1)
+            XCTAssertEqual(counter.dimensions[0].0, "http.route")
+            XCTAssertEqual(counter.dimensions[0].1, "NotFound")
+            XCTAssertEqual(counter.dimensions[1].0, "http.request.method")
+            XCTAssertEqual(counter.dimensions[1].1, "GET")
+            XCTAssertEqual(counter.dimensions[2].0, "http.response.status_code")
+            XCTAssertEqual(counter.dimensions[2].1, "404")
+            let errorCounter = try XCTUnwrap(Self.testMetrics.counters["hb.request.errors"] as? TestCounter)
+            XCTAssertEqual(errorCounter.values.withLockedValue { $0 }.count, 1)
+            XCTAssertEqual(errorCounter.values.withLockedValue { $0 }[0].1, 1)
+            XCTAssertEqual(errorCounter.dimensions.count, 3)
+            XCTAssertEqual(errorCounter.dimensions[0].0, "http.route")
+            XCTAssertEqual(errorCounter.dimensions[0].1, "NotFound")
+            XCTAssertEqual(errorCounter.dimensions[1].0, "http.request.method")
+            XCTAssertEqual(errorCounter.dimensions[1].1, "GET")
+            XCTAssertEqual(errorCounter.dimensions[2].0, "error.type")
+            XCTAssertEqual(errorCounter.dimensions[2].1, "404")
+        }
     }
 
     func testParameterEndpoint() async throws {
-        let router = Router()
-        router.middlewares.add(MetricsMiddleware())
-        router.get("/user/:id") { _, _ -> String in
-            throw HTTPError(.badRequest)
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/user/765", method: .get) { _ in }
-        }
+        try await Self.testMetrics.withUnique {
+            let router = Router()
+            router.middlewares.add(MetricsMiddleware())
+            router.get("/user/:id") { _, _ -> String in
+                throw HTTPError(.badRequest)
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/user/765", method: .get) { _ in }
+            }
 
-        let counter = try XCTUnwrap(Self.testMetrics.counters.withLockedValue { $0 }["hb.request.errors"] as? TestCounter)
-        XCTAssertEqual(counter.values.withLockedValue { $0 }.count, 1)
-        XCTAssertEqual(counter.values.withLockedValue { $0 }[0].1, 1)
-        XCTAssertEqual(counter.dimensions.count, 3)
-        XCTAssertEqual(counter.dimensions[0].0, "http.route")
-        XCTAssertEqual(counter.dimensions[0].1, "/user/{id}")
-        XCTAssertEqual(counter.dimensions[1].0, "http.request.method")
-        XCTAssertEqual(counter.dimensions[1].1, "GET")
-        XCTAssertEqual(counter.dimensions[2].0, "error.type")
-        XCTAssertEqual(counter.dimensions[2].1, "400")
+            let counter = try XCTUnwrap(Self.testMetrics.counters["hb.request.errors"] as? TestCounter)
+            XCTAssertEqual(counter.values.withLockedValue { $0 }.count, 1)
+            XCTAssertEqual(counter.values.withLockedValue { $0 }[0].1, 1)
+            XCTAssertEqual(counter.dimensions.count, 3)
+            XCTAssertEqual(counter.dimensions[0].0, "http.route")
+            XCTAssertEqual(counter.dimensions[0].1, "/user/{id}")
+            XCTAssertEqual(counter.dimensions[1].0, "http.request.method")
+            XCTAssertEqual(counter.dimensions[1].1, "GET")
+            XCTAssertEqual(counter.dimensions[2].0, "error.type")
+            XCTAssertEqual(counter.dimensions[2].1, "400")
+        }
     }
 
     func testRecordingBodyWriteTime() async throws {
-        let router = Router()
-        router.middlewares.add(MetricsMiddleware())
-        router.get("/hello") { _, _ -> Response in
-            Response(
-                status: .ok,
-                body: .init { _ in
-                    try await Task.sleep(for: .milliseconds(5))
-                }
-            )
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/hello", method: .get) { _ in }
-        }
+        try await Self.testMetrics.withUnique {
+            let router = Router()
+            router.middlewares.add(MetricsMiddleware())
+            router.get("/hello") { _, _ -> Response in
+                Response(
+                    status: .ok,
+                    body: .init { _ in
+                        try await Task.sleep(for: .milliseconds(5))
+                    }
+                )
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/hello", method: .get) { _ in }
+            }
 
-        let timer = try XCTUnwrap(Self.testMetrics.timers.withLockedValue { $0 }["http.server.request.duration"] as? TestTimer)
-        XCTAssertGreaterThan(timer.values.withLockedValue { $0 }[0].1, 5_000_000)
+            let timer = try XCTUnwrap(Self.testMetrics.timers["http.server.request.duration"] as? TestTimer)
+            XCTAssertGreaterThan(timer.values.withLockedValue { $0 }[0].1, 5_000_000)
+        }
     }
 
     func testActiveRequestsMetric() async throws {
-        let router = Router()
-        router.middlewares.add(MetricsMiddleware())
-        router.get("/hello") { _, _ -> Response in
-            Response(status: .ok)
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/hello", method: .get) { _ in }
-        }
+        try await Self.testMetrics.withUnique {
+            let router = Router()
+            router.middlewares.add(MetricsMiddleware())
+            router.get("/hello") { _, _ -> Response in
+                Response(status: .ok)
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/hello", method: .get) { _ in }
+            }
 
-        let meter = try XCTUnwrap(Self.testMetrics.meters.withLockedValue { $0 }["http.server.active_requests"] as? TestMeter)
-        let values = meter.values.withLockedValue { $0 }.map { $0.1 }
-        let maxValue = values.max() ?? 0.0
-        XCTAssertGreaterThan(maxValue, 0.0)
+            let meter = try XCTUnwrap(Self.testMetrics.meters["http.server.active_requests"] as? TestMeter)
+            let values = meter.values.withLockedValue { $0 }.map { $0.1 }
+            let maxValue = values.max() ?? 0.0
+            XCTAssertGreaterThan(maxValue, 0.0)
+        }
     }
 }

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -256,7 +256,6 @@ internal final class TestTimer: TimerHandler, Equatable {
 final class TaskUniqueTestMetrics: MetricsFactory {
     @TaskLocal static var current: TestMetrics = .init()
     func withUnique<Value: Sendable>(
-        isolation: isolated (any Actor)? = #isolation,
         _ operation: () async throws -> Value
     ) async throws -> Value {
         try await TaskUniqueTestMetrics.$current.withValue(TestMetrics()) {

--- a/Tests/HummingbirdTests/TestTracer.swift
+++ b/Tests/HummingbirdTests/TestTracer.swift
@@ -187,7 +187,6 @@ final class TaskUniqueTestTracer: Tracer {
     @TaskLocal static var current: TestTracer = .init()
 
     func withUnique<Value: Sendable>(
-        isolation: isolated (any Actor)? = #isolation,
         _ operation: () async throws -> Value
     ) async throws -> Value {
         try await TaskUniqueTestTracer.$current.withValue(TestTracer()) {

--- a/Tests/HummingbirdTests/TestTracer.swift
+++ b/Tests/HummingbirdTests/TestTracer.swift
@@ -180,3 +180,64 @@ final class TestSpan: Span {
 
 extension TestTracer: @unchecked Sendable {}  // only intended for single threaded testing
 extension TestSpan: @unchecked Sendable {}  // only intended for single threaded testing
+
+final class TaskUniqueTestTracer: Tracer {
+    typealias Span = TestTracer.Span
+
+    @TaskLocal static var current: TestTracer = .init()
+
+    func withUnique<Value: Sendable>(
+        isolation: isolated (any Actor)? = #isolation,
+        _ operation: () async throws -> Value
+    ) async throws -> Value {
+        try await TaskUniqueTestTracer.$current.withValue(TestTracer()) {
+            try await operation()
+        }
+    }
+
+    var spans: [TestSpan] {
+        TaskUniqueTestTracer.current.spans
+    }
+    var onEndSpan: (TestSpan) -> Void {
+        get { TaskUniqueTestTracer.current.onEndSpan }
+        set { TaskUniqueTestTracer.current.onEndSpan = newValue }
+    }
+
+    func startSpan<Instant>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContextModule.ServiceContext,
+        ofKind kind: Tracing.SpanKind,
+        at instant: @autoclosure () -> Instant,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> Span where Instant: Tracing.TracerInstant {
+        TaskUniqueTestTracer.current.startSpan(
+            operationName,
+            context: context(),
+            ofKind: kind,
+            at: instant(),
+            function: function,
+            file: fileID,
+            line: line
+        )
+    }
+
+    func activeSpan(identifiedBy context: ServiceContextModule.ServiceContext) -> Span? {
+        TaskUniqueTestTracer.current.activeSpan(identifiedBy: context)
+    }
+
+    func forceFlush() {
+        TaskUniqueTestTracer.current.forceFlush()
+    }
+
+    func extract<Carrier, Extract>(_ carrier: Carrier, into context: inout ServiceContextModule.ServiceContext, using extractor: Extract)
+    where Carrier == Extract.Carrier, Extract: Instrumentation.Extractor {
+        TaskUniqueTestTracer.current.extract(carrier, into: &context, using: extractor)
+    }
+
+    func inject<Carrier, Inject>(_ context: ServiceContextModule.ServiceContext, into carrier: inout Carrier, using injector: Inject)
+    where Carrier == Inject.Carrier, Inject: Instrumentation.Injector {
+        TaskUniqueTestTracer.current.inject(context, into: &carrier, using: injector)
+    }
+}

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -22,87 +22,91 @@ import XCTest
 @testable import Instrumentation
 
 final class TracingTests: XCTestCase {
+    static let testTracer = {
+        let tracer = TaskUniqueTestTracer()
+        InstrumentationSystem.bootstrap(tracer)
+        return tracer
+    }()
+
     func testTracingMiddleware() async throws {
-        let expectation = expectation(description: "Expected span to be ended.")
+        try await Self.testTracer.withUnique {
+            let expectation = expectation(description: "Expected span to be ended.")
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
-
-        let router = Router()
-        router.middlewares.add(TracingMiddleware(attributes: ["net.host.name": "127.0.0.1", "net.host.port": 8080]))
-        router.get("users/{id}") { _, _ -> String in
-            "42"
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/users/42", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
-                XCTAssertEqual(String(buffer: response.body), "42")
+            let router = Router()
+            router.middlewares.add(TracingMiddleware(attributes: ["net.host.name": "127.0.0.1", "net.host.port": 8080]))
+            router.get("users/{id}") { _, _ -> String in
+                "42"
             }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/users/42", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    XCTAssertEqual(String(buffer: response.body), "42")
+                }
+            }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+
+            XCTAssertEqual(span.operationName, "/users/{id}")
+            XCTAssertEqual(span.kind, .server)
+            XCTAssertNil(span.status)
+            XCTAssertTrue(span.recordedErrors.isEmpty)
+
+            XCTAssertSpanAttributesEqual(
+                span.attributes,
+                [
+                    "http.method": "GET",
+                    "http.target": "/users/42",
+                    "http.status_code": 200,
+                    "http.response_content_length": 2,
+                    "net.host.name": "127.0.0.1",
+                    "net.host.port": 8080,
+                ]
+            )
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-
-        XCTAssertEqual(span.operationName, "/users/{id}")
-        XCTAssertEqual(span.kind, .server)
-        XCTAssertNil(span.status)
-        XCTAssertTrue(span.recordedErrors.isEmpty)
-
-        XCTAssertSpanAttributesEqual(
-            span.attributes,
-            [
-                "http.method": "GET",
-                "http.target": "/users/42",
-                "http.status_code": 200,
-                "http.response_content_length": 2,
-                "net.host.name": "127.0.0.1",
-                "net.host.port": 8080,
-            ]
-        )
     }
 
     func testTracingMiddlewareWithRouterBuilder() async throws {
-        let expectation = expectation(description: "Expected span to be ended.")
+        try await Self.testTracer.withUnique {
+            let expectation = expectation(description: "Expected span to be ended.")
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
-
-        let router = RouterBuilder(context: BasicRouterRequestContext.self) {
-            TracingMiddleware(attributes: ["net.host.name": "127.0.0.1", "net.host.port": 8080])
-            Get("users/{id}") { _, _ in "42" }
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/users/42", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
-                XCTAssertEqual(String(buffer: response.body), "42")
+            let router = RouterBuilder(context: BasicRouterRequestContext.self) {
+                TracingMiddleware(attributes: ["net.host.name": "127.0.0.1", "net.host.port": 8080])
+                Get("users/{id}") { _, _ in "42" }
             }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/users/42", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    XCTAssertEqual(String(buffer: response.body), "42")
+                }
+            }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+
+            XCTAssertEqual(span.operationName, "/users/{id}")
+            XCTAssertEqual(span.kind, .server)
+            XCTAssertNil(span.status)
+            XCTAssertTrue(span.recordedErrors.isEmpty)
+
+            XCTAssertSpanAttributesEqual(
+                span.attributes,
+                [
+                    "http.method": "GET",
+                    "http.target": "/users/42",
+                    "http.status_code": 200,
+                    "http.response_content_length": 2,
+                    "net.host.name": "127.0.0.1",
+                    "net.host.port": 8080,
+                ]
+            )
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-
-        XCTAssertEqual(span.operationName, "/users/{id}")
-        XCTAssertEqual(span.kind, .server)
-        XCTAssertNil(span.status)
-        XCTAssertTrue(span.recordedErrors.isEmpty)
-
-        XCTAssertSpanAttributesEqual(
-            span.attributes,
-            [
-                "http.method": "GET",
-                "http.target": "/users/42",
-                "http.status_code": 200,
-                "http.response_content_length": 2,
-                "net.host.name": "127.0.0.1",
-                "net.host.port": 8080,
-            ]
-        )
     }
 
     func testTracingMiddlewareWithFile() async throws {
@@ -113,43 +117,42 @@ final class TracingTests: XCTestCase {
         XCTAssertNoThrow(try data.write(to: fileURL))
         defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: fileURL)) }
 
-        let expectation = expectation(description: "Expected span to be ended.")
+        try await Self.testTracer.withUnique {
+            let expectation = expectation(description: "Expected span to be ended.")
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
-
-        let router = RouterBuilder(context: BasicRouterRequestContext.self) {
-            TracingMiddleware(attributes: ["net.host.name": "127.0.0.1", "net.host.port": 8080])
-            FileMiddleware(".")
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/\(filename)", method: .get) { response in
-                XCTAssertEqual(response.headers[.contentLength], text.count.description)
+            let router = RouterBuilder(context: BasicRouterRequestContext.self) {
+                TracingMiddleware(attributes: ["net.host.name": "127.0.0.1", "net.host.port": 8080])
+                FileMiddleware(".")
             }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/\(filename)", method: .get) { response in
+                    XCTAssertEqual(response.headers[.contentLength], text.count.description)
+                }
+            }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+
+            XCTAssertEqual(span.operationName, "FileMiddleware")
+            XCTAssertEqual(span.kind, .server)
+            XCTAssertNil(span.status)
+            XCTAssertTrue(span.recordedErrors.isEmpty)
+
+            XCTAssertSpanAttributesEqual(
+                span.attributes,
+                [
+                    "http.method": "GET",
+                    "http.target": "/\(filename)",
+                    "http.status_code": 200,
+                    "http.response_content_length": .int64(Int64(text.count)),
+                    "net.host.name": "127.0.0.1",
+                    "net.host.port": 8080,
+                ]
+            )
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-
-        XCTAssertEqual(span.operationName, "FileMiddleware")
-        XCTAssertEqual(span.kind, .server)
-        XCTAssertNil(span.status)
-        XCTAssertTrue(span.recordedErrors.isEmpty)
-
-        XCTAssertSpanAttributesEqual(
-            span.attributes,
-            [
-                "http.method": "GET",
-                "http.target": "/\(filename)",
-                "http.status_code": 200,
-                "http.response_content_length": .int64(Int64(text.count)),
-                "net.host.name": "127.0.0.1",
-                "net.host.port": 8080,
-            ]
-        )
     }
 
     func testMiddlewareSkippingEndpoint() async throws {
@@ -160,257 +163,257 @@ final class TracingTests: XCTestCase {
         }
         let expectation = expectation(description: "Expected span to be ended.")
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
+        try await Self.testTracer.withUnique {
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let router = RouterBuilder(context: BasicRouterRequestContext.self) {
-            TracingMiddleware()
-            RouteGroup("test") {
-                DeadendMiddleware()
-                Get("this") { _, _ in "Hello" }
+            let router = RouterBuilder(context: BasicRouterRequestContext.self) {
+                TracingMiddleware()
+                RouteGroup("test") {
+                    DeadendMiddleware()
+                    Get("this") { _, _ in "Hello" }
+                }
             }
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/test/this", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/test/this", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                }
             }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+
+            XCTAssertEqual(span.operationName, "/test")
+            XCTAssertEqual(span.kind, .server)
+            XCTAssertNil(span.status)
+            XCTAssertTrue(span.recordedErrors.isEmpty)
+
+            XCTAssertSpanAttributesEqual(
+                span.attributes,
+                [
+                    "http.method": "GET",
+                    "http.target": "/test/this",
+                    "http.status_code": 200,
+                    "http.response_content_length": 0,
+                ]
+            )
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-
-        XCTAssertEqual(span.operationName, "/test")
-        XCTAssertEqual(span.kind, .server)
-        XCTAssertNil(span.status)
-        XCTAssertTrue(span.recordedErrors.isEmpty)
-
-        XCTAssertSpanAttributesEqual(
-            span.attributes,
-            [
-                "http.method": "GET",
-                "http.target": "/test/this",
-                "http.status_code": 200,
-                "http.response_content_length": 0,
-            ]
-        )
     }
 
     func testTracingMiddlewareServerError() async throws {
         let expectation = expectation(description: "Expected span to be ended.")
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
+        try await Self.testTracer.withUnique {
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let router = Router()
-        router.middlewares.add(TracingMiddleware())
-        router.post("users") { _, _ -> String in
-            throw HTTPError(.internalServerError)
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/users", method: .post, headers: [.contentLength: "2"], body: ByteBuffer(string: "42")) { response in
-                XCTAssertEqual(response.status, .internalServerError)
+            let router = Router()
+            router.middlewares.add(TracingMiddleware())
+            router.post("users") { _, _ -> String in
+                throw HTTPError(.internalServerError)
             }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/users", method: .post, headers: [.contentLength: "2"], body: ByteBuffer(string: "42")) { response in
+                    XCTAssertEqual(response.status, .internalServerError)
+                }
+            }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+
+            XCTAssertEqual(span.operationName, "/users")
+            XCTAssertEqual(span.kind, .server)
+            XCTAssertEqual(span.status, .init(code: .error))
+
+            XCTAssertEqual(span.recordedErrors.count, 1)
+            let error = try XCTUnwrap(span.recordedErrors.first?.0 as? HTTPError, "Recorded unexpected errors: \(span.recordedErrors)")
+            XCTAssertEqual(error.status, .internalServerError)
+
+            XCTAssertSpanAttributesEqual(
+                span.attributes,
+                [
+                    "http.method": "POST",
+                    "http.target": "/users",
+                    "http.status_code": 500,
+                    "http.request_content_length": 2,
+                ]
+            )
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-
-        XCTAssertEqual(span.operationName, "/users")
-        XCTAssertEqual(span.kind, .server)
-        XCTAssertEqual(span.status, .init(code: .error))
-
-        XCTAssertEqual(span.recordedErrors.count, 1)
-        let error = try XCTUnwrap(span.recordedErrors.first?.0 as? HTTPError, "Recorded unexpected errors: \(span.recordedErrors)")
-        XCTAssertEqual(error.status, .internalServerError)
-
-        XCTAssertSpanAttributesEqual(
-            span.attributes,
-            [
-                "http.method": "POST",
-                "http.target": "/users",
-                "http.status_code": 500,
-                "http.request_content_length": 2,
-            ]
-        )
     }
 
     func testTracingMiddlewareIncludingHeaders() async throws {
         let expectation = expectation(description: "Expected span to be ended.")
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
+        try await Self.testTracer.withUnique {
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let router = Router()
-        router.middlewares.add(
-            TracingMiddleware(recordingHeaders: [
-                .accept, .contentType, .cacheControl, .test,
-            ])
-        )
-        router.get("users/{id}") { _, _ -> Response in
-            var headers = HTTPFields()
-            headers[values: .cacheControl] = ["86400", "public"]
-            headers[.contentType] = "text/plain"
-            return Response(
-                status: .ok,
-                headers: headers,
-                body: .init(byteBuffer: ByteBuffer(string: "42"))
+            let router = Router()
+            router.middlewares.add(
+                TracingMiddleware(recordingHeaders: [
+                    .accept, .contentType, .cacheControl, .test,
+                ])
+            )
+            router.get("users/{id}") { _, _ -> Response in
+                var headers = HTTPFields()
+                headers[values: .cacheControl] = ["86400", "public"]
+                headers[.contentType] = "text/plain"
+                return Response(
+                    status: .ok,
+                    headers: headers,
+                    body: .init(byteBuffer: ByteBuffer(string: "42"))
+                )
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                var requestHeaders = HTTPFields()
+                requestHeaders[values: .accept] = ["text/plain", "application/json"]
+                requestHeaders[.cacheControl] = "no-cache"
+                try await client.execute(uri: "/users/42", method: .get, headers: requestHeaders) { response in
+                    XCTAssertEqual(response.status, .ok)
+                    XCTAssertEqual(String(buffer: response.body), "42")
+                }
+            }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+
+            XCTAssertEqual(span.operationName, "/users/{id}")
+            XCTAssertEqual(span.kind, .server)
+            XCTAssertNil(span.status)
+            XCTAssertTrue(span.recordedErrors.isEmpty)
+
+            XCTAssertSpanAttributesEqual(
+                span.attributes,
+                [
+                    "http.method": "GET",
+                    "http.target": "/users/42",
+                    "http.status_code": 200,
+                    "http.response_content_length": 2,
+                    "http.request.header.accept": .stringArray(["text/plain", "application/json"]),
+                    "http.request.header.cache_control": "no-cache",
+                    "http.response.header.content_type": "text/plain",
+                    "http.response.header.cache_control": .stringArray(["86400", "public"]),
+                ]
             )
         }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            var requestHeaders = HTTPFields()
-            requestHeaders[values: .accept] = ["text/plain", "application/json"]
-            requestHeaders[.cacheControl] = "no-cache"
-            try await client.execute(uri: "/users/42", method: .get, headers: requestHeaders) { response in
-                XCTAssertEqual(response.status, .ok)
-                XCTAssertEqual(String(buffer: response.body), "42")
-            }
-        }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-
-        XCTAssertEqual(span.operationName, "/users/{id}")
-        XCTAssertEqual(span.kind, .server)
-        XCTAssertNil(span.status)
-        XCTAssertTrue(span.recordedErrors.isEmpty)
-
-        XCTAssertSpanAttributesEqual(
-            span.attributes,
-            [
-                "http.method": "GET",
-                "http.target": "/users/42",
-                "http.status_code": 200,
-                "http.response_content_length": 2,
-                "http.request.header.accept": .stringArray(["text/plain", "application/json"]),
-                "http.request.header.cache_control": "no-cache",
-                "http.response.header.content_type": "text/plain",
-                "http.response.header.cache_control": .stringArray(["86400", "public"]),
-            ]
-        )
     }
 
     func testTracingMiddlewareEmptyResponse() async throws {
         let expectation = expectation(description: "Expected span to be ended.")
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
+        try await Self.testTracer.withUnique {
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let router = Router()
-        router.middlewares.add(TracingMiddleware())
-        router.post("/users") { _, _ -> HTTPResponse.Status in
-            .noContent
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/users", method: .post) { response in
-                XCTAssertEqual(response.status, .noContent)
+            let router = Router()
+            router.middlewares.add(TracingMiddleware())
+            router.post("/users") { _, _ -> HTTPResponse.Status in
+                .noContent
             }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/users", method: .post) { response in
+                    XCTAssertEqual(response.status, .noContent)
+                }
+            }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+
+            XCTAssertEqual(span.operationName, "/users")
+            XCTAssertEqual(span.kind, .server)
+            XCTAssertNil(span.status)
+            XCTAssertTrue(span.recordedErrors.isEmpty)
+
+            XCTAssertSpanAttributesEqual(
+                span.attributes,
+                [
+                    "http.method": "POST",
+                    "http.target": "/users",
+                    "http.status_code": 204,
+                    "http.response_content_length": 0,
+                ]
+            )
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-
-        XCTAssertEqual(span.operationName, "/users")
-        XCTAssertEqual(span.kind, .server)
-        XCTAssertNil(span.status)
-        XCTAssertTrue(span.recordedErrors.isEmpty)
-
-        XCTAssertSpanAttributesEqual(
-            span.attributes,
-            [
-                "http.method": "POST",
-                "http.target": "/users",
-                "http.status_code": 204,
-                "http.response_content_length": 0,
-            ]
-        )
     }
 
     func testTracingMiddlewareIndexRoute() async throws {
         let expectation = expectation(description: "Expected span to be ended.")
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
+        try await Self.testTracer.withUnique {
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let router = Router()
-        router.middlewares.add(TracingMiddleware())
-        router.get("/") { _, _ -> HTTPResponse.Status in
-            .ok
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
+            let router = Router()
+            router.middlewares.add(TracingMiddleware())
+            router.get("/") { _, _ -> HTTPResponse.Status in
+                .ok
             }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                }
+            }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+
+            XCTAssertEqual(span.operationName, "/")
+            XCTAssertEqual(span.kind, .server)
+            XCTAssertNil(span.status)
+            XCTAssertTrue(span.recordedErrors.isEmpty)
+
+            XCTAssertSpanAttributesEqual(
+                span.attributes,
+                [
+                    "http.method": "GET",
+                    "http.target": "/",
+                    "http.status_code": 200,
+                    "http.response_content_length": 0,
+                ]
+            )
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-
-        XCTAssertEqual(span.operationName, "/")
-        XCTAssertEqual(span.kind, .server)
-        XCTAssertNil(span.status)
-        XCTAssertTrue(span.recordedErrors.isEmpty)
-
-        XCTAssertSpanAttributesEqual(
-            span.attributes,
-            [
-                "http.method": "GET",
-                "http.target": "/",
-                "http.status_code": 200,
-                "http.response_content_length": 0,
-            ]
-        )
     }
 
     func testTracingMiddlewareRouteNotFound() async throws {
         let expectation = expectation(description: "Expected span to be ended.")
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
+        try await Self.testTracer.withUnique {
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let router = Router()
-        router.middlewares.add(TracingMiddleware())
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/", method: .get) { response in
-                XCTAssertEqual(response.status, .notFound)
+            let router = Router()
+            router.middlewares.add(TracingMiddleware())
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/", method: .get) { response in
+                    XCTAssertEqual(response.status, .notFound)
+                }
             }
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+
+            XCTAssertEqual(span.operationName, "HTTP GET route not found")
+            XCTAssertEqual(span.kind, .server)
+            XCTAssertNil(span.status)
+
+            XCTAssertEqual(span.recordedErrors.count, 1)
+            let error = try XCTUnwrap(span.recordedErrors.first?.0 as? HTTPError, "Recorded unexpected errors: \(span.recordedErrors)")
+            XCTAssertEqual(error.status, .notFound)
+
+            XCTAssertSpanAttributesEqual(
+                span.attributes,
+                [
+                    "http.method": "GET",
+                    "http.target": "/",
+                    "http.status_code": 404,
+                ]
+            )
         }
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-
-        XCTAssertEqual(span.operationName, "HTTP GET route not found")
-        XCTAssertEqual(span.kind, .server)
-        XCTAssertNil(span.status)
-
-        XCTAssertEqual(span.recordedErrors.count, 1)
-        let error = try XCTUnwrap(span.recordedErrors.first?.0 as? HTTPError, "Recorded unexpected errors: \(span.recordedErrors)")
-        XCTAssertEqual(error.status, .notFound)
-
-        XCTAssertSpanAttributesEqual(
-            span.attributes,
-            [
-                "http.method": "GET",
-                "http.target": "/",
-                "http.status_code": 404,
-            ]
-        )
     }
 
     /// Test span is ended even if the response body with the span end is not run
@@ -423,213 +426,213 @@ final class TracingTests: XCTestCase {
             }
         }
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in
-            expectation.fulfill()
-        }
-        InstrumentationSystem.bootstrapInternal(tracer)
-
-        let router = Router()
-        router.middlewares.add(ErrorMiddleware())
-        router.middlewares.add(TracingMiddleware())
-        router.get("users/:id") { _, _ -> String in
-            "42"
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/users/42", method: .get) { response in
-                XCTAssertEqual(response.status, .badRequest)
+        try await Self.testTracer.withUnique {
+            Self.testTracer.onEndSpan = { _ in
+                expectation.fulfill()
             }
+
+            let router = Router()
+            router.middlewares.add(ErrorMiddleware())
+            router.middlewares.add(TracingMiddleware())
+            router.get("users/:id") { _, _ -> String in
+                "42"
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/users/42", method: .get) { response in
+                    XCTAssertEqual(response.status, .badRequest)
+                }
+            }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+
+            XCTAssertEqual(span.operationName, "/users/{id}")
+            XCTAssertEqual(span.kind, .server)
+            XCTAssertNil(span.status)
+            XCTAssertTrue(span.recordedErrors.isEmpty)
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-
-        XCTAssertEqual(span.operationName, "/users/{id}")
-        XCTAssertEqual(span.kind, .server)
-        XCTAssertNil(span.status)
-        XCTAssertTrue(span.recordedErrors.isEmpty)
     }
 
     // Test span length is the time it takes to write the response
     func testTracingSpanLength() async throws {
-        let expectation = expectation(description: "Expected span to be ended.")
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in
-            expectation.fulfill()
-        }
-        InstrumentationSystem.bootstrapInternal(tracer)
-
-        let router = Router()
-        router.middlewares.add(TracingMiddleware())
-        router.get("users/:id") { _, _ -> Response in
-            Response(
-                status: .ok,
-                body: .init { _ in try await Task.sleep(for: .milliseconds(100)) }
-            )
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/users/42", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
+        try await Self.testTracer.withUnique {
+            let expectation = expectation(description: "Expected span to be ended.")
+            Self.testTracer.onEndSpan = { _ in
+                expectation.fulfill()
             }
+
+            let router = Router()
+            router.middlewares.add(TracingMiddleware())
+            router.get("users/:id") { _, _ -> Response in
+                Response(
+                    status: .ok,
+                    body: .init { _ in try await Task.sleep(for: .milliseconds(100)) }
+                )
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/users/42", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                }
+            }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            let span = try XCTUnwrap(Self.testTracer.spans.first)
+            // Test tracer records span times in milliseconds
+            XCTAssertGreaterThanOrEqual(span.endTime! - span.startTime, 100)
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        let span = try XCTUnwrap(tracer.spans.first)
-        // Test tracer records span times in milliseconds
-        XCTAssertGreaterThanOrEqual(span.endTime! - span.startTime, 100)
     }
 
     /// Test tracing serviceContext is attached to request when route handler is called
     func testServiceContextPropagation() async throws {
-        let expectation = expectation(description: "Expected span to be ended.")
-        expectation.expectedFulfillmentCount = 2
+        try await Self.testTracer.withUnique {
+            let expectation = expectation(description: "Expected span to be ended.")
+            expectation.expectedFulfillmentCount = 2
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let router = Router()
-        router.middlewares.add(TracingMiddleware())
-        router.get("/") { _, _ -> HTTPResponse.Status in
-            var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
-            serviceContext.testID = "test"
-            let span = InstrumentationSystem.tracer.startSpan("testing", context: serviceContext, ofKind: .server)
-            span.end()
-            return .ok
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
+            let router = Router()
+            router.middlewares.add(TracingMiddleware())
+            router.get("/") { _, _ -> HTTPResponse.Status in
+                var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
+                serviceContext.testID = "test"
+                let span = InstrumentationSystem.tracer.startSpan("testing", context: serviceContext, ofKind: .server)
+                span.end()
+                return .ok
             }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                }
+            }
+            await fulfillment(of: [expectation], timeout: 1)
+
+            XCTAssertEqual(Self.testTracer.spans.count, 2)
+            let span = Self.testTracer.spans[0]
+            let span2 = Self.testTracer.spans[1]
+
+            XCTAssertEqual(span2.context.testID, "test")
+            XCTAssertEqual(span2.context.traceID, span.context.traceID)
         }
-        await fulfillment(of: [expectation], timeout: 1)
-
-        XCTAssertEqual(tracer.spans.count, 2)
-        let span = tracer.spans[0]
-        let span2 = tracer.spans[1]
-
-        XCTAssertEqual(span2.context.testID, "test")
-        XCTAssertEqual(span2.context.traceID, span.context.traceID)
     }
 
     /// Verify serviceContext set in trace middleware propagates to routes
     func testServiceContextPropagationWithSpan() async throws {
-        let expectation = expectation(description: "Expected span to be ended.")
-        expectation.expectedFulfillmentCount = 2
+        try await Self.testTracer.withUnique {
+            let expectation = expectation(description: "Expected span to be ended.")
+            expectation.expectedFulfillmentCount = 2
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let router = Router()
-        router.middlewares.add(TracingMiddleware())
-        router.get("/") { _, _ -> HTTPResponse.Status in
-            var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
-            serviceContext.testID = "test"
-            return InstrumentationSystem.tracer.withSpan("TestSpan", context: serviceContext, ofKind: .client) { span in
-                span.attributes["test-attribute"] = 42
-                return .ok
+            let router = Router()
+            router.middlewares.add(TracingMiddleware())
+            router.get("/") { _, _ -> HTTPResponse.Status in
+                var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
+                serviceContext.testID = "test"
+                return InstrumentationSystem.tracer.withSpan("TestSpan", context: serviceContext, ofKind: .client) { span in
+                    span.attributes["test-attribute"] = 42
+                    return .ok
+                }
             }
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                }
             }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            XCTAssertEqual(Self.testTracer.spans.count, 2)
+            let span = Self.testTracer.spans[0]
+            let span2 = Self.testTracer.spans[1]
+
+            XCTAssertEqual(span2.context.testID, "test")
+            XCTAssertEqual(span2.attributes["test-attribute"]?.toSpanAttribute(), 42)
+            XCTAssertEqual(span2.context.traceID, span.context.traceID)
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        XCTAssertEqual(tracer.spans.count, 2)
-        let span = tracer.spans[0]
-        let span2 = tracer.spans[1]
-
-        XCTAssertEqual(span2.context.testID, "test")
-        XCTAssertEqual(span2.attributes["test-attribute"]?.toSpanAttribute(), 42)
-        XCTAssertEqual(span2.context.traceID, span.context.traceID)
     }
 
     /// And SpanMiddleware in front of tracing middleware and set serviceContext value and use
     /// EventLoopFuture version of `request.withSpan` to call next.respond
     func testServiceContextPropagationInMiddleware() async throws {
-        let expectation = expectation(description: "Expected span to be ended.")
-        expectation.expectedFulfillmentCount = 2
+        try await Self.testTracer.withUnique {
+            let expectation = expectation(description: "Expected span to be ended.")
+            expectation.expectedFulfillmentCount = 2
 
-        struct SpanMiddleware<Context: RequestContext>: RouterMiddleware {
-            public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
-                var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
-                serviceContext.testID = "testMiddleware"
+            struct SpanMiddleware<Context: RequestContext>: RouterMiddleware {
+                public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
+                    var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
+                    serviceContext.testID = "testMiddleware"
 
-                return try await InstrumentationSystem.tracer.withSpan("TestSpan", context: serviceContext, ofKind: .server) { _ in
-                    try await next(request, context)
+                    return try await InstrumentationSystem.tracer.withSpan("TestSpan", context: serviceContext, ofKind: .server) { _ in
+                        try await next(request, context)
+                    }
                 }
             }
-        }
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in
-            expectation.fulfill()
-        }
-        InstrumentationSystem.bootstrapInternal(tracer)
-
-        let router = Router()
-        router.middlewares.add(SpanMiddleware())
-        router.middlewares.add(TracingMiddleware())
-        router.get("/") { _, _ -> HTTPResponse.Status in
-            try await Task.sleep(for: .milliseconds(2))
-            return .ok
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
+            Self.testTracer.onEndSpan = { _ in
+                expectation.fulfill()
             }
+
+            let router = Router()
+            router.middlewares.add(SpanMiddleware())
+            router.middlewares.add(TracingMiddleware())
+            router.get("/") { _, _ -> HTTPResponse.Status in
+                try await Task.sleep(for: .milliseconds(2))
+                return .ok
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                }
+            }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            XCTAssertEqual(Self.testTracer.spans.count, 2)
+            let span2 = Self.testTracer.spans[1]
+
+            XCTAssertEqual(span2.context.testID, "testMiddleware")
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        XCTAssertEqual(tracer.spans.count, 2)
-        let span2 = tracer.spans[1]
-
-        XCTAssertEqual(span2.context.testID, "testMiddleware")
     }
 
     /// Test tracing middleware serviceContext is propagated to async route handlers
     func testServiceContextPropagationAsync() async throws {
-        let expectation = expectation(description: "Expected span to be ended.")
-        expectation.expectedFulfillmentCount = 2
+        try await Self.testTracer.withUnique {
+            let expectation = expectation(description: "Expected span to be ended.")
+            expectation.expectedFulfillmentCount = 2
 
-        let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
-        InstrumentationSystem.bootstrapInternal(tracer)
+            Self.testTracer.onEndSpan = { _ in expectation.fulfill() }
 
-        let router = Router()
-        router.middlewares.add(TracingMiddleware())
-        router.get("/") { _, _ -> HTTPResponse.Status in
-            try await Task.sleep(nanoseconds: 1000)
-            return InstrumentationSystem.tracer.withAnySpan("testing", ofKind: .server) { _ in
-                .ok
+            let router = Router()
+            router.middlewares.add(TracingMiddleware())
+            router.get("/") { _, _ -> HTTPResponse.Status in
+                try await Task.sleep(nanoseconds: 1000)
+                return InstrumentationSystem.tracer.withAnySpan("testing", ofKind: .server) { _ in
+                    .ok
+                }
             }
-        }
-        let app = Application(responder: router.buildResponder())
-        try await app.test(.router) { client in
-            try await client.execute(uri: "/", method: .get) { response in
-                XCTAssertEqual(response.status, .ok)
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(uri: "/", method: .get) { response in
+                    XCTAssertEqual(response.status, .ok)
+                }
             }
+
+            await fulfillment(of: [expectation], timeout: 1)
+
+            XCTAssertEqual(Self.testTracer.spans.count, 2)
+            let span = Self.testTracer.spans[0]
+            let span2 = Self.testTracer.spans[1]
+
+            XCTAssertEqual(span2.context.traceID, span.context.traceID)
         }
-
-        await fulfillment(of: [expectation], timeout: 1)
-
-        XCTAssertEqual(tracer.spans.count, 2)
-        let span = tracer.spans[0]
-        let span2 = tracer.spans[1]
-
-        XCTAssertEqual(span2.context.traceID, span.context.traceID)
     }
 }
 


### PR DESCRIPTION
By isolating a tracer or metrics factory for each test we can run them in parallel. This isn't an issue at the moment really, but when we move to Swift Testing it will be so lets just fix it now.