### PR TITLE
Fix compile errors in HummingbirdTests

### DIFF
--- a/Tests/HummingbirdTests/ApplicationTests.swift
+++ b/Tests/HummingbirdTests/ApplicationTests.swift
@@ -1242,7 +1242,7 @@ struct ApplicationTests {
                     }
                     var request = HTTPClientRequest(url: "http://localhost:\(port)")
                     request.method = .POST
-                    request.body = .stream(stream, length: .known(Int64(4096)))
+                    request.body = .stream(stream, length: .known(4096))
                     let response = try await httpClient.execute(request, deadline: .now() + .minutes(30))
                     let result = try await response.body.collect(upTo: .max)
                     print("Result size: \(result.readableBytes)")

--- a/Tests/HummingbirdTests/TestTracer.swift
+++ b/Tests/HummingbirdTests/TestTracer.swift
@@ -222,10 +222,6 @@ final class TaskUniqueTestTracer: Tracer {
         )
     }
 
-    func activeSpan(identifiedBy context: ServiceContextModule.ServiceContext) -> Span? {
-        TaskUniqueTestTracer.current.activeSpan(identifiedBy: context)
-    }
-
     func forceFlush() {
         TaskUniqueTestTracer.current.forceFlush()
     }


### PR DESCRIPTION
Compilation of `HummingbirdTests` is failing with the following error:

```
/hummingbird/Tests/HummingbirdTests/ApplicationTests.swift:1245:67: error: cannot convert value of type 'Int64' to expected argument type 'Int'
1243 |                     var request = HTTPClientRequest(url: "http://localhost:\(port)")
1244 |                     request.method = .POST
1245 |                     request.body = .stream(stream, length: .known(Int64(4096)))
     |                                                                   `- error: cannot convert value of type 'Int64' to expected argument type 'Int'
1246 |                     let response = try await httpClient.execute(request, deadline: .now() + .minutes(30))
1247 |                     let result = try await response.body.collect(upTo: .max)
/hummingbird/Tests/HummingbirdTests/TestTracer.swift:226:38: error: value of type 'TestTracer' has no member 'activeSpan'
224 | 
225 |     func activeSpan(identifiedBy context: ServiceContextModule.ServiceContext) -> Span? {
226 |         TaskUniqueTestTracer.current.activeSpan(identifiedBy: context)
    |                                      `- error: value of type 'TestTracer' has no member 'activeSpan'
227 |     }
228 | 
[5/6] Emitting module HummingbirdTests
error: fatalError
```

The tests should be running in CI, but it's unclear why this specific error is being overlooked.
Reproduced on macOS and Linux (Swift 6.2, 6.0).
