### PR TITLE
Allow for empty arrays and dictionaries, improve error messages

### DIFF
--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormNode.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormNode.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct URLEncodedFormError: Error {
+/// Error thrown from parsing URLEncoded forms
+public struct URLEncodedFormError: Error, CustomStringConvertible {
     public struct Code: Sendable, Equatable {
         fileprivate enum Internal: Equatable {
             case duplicateKeys
@@ -55,6 +56,20 @@ public struct URLEncodedFormError: Error {
     }
 }
 
+extension URLEncodedFormError {
+    public var description: String {
+        switch self.code.value {
+        case .duplicateKeys: "Found duplicate keys with name '\(self.value)'"
+        case .addingToInvalidType: "Adding array or dictionary value to non array or dictionary value '\(self.value)'"
+        case .failedToPercentDecode: "Failed to percent decode '\(self.value)'"
+        case .corruptKeyValue: "Parsing dictionary key value failed '\(self.value)'"
+        case .notSupported: "URLEncoded form structure not supported '\(self.value)'"
+        case .invalidArrayIndex: "Invalid array index '\(self.value)'"
+        case .unexpectedError:
+            "Unexpected error with '\(self.value)' please add an issue at https://github.com/hummingbird-project/hummingbird/issues"
+        }
+    }
+}
 /// Internal representation of URL encoded form data used by both encode and decode
 enum URLEncodedFormNode: CustomStringConvertible, Equatable {
     /// holds a value
@@ -142,7 +157,7 @@ enum URLEncodedFormNode: CustomStringConvertible, Equatable {
             }
         case (.array(let array), .arrayWithIndices(let index)):
             guard keys.count == 0, array.values.count == index else {
-                throw URLEncodedFormError(code: .invalidArrayIndex, value: key)
+                throw URLEncodedFormError(code: .invalidArrayIndex, value: "\(key)[\(index)]")
             }
             array.values.append(.leaf(value))
         case (_, .arrayWithIndices), (_, .array):


### PR DESCRIPTION
Allow for empty arrays/dictionaries by adding `URLEncodedFormNode.empty`

Improve error reporting. Previously we had an enum which was not public (jeez I hate looking at code I wrote 4 years ago). We now have a public struct error which can be broken up to allow the user to report these back in whatever form they prefer.