### PR TITLE
Update TracingMiddleware to follow updated OTel semantic conventions

### DIFF
--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -92,7 +92,7 @@ public struct TracingMiddleware<Context: RequestContext>: RouterMiddleware {
                 span.updateAttributes { attributes in
                     attributes = self.recordHeaders(response.headers, toSpanAttributes: attributes, withPrefix: "http.response.header.")
 
-                    attributes["http.status_code"] = Int(response.status.code)
+                    attributes["http.response.status_code"] = Int(response.status.code)
                     attributes["http.response_content_length"] = response.body.contentLength
                 }
                 let spanWrapper = UnsafeTransfer(SpanWrapper(span))
@@ -106,7 +106,7 @@ public struct TracingMiddleware<Context: RequestContext>: RouterMiddleware {
                 span.operationName = endpointPath
             }
             let statusCode = (error as? HTTPResponseError)?.status.code ?? 500
-            span.attributes["http.status_code"] = statusCode
+            span.attributes["http.response.status_code"] = statusCode
             if 500..<600 ~= statusCode {
                 span.setStatus(.init(code: .error))
             }

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -93,7 +93,7 @@ public struct TracingMiddleware<Context: RequestContext>: RouterMiddleware {
                     attributes = self.recordHeaders(response.headers, toSpanAttributes: attributes, withPrefix: "http.response.header.")
 
                     attributes["http.response.status_code"] = Int(response.status.code)
-                    attributes["http.response_content_length"] = response.body.contentLength
+                    attributes["http.response.body.size"] = response.body.contentLength
                 }
                 let spanWrapper = UnsafeTransfer(SpanWrapper(span))
                 response.body = response.body.withPostWriteClosure {

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -56,7 +56,7 @@ public struct TracingMiddleware<Context: RequestContext>: RouterMiddleware {
             if let staticAttributes = self.attributes {
                 attributes.merge(staticAttributes)
             }
-            attributes["http.method"] = request.method.rawValue
+            attributes["http.request.method"] = request.method.rawValue
             attributes["http.target"] = request.uri.path
             // TODO: Get HTTP version and scheme
             // attributes["http.flavor"] = "\(request.version.major).\(request.version.minor)"

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -60,7 +60,7 @@ public struct TracingMiddleware<Context: RequestContext>: RouterMiddleware {
             attributes["http.target"] = request.uri.path
             // TODO: Get HTTP version and scheme
             // attributes["http.flavor"] = "\(request.version.major).\(request.version.minor)"
-            // attributes["http.scheme"] = request.uri.scheme?.rawValue
+            // attributes["url.scheme"] = request.uri.scheme?.rawValue
             attributes["http.user_agent"] = request.headers[.userAgent]
             attributes["http.request.body.size"] = request.headers[.contentLength].map { Int($0) } ?? nil
 

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -62,7 +62,7 @@ public struct TracingMiddleware<Context: RequestContext>: RouterMiddleware {
             // attributes["http.flavor"] = "\(request.version.major).\(request.version.minor)"
             // attributes["http.scheme"] = request.uri.scheme?.rawValue
             attributes["http.user_agent"] = request.headers[.userAgent]
-            attributes["http.request_content_length"] = request.headers[.contentLength].map { Int($0) } ?? nil
+            attributes["http.request.body.size"] = request.headers[.contentLength].map { Int($0) } ?? nil
 
             if let remoteAddress = (context as? any RemoteAddressRequestContext)?.remoteAddress {
                 attributes["net.sock.peer.port"] = remoteAddress.port

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -62,7 +62,7 @@ public struct TracingMiddleware<Context: RequestContext>: RouterMiddleware {
             // TODO: Get HTTP version and scheme
             // attributes["http.flavor"] = "\(request.version.major).\(request.version.minor)"
             // attributes["url.scheme"] = request.uri.scheme?.rawValue
-            attributes["http.user_agent"] = request.headers[.userAgent]
+            attributes["user_agent.original"] = request.headers[.userAgent]
             attributes["http.request.body.size"] = request.headers[.contentLength].map { Int($0) } ?? nil
 
             if let remoteAddress = (context as? any RemoteAddressRequestContext)?.remoteAddress {

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -38,6 +38,20 @@ public struct TracingMiddleware<Context: RequestContext>: RouterMiddleware {
     /// - Parameters
     ///     - recordingHeaders: A list of HTTP header names to be recorded as span attributes. By default, no headers
     ///         are being recorded.
+    ///     - parameters: A list of static parameters added to every span. These could be the "net.host.name",
+    ///         "net.host.port" or "http.scheme"
+    public init(
+        recordingHeaders headerNamesToRecord: some Collection<HTTPField.Name> = [],
+        attributes: SpanAttributes? = nil
+    ) {
+        self.init(recordingHeaders: headerNamesToRecord, redactingQueryParameters: [], attributes: attributes)
+    }
+
+    /// Intialize a new TracingMiddleware.
+    ///
+    /// - Parameters
+    ///     - recordingHeaders: A list of HTTP header names to be recorded as span attributes. By default, no headers
+    ///         are being recorded.
     ///     - redactingQueryParameters: A set of query parameter keys to redact. By default, all query parameters are
     ///         being recorded without redaction.
     ///     - parameters: A list of static parameters added to every span. These could be the "net.host.name",

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -237,7 +237,7 @@ final class TracingTests: XCTestCase {
                     "http.request.method": "POST",
                     "http.target": "/users",
                     "http.response.status_code": 500,
-                    "http.request_content_length": 2,
+                    "http.request.body.size": 2,
                 ]
             )
         }

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -58,7 +58,7 @@ final class TracingTests: XCTestCase {
             XCTAssertSpanAttributesEqual(
                 span.attributes,
                 [
-                    "http.method": "GET",
+                    "http.request.method": "GET",
                     "http.target": "/users/42",
                     "http.status_code": 200,
                     "http.response_content_length": 2,
@@ -98,7 +98,7 @@ final class TracingTests: XCTestCase {
             XCTAssertSpanAttributesEqual(
                 span.attributes,
                 [
-                    "http.method": "GET",
+                    "http.request.method": "GET",
                     "http.target": "/users/42",
                     "http.status_code": 200,
                     "http.response_content_length": 2,
@@ -144,7 +144,7 @@ final class TracingTests: XCTestCase {
             XCTAssertSpanAttributesEqual(
                 span.attributes,
                 [
-                    "http.method": "GET",
+                    "http.request.method": "GET",
                     "http.target": "/\(filename)",
                     "http.status_code": 200,
                     "http.response_content_length": .int64(Int64(text.count)),
@@ -192,7 +192,7 @@ final class TracingTests: XCTestCase {
             XCTAssertSpanAttributesEqual(
                 span.attributes,
                 [
-                    "http.method": "GET",
+                    "http.request.method": "GET",
                     "http.target": "/test/this",
                     "http.status_code": 200,
                     "http.response_content_length": 0,
@@ -234,7 +234,7 @@ final class TracingTests: XCTestCase {
             XCTAssertSpanAttributesEqual(
                 span.attributes,
                 [
-                    "http.method": "POST",
+                    "http.request.method": "POST",
                     "http.target": "/users",
                     "http.status_code": 500,
                     "http.request_content_length": 2,
@@ -288,7 +288,7 @@ final class TracingTests: XCTestCase {
             XCTAssertSpanAttributesEqual(
                 span.attributes,
                 [
-                    "http.method": "GET",
+                    "http.request.method": "GET",
                     "http.target": "/users/42",
                     "http.status_code": 200,
                     "http.response_content_length": 2,
@@ -331,7 +331,7 @@ final class TracingTests: XCTestCase {
             XCTAssertSpanAttributesEqual(
                 span.attributes,
                 [
-                    "http.method": "POST",
+                    "http.request.method": "POST",
                     "http.target": "/users",
                     "http.status_code": 204,
                     "http.response_content_length": 0,
@@ -370,7 +370,7 @@ final class TracingTests: XCTestCase {
             XCTAssertSpanAttributesEqual(
                 span.attributes,
                 [
-                    "http.method": "GET",
+                    "http.request.method": "GET",
                     "http.target": "/",
                     "http.status_code": 200,
                     "http.response_content_length": 0,
@@ -408,7 +408,7 @@ final class TracingTests: XCTestCase {
             XCTAssertSpanAttributesEqual(
                 span.attributes,
                 [
-                    "http.method": "GET",
+                    "http.request.method": "GET",
                     "http.target": "/",
                     "http.status_code": 404,
                 ]

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -61,7 +61,7 @@ final class TracingTests: XCTestCase {
                     "http.request.method": "GET",
                     "http.target": "/users/42",
                     "http.response.status_code": 200,
-                    "http.response_content_length": 2,
+                    "http.response.body.size": 2,
                     "net.host.name": "127.0.0.1",
                     "net.host.port": 8080,
                 ]
@@ -101,7 +101,7 @@ final class TracingTests: XCTestCase {
                     "http.request.method": "GET",
                     "http.target": "/users/42",
                     "http.response.status_code": 200,
-                    "http.response_content_length": 2,
+                    "http.response.body.size": 2,
                     "net.host.name": "127.0.0.1",
                     "net.host.port": 8080,
                 ]
@@ -147,7 +147,7 @@ final class TracingTests: XCTestCase {
                     "http.request.method": "GET",
                     "http.target": "/\(filename)",
                     "http.response.status_code": 200,
-                    "http.response_content_length": .int64(Int64(text.count)),
+                    "http.response.body.size": .int64(Int64(text.count)),
                     "net.host.name": "127.0.0.1",
                     "net.host.port": 8080,
                 ]
@@ -195,7 +195,7 @@ final class TracingTests: XCTestCase {
                     "http.request.method": "GET",
                     "http.target": "/test/this",
                     "http.response.status_code": 200,
-                    "http.response_content_length": 0,
+                    "http.response.body.size": 0,
                 ]
             )
         }
@@ -291,7 +291,7 @@ final class TracingTests: XCTestCase {
                     "http.request.method": "GET",
                     "http.target": "/users/42",
                     "http.response.status_code": 200,
-                    "http.response_content_length": 2,
+                    "http.response.body.size": 2,
                     "http.request.header.accept": .stringArray(["text/plain", "application/json"]),
                     "http.request.header.cache_control": "no-cache",
                     "http.response.header.content_type": "text/plain",
@@ -334,7 +334,7 @@ final class TracingTests: XCTestCase {
                     "http.request.method": "POST",
                     "http.target": "/users",
                     "http.response.status_code": 204,
-                    "http.response_content_length": 0,
+                    "http.response.body.size": 0,
                 ]
             )
         }
@@ -373,7 +373,7 @@ final class TracingTests: XCTestCase {
                     "http.request.method": "GET",
                     "http.target": "/",
                     "http.response.status_code": 200,
-                    "http.response_content_length": 0,
+                    "http.response.body.size": 0,
                 ]
             )
         }

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -40,7 +40,7 @@ final class TracingTests: XCTestCase {
             }
             let app = Application(responder: router.buildResponder())
             try await app.test(.router) { client in
-                try await client.execute(uri: "/users/42", method: .get) { response in
+                try await client.execute(uri: "/users/42", method: .get, headers: [.userAgent: "42"]) { response in
                     XCTAssertEqual(response.status, .ok)
                     XCTAssertEqual(String(buffer: response.body), "42")
                 }
@@ -65,6 +65,7 @@ final class TracingTests: XCTestCase {
                     "http.response.body.size": 2,
                     "net.host.name": "127.0.0.1",
                     "net.host.port": 8080,
+                    "user_agent.original": "42",
                 ]
             )
         }

--- a/Tests/HummingbirdTests/TracingTests.swift
+++ b/Tests/HummingbirdTests/TracingTests.swift
@@ -60,7 +60,7 @@ final class TracingTests: XCTestCase {
                 [
                     "http.request.method": "GET",
                     "http.target": "/users/42",
-                    "http.status_code": 200,
+                    "http.response.status_code": 200,
                     "http.response_content_length": 2,
                     "net.host.name": "127.0.0.1",
                     "net.host.port": 8080,
@@ -100,7 +100,7 @@ final class TracingTests: XCTestCase {
                 [
                     "http.request.method": "GET",
                     "http.target": "/users/42",
-                    "http.status_code": 200,
+                    "http.response.status_code": 200,
                     "http.response_content_length": 2,
                     "net.host.name": "127.0.0.1",
                     "net.host.port": 8080,
@@ -146,7 +146,7 @@ final class TracingTests: XCTestCase {
                 [
                     "http.request.method": "GET",
                     "http.target": "/\(filename)",
-                    "http.status_code": 200,
+                    "http.response.status_code": 200,
                     "http.response_content_length": .int64(Int64(text.count)),
                     "net.host.name": "127.0.0.1",
                     "net.host.port": 8080,
@@ -194,7 +194,7 @@ final class TracingTests: XCTestCase {
                 [
                     "http.request.method": "GET",
                     "http.target": "/test/this",
-                    "http.status_code": 200,
+                    "http.response.status_code": 200,
                     "http.response_content_length": 0,
                 ]
             )
@@ -236,7 +236,7 @@ final class TracingTests: XCTestCase {
                 [
                     "http.request.method": "POST",
                     "http.target": "/users",
-                    "http.status_code": 500,
+                    "http.response.status_code": 500,
                     "http.request_content_length": 2,
                 ]
             )
@@ -290,7 +290,7 @@ final class TracingTests: XCTestCase {
                 [
                     "http.request.method": "GET",
                     "http.target": "/users/42",
-                    "http.status_code": 200,
+                    "http.response.status_code": 200,
                     "http.response_content_length": 2,
                     "http.request.header.accept": .stringArray(["text/plain", "application/json"]),
                     "http.request.header.cache_control": "no-cache",
@@ -333,7 +333,7 @@ final class TracingTests: XCTestCase {
                 [
                     "http.request.method": "POST",
                     "http.target": "/users",
-                    "http.status_code": 204,
+                    "http.response.status_code": 204,
                     "http.response_content_length": 0,
                 ]
             )
@@ -372,7 +372,7 @@ final class TracingTests: XCTestCase {
                 [
                     "http.request.method": "GET",
                     "http.target": "/",
-                    "http.status_code": 200,
+                    "http.response.status_code": 200,
                     "http.response_content_length": 0,
                 ]
             )
@@ -410,7 +410,7 @@ final class TracingTests: XCTestCase {
                 [
                     "http.request.method": "GET",
                     "http.target": "/",
-                    "http.status_code": 404,
+                    "http.response.status_code": 404,
                 ]
             )
         }


### PR DESCRIPTION
## Motivation

The current `TracingMiddleware` implementation is based on the OpenTelemetry semantic conventions for HTTP server spans. Since its creation the semantic conventions have changed so it'd be great to once again be up-to-date to make sure observability backends can visualize server spans created by `TracingMiddleware` as best as possible.

See Also: [OTel SemConv: HTTP Server spans](https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/http/http-spans.md#http-server)

## Modifications

- Rename `http.method` attribute to `http.request.method`
- Rename `http.status_code` attribute to `http.response.status`
- Rename `http.request_content_length` attribute to `http.request.body.size`
- Rename `http.response_content_length` attribute to `http.response.body.size`
- Rename commented out `http.scheme` attribute to `url.scheme`
- Replace `http.target` attribute with `url.path` and `url.query`
- Add `http.route` attribute
- Rename `http.user_agent` attribute to `user_agent.original`

## Result

Spans produced by `TracingMiddleware` are following the latest (stable) HTTP server span semantic conventions.