### PR TITLE
Security middleware

### DIFF
--- a/Sources/Hummingbird/Middleware/ContentSecurityMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/ContentSecurityMiddleware.swift
@@ -8,37 +8,12 @@
 
 import HTTPTypes
 
-/// Middleware for setting up various security related response headers
+/// Middleware for setting up content-security-policy related response headers
 ///
-/// Currently sets headers `content-security-policy`, `cross-origin-resource-policy`, `x-content-type-options`
+/// Currently sets headers `content-security-policy`, `x-content-type-options`
 /// and optionally sets `content-security-policy-report-only` and `reporting-endpoints`.
-public struct SecurityMiddleware<Context: RequestContext>: RouterMiddleware {
+public struct ContentSecurityMiddleware<Context: RequestContext>: RouterMiddleware {
     let headers: HTTPFields
-
-    /// Let websites and applications opt-in to protection against vulnerabilities related to certain
-    /// cross-origin requests. As the policy is expressed by a response header it relies on the browser
-    /// to strip the response body
-    public struct CrossOriginResourcePolicy: Sendable {
-        @usableFromInline
-        enum Internal: String, Sendable {
-            case sameOrigin = "same-origin"
-            case sameSite = "same-site"
-            case crossOrigin = "cross-origin"
-        }
-        @usableFromInline
-        let value: Internal
-        @usableFromInline
-        init(value: Internal) {
-            self.value = value
-        }
-
-        /// Limits resource access to requests coming from the same origin.
-        @inlinable public static var sameOrigin: Self { .init(value: .sameOrigin) }
-        /// Limits resource access to requests coming from the same site.
-        @inlinable public static var sameSite: Self { .init(value: .sameSite) }
-        /// Allows resources to be accessed by cross-origin requests.
-        @inlinable public static var crossOrigin: Self { .init(value: .crossOrigin) }
-    }
 
     /// Initialize the SecurityMiddleware
     ///
@@ -56,11 +31,9 @@ public struct SecurityMiddleware<Context: RequestContext>: RouterMiddleware {
             .frameAncestors(.self),
         ],
         contentSecurityPolicyReportOnly: ContentSecurityPolicy? = nil,
-        crossOriginResourcePolicy: CrossOriginResourcePolicy = .sameSite,
         reportingEndpoints: [String: String]? = nil
     ) {
         var headers: HTTPFields = [
-            .crossOriginResourcePolicy: crossOriginResourcePolicy.value.rawValue,
             .contentSecurityPolicy: contentSecurityPolicy.description,
             .xContentTypeOptions: "nosniff",
         ]

--- a/Sources/Hummingbird/Middleware/ContentSecurityMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/ContentSecurityMiddleware.swift
@@ -20,8 +20,6 @@ public struct ContentSecurityMiddleware<Context: RequestContext>: RouterMiddlewa
     /// - Parameters:
     ///   - contentSecurityPolicy: Set `content-security-policy` header. Defines access to resources, from served HTML pages.
     ///   - contentSecurityPolicyReportOnly: Set `content-security-policy-report-only` header. Reports access to resources, from served HTML pages.
-    ///   - crossOriginResourcePolicy: Set `cross-origin-resource-policy` header. Defines whether browser should block no-cors cross-origin or
-    ///         cross-site requests to the given resource.
     ///   - reportingEndpoints: Set `reporting-endpoints` header. If you are using content security policy directive `report-to` you
     ///         can use this to define your reporting endpoints.
     public init(

--- a/Sources/Hummingbird/Middleware/SecurityMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/SecurityMiddleware.swift
@@ -11,7 +11,7 @@ import HTTPTypes
 /// Middleware for setting up various security related response headers
 ///
 /// Currently sets headers `content-security-policy`, `cross-origin-resource-policy`, `x-content-type-options`
-/// and optionally sets `reporting-endpoints`.
+/// and optionally sets `content-security-policy-report-only` and `reporting-endpoints`.
 public struct SecurityMiddleware<Context: RequestContext>: RouterMiddleware {
     let headers: HTTPFields
 
@@ -43,8 +43,10 @@ public struct SecurityMiddleware<Context: RequestContext>: RouterMiddleware {
     /// Initialize the SecurityMiddleware
     ///
     /// - Parameters:
-    ///   - contentSecurityPolicy: Set `content-security-policy` header. Defines access to website resources.
-    ///   - crossOriginResourcePolicy: Set `cross-origin-resource-policy` header. Defines whether browser should drop body.
+    ///   - contentSecurityPolicy: Set `content-security-policy` header. Defines access to resources, from served HTML pages.
+    ///   - contentSecurityPolicyReportOnly: Set `content-security-policy-report-only` header. Reports access to resources, from served HTML pages.
+    ///   - crossOriginResourcePolicy: Set `cross-origin-resource-policy` header. Defines whether browser should block no-cors cross-origin or
+    ///         cross-site requests to the given resource.
     ///   - reportingEndpoints: Set `reporting-endpoints` header. If you are using content security policy directive `report-to` you
     ///         can use this to define your reporting endpoints.
     public init(
@@ -53,6 +55,7 @@ public struct SecurityMiddleware<Context: RequestContext>: RouterMiddleware {
             .formAction(.self),
             .frameAncestors(.self),
         ],
+        contentSecurityPolicyReportOnly: ContentSecurityPolicy? = nil,
         crossOriginResourcePolicy: CrossOriginResourcePolicy = .sameSite,
         reportingEndpoints: [String: String]? = nil
     ) {
@@ -61,6 +64,9 @@ public struct SecurityMiddleware<Context: RequestContext>: RouterMiddleware {
             .contentSecurityPolicy: contentSecurityPolicy.description,
             .xContentTypeOptions: "nosniff",
         ]
+        if let contentSecurityPolicyReportOnly {
+            headers[.contentSecurityPolicyReportOnly] = contentSecurityPolicyReportOnly.description
+        }
         if let reportingEndpoints {
             headers[HTTPField.Name("Reporting-Endpoints")!] = reportingEndpoints.map { "\($0.key)=\"\($0.value)\"" }.joined(separator: ",")
         }

--- a/Sources/Hummingbird/Middleware/SecurityMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/SecurityMiddleware.swift
@@ -1,0 +1,75 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import HTTPTypes
+
+/// Middleware for setting up various security related response headers
+///
+/// Currently sets headers `content-security-policy`, `cross-origin-resource-policy`, `x-content-type-options`
+/// and optionally sets `reporting-endpoints`.
+public struct SecurityMiddleware<Context: RequestContext>: RouterMiddleware {
+    let headers: HTTPFields
+
+    /// Let websites and applications opt-in to protection against vulnerabilities related to certain
+    /// cross-origin requests. As the policy is expressed by a response header it relies on the browser
+    /// to strip the response body
+    public struct CrossOriginResourcePolicy: Sendable {
+        @usableFromInline
+        enum Internal: String, Sendable {
+            case sameOrigin = "same-origin"
+            case sameSite = "same-site"
+            case crossOrigin = "cross-origin"
+        }
+        @usableFromInline
+        let value: Internal
+        @usableFromInline
+        init(value: Internal) {
+            self.value = value
+        }
+
+        /// Limits resource access to requests coming from the same origin.
+        @inlinable public static var sameOrigin: Self { .init(value: .sameOrigin) }
+        /// Limits resource access to requests coming from the same site.
+        @inlinable public static var sameSite: Self { .init(value: .sameSite) }
+        /// Allows resources to be accessed by cross-origin requests.
+        @inlinable public static var crossOrigin: Self { .init(value: .crossOrigin) }
+    }
+
+    /// Initialize the SecurityMiddleware
+    ///
+    /// - Parameters:
+    ///   - contentSecurityPolicy: Set `content-security-policy` header. Defines access to website resources.
+    ///   - crossOriginResourcePolicy: Set `cross-origin-resource-policy` header. Defines whether browser should drop body.
+    ///   - reportingEndpoints: Set `reporting-endpoints` header. If you are using content security policy directive `report-to` you
+    ///         can use this to define your reporting endpoints.
+    public init(
+        contentSecurityPolicy: ContentSecurityPolicy = [
+            .defaultSrc(.self),
+            .formAction(.self),
+            .frameAncestors(.self),
+        ],
+        crossOriginResourcePolicy: CrossOriginResourcePolicy = .sameSite,
+        reportingEndpoints: [String: String]? = nil
+    ) {
+        var headers: HTTPFields = [
+            .crossOriginResourcePolicy: crossOriginResourcePolicy.value.rawValue,
+            .contentSecurityPolicy: contentSecurityPolicy.description,
+            .xContentTypeOptions: "nosniff",
+        ]
+        if let reportingEndpoints {
+            headers[HTTPField.Name("Reporting-Endpoints")!] = reportingEndpoints.map { "\($0.key)=\"\($0.value)\"" }.joined(separator: ",")
+        }
+        self.headers = headers
+    }
+
+    public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
+        var response = try await next(request, context)
+        response.headers.append(contentsOf: headers)
+        return response
+    }
+}

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import HTTPTypes
 import HummingbirdTesting
 import Logging
 import NIOConcurrencyHelpers
@@ -469,6 +470,54 @@ struct MiddlewareTests {
                 let logs = logAccumalator.filter { $0.metadata?["hb.request.path"]?.description == "/test" }
                 let firstLog = try #require(logs.first)
                 #expect(firstLog.metadata?["hb.request.headers"] == .stringConvertible(["hbtest": "One, Two"]))
+            }
+        }
+    }
+
+    @Test func testSecurityMiddlewareDefaults() async throws {
+        let router = Router()
+        router.add(middleware: SecurityMiddleware())
+        router.get("/") { _, _ in
+            HTTPResponse.Status.ok
+        }
+        let app = Application(router: router)
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/", method: .get) { response in
+                #expect(response.headers[.contentSecurityPolicy] == "default-src 'self'; form-action 'self'; frame-ancestors 'self'")
+                #expect(response.headers[.crossOriginResourcePolicy] == "same-site")
+                #expect(response.headers[.xContentTypeOptions] == "nosniff")
+                #expect(response.headers[HTTPField.Name("Reporting-Endpoints")!] == nil)
+            }
+        }
+    }
+
+    @Test func testSecurityMiddleware() async throws {
+        let router = Router()
+        router.add(
+            middleware: SecurityMiddleware(
+                contentSecurityPolicy: [.upgradeInsecureRequests, .reportTo("csp-endpoint")],
+                crossOriginResourcePolicy: .sameOrigin,
+                reportingEndpoints: [
+                    "csp-endpoint": "http://example.com/csp-reports", "permissions-endpoint": "http://example.com/permissions-reports",
+                ]
+            )
+        )
+        router.get("/") { _, _ in
+            HTTPResponse.Status.ok
+        }
+        let app = Application(router: router)
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/", method: .get) { response in
+                #expect(response.headers[.contentSecurityPolicy] == "upgrade-insecure-requests; report-to csp-endpoint")
+                #expect(response.headers[.crossOriginResourcePolicy] == "same-origin")
+                #expect(response.headers[.xContentTypeOptions] == "nosniff")
+                #expect(
+                    response.headers[HTTPField.Name("Reporting-Endpoints")!]
+                        == "csp-endpoint=\"http://example.com/csp-reports\",permissions-endpoint=\"http://example.com/permissions-reports\""
+                        || response.headers[HTTPField.Name("Reporting-Endpoints")!]
+                            == "permissions-endpoint=\"http://example.com/permissions-reports\",csp-endpoint=\"http://example.com/csp-reports\""
+
+                )
             }
         }
     }

