### PR TITLE
doc(readme): Fix swift package add-target-dependency using

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Or run the following commands on your package using SwiftPM, replacing `MyApp` w
 
 ```swift
 swift package add-dependency https://github.com/hummingbird-project/hummingbird.git --from 2.0.0
-swift package add-target-dependency Hummingbird MyApp
+swift package add-target-dependency Hummingbird MyApp --package hummingbird
 ```
 
 ## Contributing


### PR DESCRIPTION

### Problem

From the installation part of readme:
```sh
swift package add-target-dependency Hummingbird MyApp
```
This version adds Hummingbird to MyApp target as local target dependency:
```swift
.target(name: "Hummingbird"),
```
Which is wrong for common using of library
<img width="706" height="301" alt="Screenshot 2025-09-18 at 12 54 00" src="https://github.com/user-attachments/assets/fa4c4a2b-c056-43f1-9db6-c33644d6760b" />
<img width="866" height="374" alt="Screenshot 2025-09-18 at 12 53 20" src="https://github.com/user-attachments/assets/d4aa61e7-47f0-4cc0-9e92-4726444943f8" />

<img width="1453" height="145" alt="Screenshot 2025-09-18 at 12 54 12" src="https://github.com/user-attachments/assets/32b8a0d3-84a4-4997-baa8-281e6921799b" />

### Solution

To fix that additionally to existing command we need to specify `--package hummingbird`, which will generate what we expect:
```swift
.product(name: "Hummingbird", package: "hummingbird"),
```
<img width="867" height="414" alt="image" src="https://github.com/user-attachments/assets/0ff9c9b7-c4da-48f4-b52c-2762fff26b30" />
