### PR TITLE
Change `CI` environment variable check in Package.swift to `HUMMINGBIRD_CI`

### DIFF
--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -1,13 +1,13 @@
 name: API breaking changes
 
-env:
-  HUMMINGBIRD_CI: 1
-
 on:
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-apibreakage
   cancel-in-progress: true
+
+env:
+  HB_ENABLE_ALL_TRAITS: true
 
 jobs:
   linux:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,5 @@
 name: Benchmark PR vs main
 
-env:
-  HUMMINGBIRD_CI: 1
-
 on:
   workflow_dispatch:
   pull_request:
@@ -16,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-benchmark
   cancel-in-progress: true
     
+env:
+  HB_ENABLE_ALL_TRAITS: "true"
+
 jobs:
   benchmark-delta:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-env:
-  HUMMINGBIRD_CI: 1
-
 on:
   push:
     branches:
@@ -15,6 +12,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-ci
   cancel-in-progress: true
+
+env:
+  HB_ENABLE_ALL_TRAITS: true
 
 jobs:
   linux:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,10 +1,10 @@
 name: Swift nightly build
 
-env:
-  HUMMINGBIRD_CI: 1
-
 on:
   workflow_dispatch:
+
+env:
+  HB_ENABLE_ALL_TRAITS: true
 
 jobs:
   linux:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,8 +1,5 @@
 name: Validity Check
 
-env:
-  HUMMINGBIRD_CI: 1
-
 on:
   pull_request:
 concurrency:

--- a/.github/workflows/verify-documentation.yml
+++ b/.github/workflows/verify-documentation.yml
@@ -1,14 +1,14 @@
 name: Verify Documentation
 
-env:
-  HUMMINGBIRD_CI: 1
-
 on:
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-verifydocs
   cancel-in-progress: true
   
+env:
+  HB_ENABLE_ALL_TRAITS: true
+
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/Package.swift
+++ b/Package.swift
@@ -17,9 +17,7 @@ let swiftSettings: [SwiftSetting] = [
 ]
 
 // Should we enable all traits.
-let enableAllTraitsExplicitly = ProcessInfo.processInfo.environment["ENABLE_ALL_TRAITS"] != nil
-let enableAllTraitsInCI = ProcessInfo.processInfo.environment["HUMMINGBIRD_CI"] != nil
-let enableAllTraits = enableAllTraitsExplicitly || enableAllTraitsInCI
+let enableAllTraits = ProcessInfo.processInfo.environment["HB_ENABLE_ALL_TRAITS"] != nil
 // Construct trait set
 var traits: Set<Trait> = [
     .trait(name: "ConfigurationSupport")


### PR DESCRIPTION
This PR updates Package.swift to change its CI detection from the generic `CI` environment variable to a new Hummingbird-specific `HUMMINGBIRD_CI`:

```diff
-let enableAllTraitsInCI = ProcessInfo.processInfo.environment["CI"] != nil
+let enableAllTraitsInCI = ProcessInfo.processInfo.environment["HUMMINGBIRD_CI"] != nil
```

And it adds the `HUMMINGBIRD_CI` environment variable declaration to all of the existing GitHub workflows.

This means that all traits should hopefully be enabled just for this repo's workflows, and not for everyone's CI workflows. This was causing issues for me when `-disableAutomaticPackageResolution` is passed to `xcodebuild` – the trait is not enabled on my local machine so `swift-configuration` is missing from my `Package.resolved`, but the trait IS enabled on Xcode Cloud because it too sets the `CI` environment variable, causing my jobs to fail.

This PR has been tested on my fork and I can see the `ConfigReaderTests` suite was [run successfully on Swift 6.2](https://github.com/bok-/hummingbird/actions/runs/20267291277/job/58193638654):

```
◇ Suite ConfigReaderTests started.
◇ Suite ConfigReaderTests started.
✔ Suite ConfigReaderTests passed after 1.763 seconds.
✔ Suite ConfigReaderTests passed after 1.780 seconds.
```

As both implementations of `ConfigReaderTests` are behind `#if ConfigurationSupport` conditional compilation expressions I assume that means the `enableAllTraitsInCI` variable is working correctly.