### PR TITLE
Add ServerErrorHandler to catch errors when creating child channel

### DIFF
--- a/Sources/HummingbirdCore/Server/Server.swift
+++ b/Sources/HummingbirdCore/Server/Server.swift
@@ -220,6 +220,9 @@ public actor Server<ChildChannel: ServerChildChannel>: Service {
         let quiescingHelper = ServerQuiescingHelper(group: self.eventLoopGroup)
         bootstrap = bootstrap.serverChannelInitializer { channel in
             channel.eventLoop.makeCompletedFuture {
+                #if os(macOS)
+                try channel.pipeline.syncOperations.addHandler(ServerErrorHandler(logger: self.logger))
+                #endif
                 if let availableConnectionsDelegate = configuration.availableConnectionsDelegate {
                     let handler = availableConnectionsDelegate.availableConnectionsChannelHandler
                     try channel.pipeline.syncOperations.addHandler(handler)

--- a/Sources/HummingbirdCore/Server/ServerErrorHandler.swift
+++ b/Sources/HummingbirdCore/Server/ServerErrorHandler.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Logging
+import NIOCore
+import NIOPosix
+
+final class ServerErrorHandler: ChannelInboundHandler {
+    typealias InboundIn = NIOAny
+    typealias InboundOut = NIOAny
+
+    let logger: Logger
+
+    init(logger: Logger) {
+        self.logger = logger
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: any Error) {
+        switch error {
+        case is NIOFcntlFailedError:
+            // On macOS, this error can be caused by a race condition when a connection is created and closed
+            // in quick succession. We don't want to propagate this error as it will shutdown the server.
+            logger.debug("Server channel error", metadata: ["error": "\(error)"])
+        default:
+            logger.error("Server channel error", metadata: ["error": "\(error)"])
+            context.fireErrorCaught(error)
+        }
+    }
+}


### PR DESCRIPTION
See #812 and https://github.com/apple/swift-nio/issues/3576