### PR TITLE
Add plaintext HTTP2 support

### DIFF
--- a/Sources/HummingbirdHTTP2/HTTP2Channel.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2Channel.swift
@@ -50,7 +50,7 @@ public struct HTTP2ChannelConfiguration: Sendable {
 }
 
 /// Child channel for processing HTTP2
-internal struct HTTP2Channel: ServerChildChannel {
+public struct HTTP2Channel: ServerChildChannel {
     public typealias Configuration = HTTP2ChannelConfiguration
     typealias HTTP2Connection = NIOHTTP2Handler.AsyncStreamMultiplexer<HTTP2StreamChannel.Value>
     public struct Value: ServerChildChannelValue {

--- a/Sources/HummingbirdHTTP2/HTTPServerBuilder+http2.swift
+++ b/Sources/HummingbirdHTTP2/HTTPServerBuilder+http2.swift
@@ -96,4 +96,28 @@ extension HTTPServerBuilder {
             )
         }
     }
+
+    /// Build HTTP channel with HTTP2 upgrade
+    ///
+    /// Use in ``Hummingbird/Application`` initialization.
+    /// ```
+    /// let app = Application(
+    ///     router: router,
+    ///     server: .http2Upgrade(configuration: .init(tlsConfiguration: tlsConfiguration))
+    /// )
+    /// ```
+    /// - Parameters:
+    ///   - tlsChannelConfiguration: TLS channel configuration
+    ///   - configuration: HTTP2 Upgrade channel configuration
+    /// - Returns: HTTPChannelHandler builder
+    public static func plaintextHTTP2(
+        configuration: HTTP2Channel.Configuration = .init()
+    ) -> HTTPServerBuilder {
+        .init { responder in
+            HTTP2Channel(
+                responder: responder,
+                configuration: configuration
+            )
+        }
+    }
 }

--- a/Sources/HummingbirdHTTP2/HTTPServerBuilder+http2.swift
+++ b/Sources/HummingbirdHTTP2/HTTPServerBuilder+http2.swift
@@ -97,18 +97,21 @@ extension HTTPServerBuilder {
         }
     }
 
-    /// Build HTTP channel with HTTP2 upgrade
+    /// Build plaintext HTTP2 channel
+    ///
+    /// As this is running on a connection without TLS it cannot perform the upgrade negotiation via ALPN.
+    /// Therefore a client will need to know in advance it is connecting to an HTTP2 server. You can
+    /// test this with curl as follows: `curl --http2-prior-knowledge http://localhost:8080/`
     ///
     /// Use in ``Hummingbird/Application`` initialization.
     /// ```
     /// let app = Application(
     ///     router: router,
-    ///     server: .http2Upgrade(configuration: .init(tlsConfiguration: tlsConfiguration))
+    ///     server: .plaintextHTTP2()
     /// )
     /// ```
     /// - Parameters:
-    ///   - tlsChannelConfiguration: TLS channel configuration
-    ///   - configuration: HTTP2 Upgrade channel configuration
+    ///   - configuration: HTTP2 channel configuration
     /// - Returns: HTTPChannelHandler builder
     public static func plaintextHTTP2(
         configuration: HTTP2Channel.Configuration = .init()


### PR DESCRIPTION
Inspired by discussion in https://forums.swift.org/t/swiftnio-http2-server-without-tls/79166/

Realised it'd be really easy to add support. Its quite an obscure case, what do you think?