### PR TITLE
set Dependabot cooldown 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "codecov/codecov-action"
         update-types: ["version-update:semver-major"]
@@ -15,6 +17,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     allow:
       - dependency-type: all


### PR DESCRIPTION
## Summary

- Add a 7-day Dependabot cooldown for dependency update pull requests.
- Apply the cooldown to both GitHub Actions and Swift dependency updates.
- Delay automated updates to reduce exposure to newly released malicious packages and give the ecosystem time to detect potential supply chain attacks.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-