### PR TITLE
Deal with HTTP parser errors

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -15,6 +15,7 @@
 import HummingbirdCore
 import Logging
 import NIOCore
+import NIOHTTP1
 import NIOHTTPTypes
 import NIOPosix
 import ServiceLifecycle
@@ -116,6 +117,10 @@ extension ApplicationProtocol {
             var response: Response
             do {
                 response = try await responder.respond(to: request, context: context)
+            } catch is HTTPParserError {
+                // if we receive an HTTPParserError the `HTTPServerProtocolErrorHandler` will have
+                // already finished the response so don't start sending a response
+                return
             } catch {
                 logger.debug("Unrecognised Error", metadata: ["error.type": "\(error)"])
                 response = Response(

--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -28,6 +28,8 @@ public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
         public var additionalChannelHandlers: @Sendable () -> [any RemovableChannelHandler]
         /// Time before closing an idle channel.
         public var idleTimeout: TimeAmount?
+        /// Internal flag for enabling/disabling pipeline assistance
+        package var pipliningAssistance: Bool = false
 
         ///  Initialize HTTP1Channel.Configuration
         /// - Parameters:
@@ -77,7 +79,7 @@ public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
     public func setup(channel: Channel, logger: Logger) -> EventLoopFuture<Value> {
         channel.eventLoop.makeCompletedFuture {
             try channel.pipeline.syncOperations.configureHTTPServerPipeline(
-                withPipeliningAssistance: false,  // HTTP is pipelined by NIOAsyncChannel
+                withPipeliningAssistance: self.configuration.pipliningAssistance,  // HTTP is pipelined by NIOAsyncChannel
                 withErrorHandling: true,
                 withOutboundHeaderValidation: false  // Swift HTTP Types are already doing this validation
             )

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -24,6 +24,7 @@ import Logging
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
+import NIOHTTPTypes
 import NIOSSL
 import ServiceLifecycle
 import Synchronization
@@ -1172,8 +1173,11 @@ final class ApplicationTests: XCTestCase {
             let b = try await request.body.collect(upTo: .max)
             return Response(status: .ok, body: .init(byteBuffer: b))
         }
+        var httpConfiguration = HTTP1Channel.Configuration()
+        httpConfiguration.pipliningAssistance = true
         let app = Application(
             router: router,
+            server: .http1(configuration: httpConfiguration),
             onServerRunning: { cont.yield($0.localAddress!.port!) }
         )
         do {

--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AsyncHTTPClient
 import Atomics
 import Foundation
 import HTTPTypes
@@ -25,6 +26,7 @@ import NIOCore
 import NIOEmbedded
 import NIOSSL
 import ServiceLifecycle
+import Synchronization
 import XCTest
 
 @testable import Hummingbird
@@ -1158,6 +1160,67 @@ final class ApplicationTests: XCTestCase {
                 XCTAssertEqual(response.status, .ok)
             }
         }
+    }
+
+    @available(macOS 15, *)
+    func testCancelledRequest() async throws {
+        let httpClient = HTTPClient()
+        let (stream, cont) = AsyncStream.makeStream(of: Int.self)
+
+        let router = Router()
+        router.post("/") { request, context in
+            let b = try await request.body.collect(upTo: .max)
+            return Response(status: .ok, body: .init(byteBuffer: b))
+        }
+        let app = Application(
+            router: router,
+            onServerRunning: { cont.yield($0.localAddress!.port!) }
+        )
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                let serviceGroup = ServiceGroup(
+                    configuration: .init(
+                        services: [app],
+                        gracefulShutdownSignals: [.sigterm, .sigint],
+                        logger: Logger(label: "SG")
+                    )
+                )
+
+                group.addTask {
+                    try await serviceGroup.run()
+                }
+
+                let port = await stream.first { _ in true }!
+                let task = Task {
+                    let count = Atomic(0)
+                    let stream = AsyncStream {
+                        let values = count.add(1, ordering: .relaxed)
+                        if values.oldValue < 16 {
+                            try? await Task.sleep(for: .milliseconds(100))
+                            return ByteBuffer(repeating: 0, count: 256)
+                        } else {
+                            return nil
+                        }
+                    }
+                    var request = HTTPClientRequest(url: "http://localhost:\(port)")
+                    request.method = .POST
+                    request.body = .stream(stream, length: .known(Int64(4096)))
+                    let response = try await httpClient.execute(request, deadline: .now() + .minutes(30))
+                    let result = try await response.body.collect(upTo: .max)
+                    print("Result size: \(result.readableBytes)")
+                }
+
+                try await Task.sleep(for: .seconds(1))
+                task.cancel()
+                try await Task.sleep(for: .seconds(1))
+                //                _ = try await group.next()
+                await serviceGroup.triggerGracefulShutdown()
+            }
+        } catch {
+            try await httpClient.shutdown()
+            throw error
+        }
+        try await httpClient.shutdown()
     }
 }
 


### PR DESCRIPTION
The `HTTPServerProtocolErrorHandler` channel handler sends a badRequest response if the HTTP request parser fails eg in the situation where a http request is not finished. Hummingbird didn't know about this and continued to send its own response. If the pipelining channel handler is running it crashes because we have sent two responses for one request.

The solution is for Hummingbird to not send a response if a request handler throws an HTTP parser error (which they will got from parsing the request body).

This was only caught because pipelining was enabled for WebSocket upgrade channels. I thought about re-enabling it to catch other similar errors but for some reason it breaks the inbound closure stuff, so haven't so far. I've added the ability to set this internally so we can use it in tests