### PR TITLE
Fix bug with metrics/tracing middleware and HEAD responses

### DIFF
--- a/Sources/HummingbirdCore/Response/Response.swift
+++ b/Sources/HummingbirdCore/Response/Response.swift
@@ -23,13 +23,17 @@ public struct Response: Sendable {
             self.headers = newValue.headerFields
         }
     }
-
+    @usableFromInline
+    /*private*/ var _body: ResponseBody
     /// Response body
+    @inlinable
     public var body: ResponseBody {
-        didSet {
-            if let contentLength = body.contentLength {
+        get { _body }
+        set {
+            if let contentLength = newValue.contentLength, self.body.contentLength != newValue.contentLength {
                 self.headers[.contentLength] = String(describing: contentLength)
             }
+            self._body = newValue
         }
     }
 
@@ -38,7 +42,7 @@ public struct Response: Sendable {
     public init(status: HTTPResponse.Status, headers: HTTPFields = .init(), body: ResponseBody = .init()) {
         self.status = status
         self.headers = headers
-        self.body = body
+        self._body = body
         if let contentLength = body.contentLength, !self.headers.contains(.contentLength) {
             self.headers[.contentLength] = String(describing: contentLength)
         }


### PR DESCRIPTION
Previously when you set the body on a response if that body had a known length it would always fix the content-length header in a didSet call. The metrics and tracing middleware do this for every response so they can alter the response body writer to update timers and spans. This breaks responses from HEAD requests as the body is set on them and it resets the content-length.

This fix changes the didSet to a set and compares the old response body with the new one. If they have the same size then we don't update the content-length header. 
- If you have a response from a head request you can only set the response body to be a body with length zero, so the response body length will not change as it is passed down and any content-length header with be fixed.
- All other responses the content-length header should be consistent with the response body length so will be changed at the relevant times.

This PR also fixes an issue where if you had a response with a content-length header and you later set the response body to be of an indeterminate length (perhaps you passed the response through a streaming compression middleware) it should clear the content-length header but it wasn't