--- a/Tests/HummingbirdTests/MiddlewareTests.swift
+++ b/Tests/HummingbirdTests/MiddlewareTests.swift
@@ -474,9 +474,9 @@ struct MiddlewareTests {
         }
     }
 
-    @Test func testSecurityMiddlewareDefaults() async throws {
+    @Test func testContentSecurityMiddlewareDefaults() async throws {
         let router = Router()
-        router.add(middleware: SecurityMiddleware())
+        router.add(middleware: ContentSecurityMiddleware())
         router.get("/") { _, _ in
             HTTPResponse.Status.ok
         }
@@ -484,19 +484,17 @@ struct MiddlewareTests {
         try await app.test(.router) { client in
             try await client.execute(uri: "/", method: .get) { response in
                 #expect(response.headers[.contentSecurityPolicy] == "default-src 'self'; form-action 'self'; frame-ancestors 'self'")
-                #expect(response.headers[.crossOriginResourcePolicy] == "same-site")
                 #expect(response.headers[.xContentTypeOptions] == "nosniff")
                 #expect(response.headers[HTTPField.Name("Reporting-Endpoints")!] == nil)
             }
         }
     }
 
-    @Test func testSecurityMiddleware() async throws {
+    @Test func testContentSecurityMiddleware() async throws {
         let router = Router()
         router.add(
-            middleware: SecurityMiddleware(
+            middleware: ContentSecurityMiddleware(
                 contentSecurityPolicy: [.upgradeInsecureRequests, .reportTo("csp-endpoint")],
-                crossOriginResourcePolicy: .sameOrigin,
                 reportingEndpoints: [
                     "csp-endpoint": "http://example.com/csp-reports", "permissions-endpoint": "http://example.com/permissions-reports",
                 ]
@@ -509,7 +507,6 @@ struct MiddlewareTests {
         try await app.test(.router) { client in
             try await client.execute(uri: "/", method: .get) { response in
                 #expect(response.headers[.contentSecurityPolicy] == "upgrade-insecure-requests; report-to csp-endpoint")
-                #expect(response.headers[.crossOriginResourcePolicy] == "same-origin")
                 #expect(response.headers[.xContentTypeOptions] == "nosniff")
                 #expect(
                     response.headers[HTTPField.Name("Reporting-Endpoints")!]


### PR DESCRIPTION
Middleware for setting various resource access related headers. `content-security-policy`, `cross-origin-resource-policy`, `x-content-type-options` and optionally setting `content-security-policy-report-only` and `reporting-endpoints`

I think it needs another name though. `SecurityMiddleware` is very vague. But `ResourcesAccessControlMiddleware` or something similar is quite a mouthful and not much more descriptive. Perhaps add an `HTML` or browser prefix as it is related to web browsers.