### PR TITLE
import DequeModule in RequestBody.swift

### DIFF
--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Collections
+internal import DequeModule
 public import NIOConcurrencyHelpers
 public import NIOCore
 package import NIOHTTPTypes


### PR DESCRIPTION
swift-collections 1.4.0 enabled MemberImportVisibility and now we are required to import DequeModule instead of Collections 