### PR TITLE
Add 6.3 nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        image: ["swift:6.0", "swift:6.1", "swift:6.2"]
+        image: ["swift:6.0", "swift:6.1", "swift:6.2", "swiftlang/swift:nightly-6.3-noble"]
     container:
       image: ${{ matrix.image }}
     env:

--- a/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
+++ b/Sources/Hummingbird/Storage/MemoryPersistDriver.swift
@@ -36,14 +36,22 @@ public actor MemoryPersistDriver<C: Clock>: PersistDriver where C.Duration == Du
 
     /// Initialize MemoryPersistDriver
     /// - Parameters:
+    ///   - configuration: Configuration of driver
+    public init(configuration: Configuration = .init()) where C == ContinuousClock {
+        self.values = [:]
+        self.clock = .continuous
+        self.configuration = configuration
+    }
+
+    /// Initialize MemoryPersistDriver
+    /// - Parameters:
     ///   - clock: Clock to use when calculating expiration dates
     ///   - configuration: Configuration of driver
-    public init(_ clock: C = .continuous, configuration: Configuration = .init()) {
+    public init(_ clock: C, configuration: Configuration = .init()) {
         self.values = [:]
         self.clock = clock
         self.configuration = configuration
     }
-
     public func create(key: String, value: some Codable & Sendable, expires: Duration?) async throws {
         guard self.values[key] == nil else { throw PersistError.duplicate }
         self.values[key] = .init(value: value, expires: expires.map { self.clock.now.advanced(by: $0) })


### PR DESCRIPTION
Fix new warning


`Cannot use default expression for inference of 'C' because it is inferrable from parameters #0, #1; this will be an error in a future Swift language mode`
