### PR TITLE
Don't override logLevel when environment variable not found or invalid

### DIFF
--- a/Sources/Hummingbird/Application.swift
+++ b/Sources/Hummingbird/Application.swift
@@ -227,7 +227,9 @@ where Responder.Context: InitializableFromSource<ApplicationRequestContextSource
             self.logger = logger
         } else {
             var logger = Logger(label: configuration.serverName ?? "Hummingbird")
-            logger.logLevel = Environment().get("LOG_LEVEL").map { Logger.Level(rawValue: $0) ?? .info } ?? .info
+            if let logLevel = Environment().get("LOG_LEVEL").flatMap({ Logger.Level(rawValue: $0) }) {
+                logger.logLevel = logLevel
+            }
             self.logger = logger
         }
         self.responder = responder


### PR DESCRIPTION
Fixes #710 