### PR TITLE
Close on outbound finish

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.1.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.80.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.83.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.20.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.34.1"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),

--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -91,7 +91,7 @@ public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
             try channel.pipeline.syncOperations.addHandler(HTTPUserEventHandler(logger: logger))
             return try NIOAsyncChannel(
                 wrappingChannelSynchronously: channel,
-                configuration: .init()
+                configuration: .init(isOutboundHalfClosureEnabled: true)
             )
         }
     }


### PR DESCRIPTION
Instead of expecting `executeThenClose` to flush writes (which it should) we add the `isOutboundHalfClosureEnabled` to the NIOAsyncChannel and finish the outbound writer when we are done and wait for the channel to close.

I have also added `testWriteLargeBodyAndClose()` which currently fails, but should start working when https://github.com/apple/swift-nio/pull/3148 makes it into a release.