### PR TITLE
Clear content-length if response body has indeterminate length

### DIFF
--- a/Sources/HummingbirdCore/Response/Response.swift
+++ b/Sources/HummingbirdCore/Response/Response.swift
@@ -30,8 +30,12 @@ public struct Response: Sendable {
     public var body: ResponseBody {
         get { _body }
         set {
-            if let contentLength = newValue.contentLength, self.body.contentLength != newValue.contentLength {
-                self.headers[.contentLength] = String(describing: contentLength)
+            if self.body.contentLength != newValue.contentLength {
+                if let contentLength = newValue.contentLength {
+                    self.headers[.contentLength] = String(describing: contentLength)
+                } else {
+                    self.headers[.contentLength] = nil
+                }
             }
             self._body = newValue
         }


### PR DESCRIPTION
Missed the second fix when setting a response body. If previously the response had a content-length header and the new response body is of indeterminate length we should clear the content-length header