### PR TITLE
Add support for optional arrays and maps to URLEncodedFormDecoder

### DIFF
--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -505,7 +505,7 @@ extension _URLEncodedFormDecoder {
         case .array, .map:
             return false
         case .empty:
-            return true
+            return false
         }
     }
 

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -499,10 +499,14 @@ extension _URLEncodedFormDecoder: SingleValueDecodingContainer {
 
 extension _URLEncodedFormDecoder {
     func unboxNil(_ node: URLEncodedFormNode) throws -> Bool {
-        guard case .leaf(let value) = node else {
-            throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Expect value not array or dictionary"))
+        switch node {
+            case .leaf(let value):
+                return value == nil
+            case .array, .map:
+                return false
+            default:
+                throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Expect value not array or dictionary"))
         }
-        return value == nil
     }
 
     func unbox(_ node: URLEncodedFormNode, as type: Bool.Type) throws -> Bool {

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -504,7 +504,7 @@ extension _URLEncodedFormDecoder {
                 return value == nil
             case .array, .map:
                 return false
-            default:
+            case .empty:
                 throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Expect value not array or dictionary"))
         }
     }

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -505,7 +505,7 @@ extension _URLEncodedFormDecoder {
         case .array, .map:
             return false
         case .empty:
-            throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Expect value not array or dictionary"))
+            return true
         }
     }
 

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -500,12 +500,12 @@ extension _URLEncodedFormDecoder: SingleValueDecodingContainer {
 extension _URLEncodedFormDecoder {
     func unboxNil(_ node: URLEncodedFormNode) throws -> Bool {
         switch node {
-            case .leaf(let value):
-                return value == nil
-            case .array, .map:
-                return false
-            case .empty:
-                throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Expect value not array or dictionary"))
+        case .leaf(let value):
+            return value == nil
+        case .array, .map:
+            return false
+        case .empty:
+            throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Expect value not array or dictionary"))
         }
     }
 

--- a/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
@@ -145,6 +145,18 @@ final class URLDecodedFormDecoderTests: XCTestCase {
         }
     }
 
+    func testOptionalArrays() {
+        struct Test: Codable, Equatable {
+            let arr: [Int]?
+        }
+
+        let test = Test(arr: [1, 2, 3, 4])
+        self.testForm(test, query: "arr[]=1&arr[]=2&arr[]=3&arr[]=4")
+
+        let test2 = Test(arr: nil)
+        self.testForm(test2, query: "")
+    }
+
     func testStringSpecialCharactersDecode() {
         struct Test: Codable, Equatable {
             let a: String
@@ -193,6 +205,18 @@ final class URLDecodedFormDecoderTests: XCTestCase {
         }
         let test = Test(a: ["one": 1, "two": 2, "three": 3])
         self.testForm(test, query: "a[one]=1&a[three]=3&a[two]=2")
+    }
+
+    func testOptionalMaps() {
+        struct Test: Codable, Equatable {
+            let map: [String: Int]?
+        }
+
+        let test = Test(map: ["one": 1, "two": 2, "three": 3])
+        self.testForm(test, query: "map[one]=1&map[two]=2&map[three]=3")
+
+        let test2 = Test(map: nil)
+        self.testForm(test2, query: "")
     }
 
     func testDateDecode() {


### PR DESCRIPTION
Maps and arrays were excluded from unboxNil and it's not clear to me why. This PR handles those cases.