### PR TITLE
Temp fix: wait until the client ends HTTP2 stream

### DIFF
--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -112,7 +112,7 @@ internal struct HTTP2Channel: ServerChildChannel {
                 }
             }
         } catch {
-            logger.error("Error handling inbound connection for HTTP2 handler: \(error)")
+            logger.debug("Error handling inbound connection for HTTP2 handler: \(error)")
         }
     }
 }

--- a/Sources/HummingbirdHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2StreamChannel.swift
@@ -77,9 +77,9 @@ struct HTTP2StreamChannel: ServerChildChannel {
                     )
                     let responseWriter = ResponseWriter(outbound: outbound)
                     try await self.responder(request, responseWriter, asyncChannel.channel)
-                    // Temporary fix: wait until the client send a RST_STREAM (to end inbound). When we
-                    // receive that we can assume that the response has been fully written. Ideally
-                    // this shouldnt be necessary as calling write should guarantee data is written
+                    // Temporary fix: wait until the client ends inbound stream. When inbound ends
+                    // we can assume that the response has been fully written. Ideally this
+                    // shouldnt be necessary as calling write should guarantee data is written
                     // TODO: Remove this once SwiftNIO code is working
                     while try await iterator.next() != nil {}
                 }

--- a/Sources/HummingbirdHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2StreamChannel.swift
@@ -77,6 +77,11 @@ struct HTTP2StreamChannel: ServerChildChannel {
                     )
                     let responseWriter = ResponseWriter(outbound: outbound)
                     try await self.responder(request, responseWriter, asyncChannel.channel)
+                    // Temporary fix: wait until the client send a RST_STREAM (to end inbound). When we
+                    // receive that we can assume that the response has been fully written. Ideally
+                    // this shouldnt be necessary as calling write should guarantee data is written
+                    // TODO: Remove this once SwiftNIO code is working
+                    while try await iterator.next() != nil {}
                 }
             } onCancel: {
                 asyncChannel.channel.close(mode: .input, promise: nil)

--- a/Sources/HummingbirdHTTP2/HTTP2StreamChannel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2StreamChannel.swift
@@ -77,10 +77,9 @@ struct HTTP2StreamChannel: ServerChildChannel {
                     )
                     let responseWriter = ResponseWriter(outbound: outbound)
                     try await self.responder(request, responseWriter, asyncChannel.channel)
-                    // Temporary fix: wait until the client ends inbound stream. When inbound ends
-                    // we can assume that the response has been fully written. Ideally this
-                    // shouldnt be necessary as calling write should guarantee data is written
-                    // TODO: Remove this once SwiftNIO code is working
+                    // Wait until inbound stream is finished. NIO will end the stream once
+                    // it receives the HTTP part `.end`. This shouldnt be necessary as calling
+                    // write should guarantee data is written
                     while try await iterator.next() != nil {}
                 }
             } onCancel: {


### PR DESCRIPTION
Fix for HTTP2 stream writes not getting written. This is a temporary fix until SwiftNIO fix the issue where calls to `NIOAsyncChannelOutboundWriter.write()` don't get flushed before a channel close.

Initially I thought this was relying on the client to end the stream but it looks like the end stream is being handled internally by NIO so we are fine. When HTTP2ChannelHandler receives the `.end` from the response being written out it ends the inbound stream. I've checked this with safari, chrome, Firefox, curl and wget all seem to work.