### PR TITLE
Use Swift String manipulation API

### DIFF
--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormNode.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormNode.swift
@@ -106,7 +106,7 @@ enum URLEncodedFormNode: CustomStringConvertible, Equatable {
             if let equals = element.firstIndex(of: "=") {
                 let before = element[..<equals].removingURLPercentEncoding()
                 let afterEquals = element.index(after: equals)
-                let after = String(element[afterEquals...].replacing("+", with: " "))
+                let after = element[afterEquals...].replacing("+", with: " ")
                 guard let key = before else { throw URLEncodedFormError(code: .failedToPercentDecode, value: element[..<equals]) }
 
                 guard let keys = KeyParser.parse(key) else { throw URLEncodedFormError(code: .corruptKeyValue, value: key) }
@@ -209,7 +209,7 @@ enum URLEncodedFormNode: CustomStringConvertible, Equatable {
             self.value = String(describing: value)
         }
 
-        init?(percentEncoded value: String) {
+        init?(percentEncoded value: some StringProtocol) {
             guard let value = value.removingURLPercentEncoding() else { return nil }
             self.value = value
         }

--- a/Sources/Hummingbird/Middleware/TracingMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/TracingMiddleware.swift
@@ -208,7 +208,7 @@ struct RecordingHeader: Hashable {
 
     init(name: HTTPField.Name) {
         self.name = name
-        self.attributeName = String(name.canonicalName.replacing("-", with: "_"))
+        self.attributeName = name.canonicalName.replacing("-", with: "_")
     }
 }
 


### PR DESCRIPTION
The current method is [not unicode safe](https://www.hackingwithswift.com/articles/280/one-swift-mistake-everyone-should-stop-making-today), haven't tested performance.

As far as I can tell we'll just need to add a new trait to conditionally exclude DateFormatter support in URLEncodedFormDecoder/Encoder after this to be fully FoundationInternationalization free. (Besides dependencies, for example swift-configuration's default traits depend on Foundation)