### PR TITLE
Close channel if `HTTP2ServerConnectionManager.StateMachine.streamClosed() returns close

### DIFF
--- a/Sources/Hummingbird/Environment.swift
+++ b/Sources/Hummingbird/Environment.swift
@@ -164,15 +164,15 @@ public struct Environment: Sendable, Decodable, ExpressibleByDictionaryLiteral {
     }
 
     /// Create Environment initialised from the `.env` file
-    public static func dotEnv(_ dovEnvPath: String = ".env") async throws -> Self {
-        guard let dotEnv = await loadDotEnv(dovEnvPath) else { return [:] }
+    public static func dotEnv(_ dotEnvPath: String = ".env") async throws -> Self {
+        guard let dotEnv = await loadDotEnv(dotEnvPath) else { return [:] }
         return try .init(rawValues: self.parseDotEnv(dotEnv))
     }
 
     /// Load `.env` file into string
-    internal static func loadDotEnv(_ dovEnvPath: String = ".env") async -> String? {
+    internal static func loadDotEnv(_ dotEnvPath: String = ".env") async -> String? {
         do {
-            let fileHandle = try NIOFileHandle(path: dovEnvPath)
+            let fileHandle = try NIOFileHandle(path: dotEnvPath)
             defer {
                 try? fileHandle.close()
             }

--- a/Sources/HummingbirdHTTP2/HTTP2ServerConnectionManager.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2ServerConnectionManager.swift
@@ -293,7 +293,8 @@ extension HTTP2ServerConnectionManager {
                 loopBoundHandler.triggerGracefulShutdown()
             }
         case .close:
-            LoopBoundHandler(self).triggerGracefulShutdown()
+            channelHandlerContext?.close(promise: nil)
+
         case .none:
             break
         }


### PR DESCRIPTION
Previously we were triggering a graceful shutdown when receiving a close action from `HTTP2ServerConnectionManager.StateMachine.streamClosed()`. This was incorrect as we are already in graceful shutdown and have sent the second goaway so we should close the connection.

This should fix #721