### PR TITLE
Update header limits

### DIFF
--- a/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
+++ b/Sources/HummingbirdCore/Server/HTTP/HTTP1Channel.swift
@@ -34,7 +34,7 @@ public struct HTTP1Channel: ServerChildChannel, HTTPChannelHandler {
             ///   - maxHeaderFieldSize: Maximum size for a header field
             ///   - maxHeaderListSize: Maximum size for all header fields
             ///   - maxHeaderFieldCount: Maximum number of headers
-            public init(maxHeaderFieldSize: Int = 80 * 1024, maxHeaderListSize: Int = 1024 * 1024, maxHeaderFieldCount: Int = 256) {
+            public init(maxHeaderFieldSize: Int = 80 * 1024, maxHeaderListSize: Int = 80 * 1024, maxHeaderFieldCount: Int = 1000) {
                 self.maxHeaderFieldSize = maxHeaderFieldSize
                 self.maxHeaderListSize = maxHeaderListSize
                 self.maxHeaderFieldCount = maxHeaderFieldCount


### PR DESCRIPTION
Total header size was too lax. Reduced to 80k which is what it was before
Total header lines was too strict. Increased to 1000 (the same as nginx)