### PR TITLE
SendableMetatype fixups

### DIFF
--- a/Sources/Hummingbird/Router/ResponseGenerator.swift
+++ b/Sources/Hummingbird/Router/ResponseGenerator.swift
@@ -13,14 +13,22 @@
 //===----------------------------------------------------------------------===//
 
 import HTTPTypes
+import HummingbirdCore
 
 /// Object that can generate a `Response`.
 ///
 /// This is used by `Router` to convert handler return values into a `Response`.
+#if compiler(>=6.2)
+public protocol ResponseGenerator: SendableMetatype {
+    /// Generate response based on the request this object came from
+    func response(from request: Request, context: some RequestContext) throws -> Response
+}
+#else
 public protocol ResponseGenerator {
     /// Generate response based on the request this object came from
     func response(from request: Request, context: some RequestContext) throws -> Response
 }
+#endif
 
 /// Extend Response to conform to ResponseGenerator
 extension Response: ResponseGenerator {

--- a/Sources/Hummingbird/Router/ResponseGenerator.swift
+++ b/Sources/Hummingbird/Router/ResponseGenerator.swift
@@ -18,17 +18,11 @@ import HummingbirdCore
 /// Object that can generate a `Response`.
 ///
 /// This is used by `Router` to convert handler return values into a `Response`.
-#if compiler(>=6.2)
-public protocol ResponseGenerator: SendableMetatype {
+@preconcurrency
+public protocol ResponseGenerator: _HB_SendableMetatype {
     /// Generate response based on the request this object came from
     func response(from request: Request, context: some RequestContext) throws -> Response
 }
-#else
-public protocol ResponseGenerator {
-    /// Generate response based on the request this object came from
-    func response(from request: Request, context: some RequestContext) throws -> Response
-}
-#endif
 
 /// Extend Response to conform to ResponseGenerator
 extension Response: ResponseGenerator {

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -13,10 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import HTTPTypes
+import HummingbirdCore
 import NIOCore
 
 /// Conform to `RouterMethods` to add standard router verb (get, post ...) methods
-public protocol RouterMethods<Context> {
+public protocol RouterMethods<Context>: _HB_SendableMetatype {
     associatedtype Context: RequestContext
 
     /// Add responder to call when path and method are matched

--- a/Sources/Hummingbird/Router/RouterMethods.swift
+++ b/Sources/Hummingbird/Router/RouterMethods.swift
@@ -17,6 +17,7 @@ import HummingbirdCore
 import NIOCore
 
 /// Conform to `RouterMethods` to add standard router verb (get, post ...) methods
+@preconcurrency
 public protocol RouterMethods<Context>: _HB_SendableMetatype {
     associatedtype Context: RequestContext
 

--- a/Sources/HummingbirdCore/Request/RequestBody+inboundClose.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody+inboundClose.swift
@@ -109,7 +109,7 @@ extension RequestBody {
         }
     }
 
-    fileprivate func withInboundCloseHandler<Value: Sendable, AsyncIterator: AsyncIteratorProtocol>(
+    fileprivate func withInboundCloseHandler<Value: Sendable, AsyncIterator: _HB_SendableMetatypeAsyncIteratorProtocol>(
         isolation: isolated (any Actor)? = #isolation,
         iterator: AsyncIterator,
         source: RequestBody.Source,

--- a/Sources/HummingbirdCore/Request/RequestBody+inboundClose.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody+inboundClose.swift
@@ -109,7 +109,7 @@ extension RequestBody {
         }
     }
 
-    fileprivate func withInboundCloseHandler<Value: Sendable, AsyncIterator: _HB_SendableMetatypeAsyncIteratorProtocol>(
+    fileprivate func withInboundCloseHandler<Value: Sendable, AsyncIterator: AsyncIteratorProtocol & _HB_SendableMetatype>(
         isolation: isolated (any Actor)? = #isolation,
         iterator: AsyncIterator,
         source: RequestBody.Source,

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -54,7 +54,7 @@ public struct RequestBody: Sendable, AsyncSequence {
     /// - Parameter asyncSequence: AsyncSequence
     @inlinable
     public init<AS: AsyncSequence & Sendable>(asyncSequence: AS)
-    where AS.Element == ByteBuffer, AS.AsyncIterator: _HB_SendableMetatypeAsyncIteratorProtocol {
+    where AS.Element == ByteBuffer, AS.AsyncIterator: _HB_SendableMetatype {
         self.init(.anyAsyncSequence(.init(asyncSequence), nil))
     }
 }

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -52,6 +52,7 @@ public struct RequestBody: Sendable, AsyncSequence {
 
     ///  Initialise ``RequestBody`` from AsyncSequence of ByteBuffers
     /// - Parameter asyncSequence: AsyncSequence
+    @preconcurrency
     @inlinable
     public init<AS: AsyncSequence & Sendable>(asyncSequence: AS)
     where AS.Element == ByteBuffer, AS.AsyncIterator: _HB_SendableMetatype {

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -53,7 +53,8 @@ public struct RequestBody: Sendable, AsyncSequence {
     ///  Initialise ``RequestBody`` from AsyncSequence of ByteBuffers
     /// - Parameter asyncSequence: AsyncSequence
     @inlinable
-    public init<AS: AsyncSequence & Sendable>(asyncSequence: AS) where AS.Element == ByteBuffer {
+    public init<AS: AsyncSequence & Sendable>(asyncSequence: AS)
+    where AS.Element == ByteBuffer, AS.AsyncIterator: _HB_SendableMetatypeAsyncIteratorProtocol {
         self.init(.anyAsyncSequence(.init(asyncSequence), nil))
     }
 }

--- a/Sources/HummingbirdCore/Utils/AnyAsyncSequence.swift
+++ b/Sources/HummingbirdCore/Utils/AnyAsyncSequence.swift
@@ -21,7 +21,7 @@ struct AnyAsyncSequence<Element>: AsyncSequence {
     let makeAsyncIteratorCallback: @Sendable () -> AsyncIteratorNextCallback
 
     @inlinable
-    init<AS: AsyncSequence>(_ base: AS) where AS.Element == Element, AS: Sendable {
+    init<AS: AsyncSequence>(_ base: AS) where AS.Element == Element, AS: Sendable, AS.AsyncIterator: _HB_SendableMetatypeAsyncIteratorProtocol {
         self.makeAsyncIteratorCallback = {
             var iterator = base.makeAsyncIterator()
             return {

--- a/Sources/HummingbirdCore/Utils/AnyAsyncSequence.swift
+++ b/Sources/HummingbirdCore/Utils/AnyAsyncSequence.swift
@@ -21,7 +21,7 @@ struct AnyAsyncSequence<Element>: AsyncSequence {
     let makeAsyncIteratorCallback: @Sendable () -> AsyncIteratorNextCallback
 
     @inlinable
-    init<AS: AsyncSequence>(_ base: AS) where AS.Element == Element, AS: Sendable, AS.AsyncIterator: _HB_SendableMetatypeAsyncIteratorProtocol {
+    init<AS: AsyncSequence>(_ base: AS) where AS.Element == Element, AS: Sendable, AS.AsyncIterator: _HB_SendableMetatype {
         self.makeAsyncIteratorCallback = {
             var iterator = base.makeAsyncIterator()
             return {

--- a/Sources/HummingbirdCore/Utils/SendableMetatype.swift
+++ b/Sources/HummingbirdCore/Utils/SendableMetatype.swift
@@ -15,11 +15,7 @@
 #if compiler(>=6.2)
 @_documentation(visibility: internal)
 public typealias _HB_SendableMetatype = SendableMetatype
-@_documentation(visibility: internal)
-public typealias _HB_SendableMetatypeAsyncIteratorProtocol = AsyncIteratorProtocol & SendableMetatype
 #else
 @_documentation(visibility: internal)
-public protocol _HB_SendableMetatype {}
-@_documentation(visibility: internal)
-public typealias _HB_SendableMetatypeAsyncIteratorProtocol = AsyncIteratorProtocol
+public typealias _HB_SendableMetatype = Any
 #endif

--- a/Sources/HummingbirdCore/Utils/SendableMetatype.swift
+++ b/Sources/HummingbirdCore/Utils/SendableMetatype.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2025 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.2)
+@_documentation(visibility: internal)
+public typealias _HB_SendableMetatype = SendableMetatype
+@_documentation(visibility: internal)
+public typealias _HB_SendableMetatypeAsyncIteratorProtocol = AsyncIteratorProtocol & SendableMetatype
+#else
+@_documentation(visibility: internal)
+public protocol _HB_SendableMetatype {}
+@_documentation(visibility: internal)
+public typealias _HB_SendableMetatypeAsyncIteratorProtocol = AsyncIteratorProtocol
+#endif


### PR DESCRIPTION
Swift 6.2 introduces the protocol `SendableMetatype` for Metatypes that are Sendable. 

Previously all meta types were Sendable but [SE-0470: Global-actor isolated conformances](https://forums.swift.org/t/se-0470-global-actor-isolated-conformances/78704) introduced the concept of isolating conformances. Types that take advantage of this, their metatype cannot be considered Sendable. So `SendableMetatype` was added to enforce Sendability.

Anyway this means certain generic functions require `SendableMetatype` for their generic parameters.