### PR TITLE
Add a metrics cache to MetricsMiddleware

### DIFF
--- a/Benchmarks/HummingbirdBenchmarks/RouterBenchmarks.swift
+++ b/Benchmarks/HummingbirdBenchmarks/RouterBenchmarks.swift
@@ -12,6 +12,8 @@ import Hummingbird
 import HummingbirdCore
 import HummingbirdRouter
 import Logging
+import Metrics
+import MetricsTestKit
 import NIOCore
 import NIOEmbedded
 import NIOHTTPTypes
@@ -59,10 +61,15 @@ extension Benchmark {
         configuration: Benchmark.Configuration = Benchmark.defaultConfiguration,
         request: HTTPRequest,
         writeBody: (@Sendable (ByteBufferWriter) async throws -> Void)? = nil,
-        createRouter: @escaping @Sendable () async throws -> ResponderBuilder
+        createRouter: @escaping @Sendable () -> ResponderBuilder
     ) where ResponderBuilder.Responder.Context: RequestContext, ResponderBuilder.Responder.Context.Source == BenchmarkRequestContextSource {
+        let responder = createRouter().buildResponder()
+
+        let (requestBody, source) = RequestBody.makeStream()
+        let hbRequest = Request(head: request, body: requestBody)
+        source.finish()
+
         self.init(name, configuration: configuration) { benchmark in
-            let responder = try await createRouter().buildResponder()
 
             if let writeBody {
                 let context = ResponderBuilder.Responder.Context(source: BenchmarkRequestContextSource())
@@ -72,24 +79,21 @@ extension Benchmark {
                 for _ in benchmark.scaledIterations {
                     for _ in 0..<50 {
                         let (requestBody, source) = RequestBody.makeStream()
-                        let Request = Request(head: request, body: requestBody)
+                        let request = Request(head: request, body: requestBody)
                         try await writeBody(source.yield)
                         source.finish()
-                        let response = try await responder.respond(to: Request, context: context)
+                        let response = try await responder.respond(to: request, context: context)
                         _ = try await response.body.write(BenchmarkBodyWriter())
                     }
                 }
             } else {
                 let context = ResponderBuilder.Responder.Context(source: BenchmarkRequestContextSource())
-                let (requestBody, source) = RequestBody.makeStream()
-                let Request = Request(head: request, body: requestBody)
-                source.finish()
 
                 benchmark.startMeasurement()
 
                 for _ in benchmark.scaledIterations {
                     for _ in 0..<50 {
-                        let response = try await responder.respond(to: Request, context: context)
+                        let response = try await responder.respond(to: hbRequest, context: context)
                         _ = try await response.body.write(BenchmarkBodyWriter())
                     }
                 }
@@ -110,6 +114,7 @@ extension HTTPField.Name {
 
 @available(macOS 14, *)
 func routerBenchmarks() {
+    MetricsSystem.bootstrap(TestMetrics())
     let buffer = ByteBufferAllocator().buffer(repeating: 0xFF, count: 10000)
     Benchmark(
         "Router:GET",
@@ -191,6 +196,24 @@ func routerBenchmarks() {
         router.middlewares.add(EmptyMiddleware())
         router.get { _, _ in
             HTTPResponse.Status.ok
+        }
+        return router
+    }
+
+    Benchmark(
+        "Router:MetricsMiddleware",
+        configuration: .init(warmupIterations: 10),
+        request: .init(method: .get, scheme: "http", authority: "localhost", path: "/test")
+    ) {
+        let router = Router(context: BasicBenchmarkContext.self)
+        router.add(middleware: MetricsMiddleware())
+        router.get("/test") { _, _ in
+            switch Int.random(in: 0..<4) {
+            case 0: HTTPResponse.Status.ok
+            case 1: HTTPResponse.Status.badRequest
+            case 2: HTTPResponse.Status.forbidden
+            default: throw HTTPError(.notFound)
+            }
         }
         return router
     }

--- a/Package.swift
+++ b/Package.swift
@@ -212,6 +212,7 @@ if Context.environment["ENABLE_HB_BENCHMARKS"] != nil {
                 "Hummingbird",
                 "HummingbirdRouter",
                 .product(name: "Benchmark", package: "benchmark"),
+                .product(name: "MetricsTestKit", package: "swift-metrics"),
             ],
             path: "Benchmarks/HummingbirdBenchmarks",
             swiftSettings: swiftSettings,

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.5.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.9.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.100.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.34.1"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.44.0"),
@@ -165,6 +165,7 @@ let package = Package(
                 .byName(name: "HummingbirdTesting"),
                 .byName(name: "HummingbirdRouter"),
                 .product(name: "InMemoryLogging", package: "swift-log"),
+                .product(name: "MetricsTestKit", package: "swift-metrics"),
             ],
             swiftSettings: swiftSettings
         ),

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.5.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.9.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.100.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.34.1"),
@@ -149,6 +149,7 @@ let package = Package(
                 .byName(name: "HummingbirdTesting"),
                 .byName(name: "HummingbirdRouter"),
                 .product(name: "InMemoryLogging", package: "swift-log"),
+                .product(name: "MetricsTestKit", package: "swift-metrics"),
             ],
             swiftSettings: swiftSettings
         ),

--- a/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
@@ -123,13 +123,25 @@ final class MetricsCache: Sendable {
 
     func getMethodMetrics(id: MethodMetrics.ID) -> MethodMetrics {
         self.methodMetricsStorage.withLockedValue { metricsMap in
-            metricsMap[id, default: .init(id: id)]
+            if let metrics = metricsMap[id] {
+                return metrics
+            } else {
+                let value = MethodMetrics(id: id)
+                metricsMap[id] = value
+                return value
+            }
         }
     }
 
     func getEndpointMetrics(id: EndpointMetrics.ID) -> EndpointMetrics {
         self.endpointMetricsStorage.withLockedValue { metricsMap in
-            metricsMap[id, default: .init(id: id)]
+            if let metrics = metricsMap[id] {
+                return metrics
+            } else {
+                let value = EndpointMetrics(id: id)
+                metricsMap[id] = value
+                return value
+            }
         }
     }
 }

--- a/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
+++ b/Sources/Hummingbird/Middleware/MetricsMiddleware.swift
@@ -8,6 +8,7 @@
 
 import Dispatch
 import Metrics
+import NIOConcurrencyHelpers
 
 /// Middleware recording metrics for each request
 ///
@@ -19,60 +20,116 @@ import Metrics
 ///
 /// A list of implementations is available in the swift-log repository's README.
 public struct MetricsMiddleware<Context: RequestContext>: RouterMiddleware {
-    public init() {}
+    let metricsCache: MetricsCache
+
+    public init() {
+        self.metricsCache = .init()
+    }
 
     public func handle(_ request: Request, context: Context, next: (Request, Context) async throws -> Response) async throws -> Response {
         let startTime = DispatchTime.now().uptimeNanoseconds
-        let activeRequestMeter = Meter(label: "http.server.active_requests", dimensions: [("http.request.method", request.method.description)])
+        let activeRequestMeter = self.metricsCache.getMethodMetrics(id: .init(method: request.method)).activeRequestMeter
         activeRequestMeter.increment()
         do {
             var response = try await next(request, context)
             let responseStatus = response.status
             response.body = response.body.withPostWriteClosure {
-                // need to create dimensions once request has been responded to ensure
-                // we have the correct endpoint path
-                let dimensions: [(String, String)] = [
-                    ("http.route", context.endpointPath ?? "Unknown"),
-                    ("http.request.method", request.method.rawValue),
-                    ("http.response.status_code", responseStatus.code.description),
-                ]
-                Counter(label: "hb.requests", dimensions: dimensions).increment()
-                Metrics.Timer(
-                    label: "http.server.request.duration",
-                    dimensions: dimensions,
-                    preferredDisplayUnit: .seconds
-                ).recordNanoseconds(DispatchTime.now().uptimeNanoseconds - startTime)
+                let metrics = self.metricsCache.getEndpointMetrics(
+                    id: .init(endpoint: context.endpointPath ?? "Unknown", method: request.method, status: responseStatus)
+                )
+                metrics.counter.increment()
+                metrics.timer.recordNanoseconds(DispatchTime.now().uptimeNanoseconds - startTime)
                 activeRequestMeter.decrement()
             }
             return response
         } catch {
-            let errorType: String
+            let errorType: HTTPResponse.Status
             if let httpError = error as? any HTTPResponseError {
-                errorType = httpError.status.code.description
+                errorType = httpError.status
             } else {
-                errorType = "500"
+                errorType = .internalServerError
             }
-            let endpointPath = context.endpointPath ?? "NotFound"
-            // increment requests
-            Counter(
-                label: "hb.requests",
-                dimensions: [
-                    ("http.route", endpointPath),
-                    ("http.request.method", request.method.rawValue),
-                    ("http.response.status_code", errorType),
-                ]
-            ).increment()
-            // increment errors
-            Counter(
-                label: "hb.request.errors",
-                dimensions: [
-                    ("http.route", endpointPath),
-                    ("http.request.method", request.method.rawValue),
-                    ("error.type", errorType),
-                ]
-            ).increment()
+            let metrics = self.metricsCache.getEndpointMetrics(
+                id: .init(endpoint: context.endpointPath ?? "NotFound", method: request.method, status: errorType)
+            )
+            metrics.counter.increment()
+            metrics.errorCounter.increment()
             activeRequestMeter.decrement()
             throw error
+        }
+    }
+}
+
+/// Cache to store, metrics associated with particular endpoints and methods.
+///
+/// This should provide a quicker lookup for metrics primitives than expecting the
+/// underlying metrics factory to do a general lookup
+final class MetricsCache: Sendable {
+    struct MethodMetrics: Sendable {
+        struct ID: Hashable {
+            let method: HTTPRequest.Method
+        }
+        let activeRequestMeter: Meter
+
+        init(id: ID) {
+            self.activeRequestMeter = Meter(label: "http.server.active_requests", dimensions: [("http.request.method", id.method.description)])
+        }
+    }
+    struct EndpointMetrics: Sendable {
+        struct ID: Hashable {
+            let endpoint: String
+            let method: HTTPRequest.Method
+            let status: HTTPResponse.Status
+        }
+        let counter: Counter
+        let timer: Timer
+        let errorCounter: Counter
+
+        init(id: ID) {
+            self.counter = Counter(
+                label: "hb.requests",
+                dimensions: [
+                    ("http.route", id.endpoint),
+                    ("http.request.method", id.method.description),
+                    ("http.response.status_code", id.status.code.description),
+                ]
+            )
+            self.timer = Timer(
+                label: "http.server.request.duration",
+                dimensions: [
+                    ("http.route", id.endpoint),
+                    ("http.request.method", id.method.description),
+                    ("http.response.status_code", id.status.code.description),
+                ],
+                preferredDisplayUnit: .seconds
+            )
+            self.errorCounter = Counter(
+                label: "hb.request.errors",
+                dimensions: [
+                    ("http.route", id.endpoint),
+                    ("http.request.method", id.method.description),
+                    ("error.type", id.status.code.description),
+                ]
+            )
+        }
+    }
+    let methodMetricsStorage: NIOLockedValueBox<[MethodMetrics.ID: MethodMetrics]>
+    let endpointMetricsStorage: NIOLockedValueBox<[EndpointMetrics.ID: EndpointMetrics]>
+
+    init() {
+        self.methodMetricsStorage = .init([:])
+        self.endpointMetricsStorage = .init([:])
+    }
+
+    func getMethodMetrics(id: MethodMetrics.ID) -> MethodMetrics {
+        self.methodMetricsStorage.withLockedValue { metricsMap in
+            metricsMap[id, default: .init(id: id)]
+        }
+    }
+
+    func getEndpointMetrics(id: EndpointMetrics.ID) -> EndpointMetrics {
+        self.endpointMetricsStorage.withLockedValue { metricsMap in
+            metricsMap[id, default: .init(id: id)]
         }
     }
 }

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -10,302 +10,14 @@ import Foundation
 import Hummingbird
 import HummingbirdTesting
 import Metrics
+import MetricsTestKit
 import NIOConcurrencyHelpers
 import Testing
 
-final class TestMetrics: MetricsFactory {
-    private let lock = NIOLock()
-    private let _counters = NIOLockedValueBox([String: any CounterHandler]())
-    private let _meters = NIOLockedValueBox([String: any MeterHandler]())
-    private let _recorders = NIOLockedValueBox([String: any RecorderHandler]())
-    private let _timers = NIOLockedValueBox([String: any TimerHandler]())
-
-    public var counters: [String: any CounterHandler] { _counters.withLockedValue { $0 } }
-    public var meters: [String: any MeterHandler] { _meters.withLockedValue { $0 } }
-    public var recorders: [String: any RecorderHandler] { _recorders.withLockedValue { $0 } }
-    public var timers: [String: any TimerHandler] { _timers.withLockedValue { $0 } }
-
-    public func makeCounter(label: String, dimensions: [(String, String)]) -> any CounterHandler {
-        self._counters.withLockedValue { counters in
-            self.make(label: label, dimensions: dimensions, registry: &counters, maker: TestCounter.init)
-        }
-    }
-
-    public func makeMeter(label: String, dimensions: [(String, String)]) -> any MeterHandler {
-        self._meters.withLockedValue { counters in
-            self.make(label: label, dimensions: dimensions, registry: &counters, maker: TestMeter.init)
-        }
-    }
-
-    public func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> any RecorderHandler {
-        let maker = { (label: String, dimensions: [(String, String)]) -> any RecorderHandler in
-            TestRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
-        }
-        return self._recorders.withLockedValue { recorders in
-            self.make(label: label, dimensions: dimensions, registry: &recorders, maker: maker)
-        }
-    }
-
-    public func makeTimer(label: String, dimensions: [(String, String)]) -> any TimerHandler {
-        self._timers.withLockedValue { timers in
-            self.make(label: label, dimensions: dimensions, registry: &timers, maker: TestTimer.init)
-        }
-    }
-
-    private func make<Item>(
-        label: String,
-        dimensions: [(String, String)],
-        registry: inout [String: Item],
-        maker: (String, [(String, String)]) -> Item
-    ) -> Item {
-        let item = maker(label, dimensions)
-        registry[label] = item
-        return item
-    }
-
-    func destroyCounter(_ handler: any CounterHandler) {
-        if let testCounter = handler as? TestCounter {
-            _ = self._counters.withLockedValue { counters in
-                counters.removeValue(forKey: testCounter.label)
-            }
-        }
-    }
-
-    func destroyMeter(_ handler: any MeterHandler) {
-        if let testMeter = handler as? TestMeter {
-            _ = self._counters.withLockedValue { counters in
-                counters.removeValue(forKey: testMeter.label)
-            }
-        }
-    }
-
-    func destroyRecorder(_ handler: any RecorderHandler) {
-        if let testRecorder = handler as? TestRecorder {
-            _ = self._recorders.withLockedValue { recorders in
-                recorders.removeValue(forKey: testRecorder.label)
-            }
-        }
-    }
-
-    func destroyTimer(_ handler: any TimerHandler) {
-        if let testTimer = handler as? TestTimer {
-            _ = self._timers.withLockedValue { timers in
-                timers.removeValue(forKey: testTimer.label)
-            }
-        }
-    }
-}
-
-internal final class TestCounter: CounterHandler, Equatable {
-    let id: String
-    let label: String
-    let dimensions: [(String, String)]
-    let values = NIOLockedValueBox([(Date, Int64)]())
-
-    init(label: String, dimensions: [(String, String)]) {
-        self.id = NSUUID().uuidString
-        self.label = label
-        self.dimensions = dimensions
-    }
-
-    func increment(by amount: Int64) {
-        self.values.withLockedValue { values in
-            values.append((Date(), amount))
-        }
-        print("adding \(amount) to \(self.label)")
-    }
-
-    func reset() {
-        self.values.withLockedValue { values in
-            values = []
-        }
-        print("reseting \(self.label)")
-    }
-
-    public static func == (lhs: TestCounter, rhs: TestCounter) -> Bool {
-        lhs.id == rhs.id
-    }
-}
-
-internal final class TestMeter: MeterHandler, Equatable {
-    let id: String
-    let label: String
-    let dimensions: [(String, String)]
-    let values = NIOLockedValueBox([(Date, Double)]())
-
-    init(label: String, dimensions: [(String, String)]) {
-        self.id = NSUUID().uuidString
-        self.label = label
-        self.dimensions = dimensions
-    }
-
-    func set(_ value: Int64) {
-        self.set(Double(value))
-    }
-
-    func set(_ value: Double) {
-        self.values.withLockedValue { values in
-            values.append((Date(), value))
-        }
-        print("adding \(value) to \(self.label)")
-    }
-
-    func increment(by: Double) {
-        self.values.withLockedValue { values in
-            let value = values.last?.1 ?? 0.0
-            values.append((Date(), value + by))
-        }
-        print("incrementing \(by) to \(self.label)")
-
-    }
-
-    func decrement(by: Double) {
-        self.values.withLockedValue { values in
-            let value = values.last?.1 ?? 0.0
-            values.append((Date(), value - by))
-        }
-        print("decrementing \(by) to \(self.label)")
-
-    }
-
-    static func == (lhs: TestMeter, rhs: TestMeter) -> Bool {
-        lhs.id == rhs.id
-    }
-}
-
-internal final class TestRecorder: RecorderHandler, Equatable {
-    let id: String
-    let label: String
-    let dimensions: [(String, String)]
-    let aggregate: Bool
-    let values = NIOLockedValueBox([(Date, Double)]())
-
-    init(label: String, dimensions: [(String, String)], aggregate: Bool) {
-        self.id = NSUUID().uuidString
-        self.label = label
-        self.dimensions = dimensions
-        self.aggregate = aggregate
-    }
-
-    func record(_ value: Int64) {
-        self.record(Double(value))
-    }
-
-    func record(_ value: Double) {
-        self.values.withLockedValue { values in
-            // this may loose precision but good enough as an example
-            values.append((Date(), Double(value)))
-        }
-        print("recording \(value) in \(self.label)")
-    }
-
-    public static func == (lhs: TestRecorder, rhs: TestRecorder) -> Bool {
-        lhs.id == rhs.id
-    }
-}
-
-internal final class TestTimer: TimerHandler, Equatable {
-    let id: String
-    let label: String
-    let displayUnit: NIOLockedValueBox<TimeUnit?>
-    let dimensions: [(String, String)]
-    let values = NIOLockedValueBox([(Date, Int64)]())
-
-    init(label: String, dimensions: [(String, String)]) {
-        self.id = NSUUID().uuidString
-        self.label = label
-        self.displayUnit = .init(nil)
-        self.dimensions = dimensions
-    }
-
-    func preferDisplayUnit(_ unit: TimeUnit) {
-        self.displayUnit.withLockedValue { displayUnit in
-            displayUnit = unit
-        }
-    }
-
-    func retriveValueInPreferredUnit(atIndex i: Int) -> Double {
-        self.values.withLockedValue { values in
-            let value = values[i].1
-            return self.displayUnit.withLockedValue { displayUnit in
-                guard let displayUnit else {
-                    return Double(value)
-                }
-                return Double(value) / Double(displayUnit.scaleFromNanoseconds)
-            }
-        }
-    }
-
-    func recordNanoseconds(_ duration: Int64) {
-        self.values.withLockedValue { values in
-            values.append((Date(), duration))
-        }
-        print("recording \(duration) \(self.label)")
-    }
-
-    public static func == (lhs: TestTimer, rhs: TestTimer) -> Bool {
-        lhs.id == rhs.id
-    }
-}
-
-final class TaskUniqueTestMetrics: MetricsFactory {
-    @TaskLocal static var current: TestMetrics = .init()
-    func withUnique<Value: Sendable>(
-        _ operation: () async throws -> Value
-    ) async throws -> Value {
-        try await TaskUniqueTestMetrics.$current.withValue(TestMetrics()) {
-            try await operation()
-        }
-    }
-
-    func makeCounter(label: String, dimensions: [(String, String)]) -> any CounterHandler {
-        TaskUniqueTestMetrics.current.makeCounter(label: label, dimensions: dimensions)
-    }
-
-    public func makeMeter(label: String, dimensions: [(String, String)]) -> any MeterHandler {
-        TaskUniqueTestMetrics.current.makeMeter(label: label, dimensions: dimensions)
-    }
-
-    func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> any RecorderHandler {
-        TaskUniqueTestMetrics.current.makeRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
-    }
-
-    func makeTimer(label: String, dimensions: [(String, String)]) -> any TimerHandler {
-        TaskUniqueTestMetrics.current.makeTimer(label: label, dimensions: dimensions)
-    }
-
-    func destroyCounter(_ handler: any CounterHandler) {
-        TaskUniqueTestMetrics.current.destroyCounter(handler)
-    }
-
-    func destroyMeter(_ handler: any MeterHandler) {
-        TaskUniqueTestMetrics.current.destroyMeter(handler)
-    }
-
-    func destroyRecorder(_ handler: any RecorderHandler) {
-        TaskUniqueTestMetrics.current.destroyRecorder(handler)
-    }
-
-    func destroyTimer(_ handler: any TimerHandler) {
-        TaskUniqueTestMetrics.current.destroyTimer(handler)
-    }
-
-    public var counters: [String: any CounterHandler] { TaskUniqueTestMetrics.current.counters }
-    public var meters: [String: any MeterHandler] { TaskUniqueTestMetrics.current.meters }
-    public var recorders: [String: any RecorderHandler] { TaskUniqueTestMetrics.current.recorders }
-    public var timers: [String: any TimerHandler] { TaskUniqueTestMetrics.current.timers }
-
-}
-
 struct MetricsTests {
-    static let testMetrics = {
-        let metrics = TaskUniqueTestMetrics()
-        MetricsSystem.bootstrap(metrics)
-        return metrics
-    }()
-
     @Test func testCounter() async throws {
-        try await Self.testMetrics.withUnique {
+        let metrics = TestMetrics()
+        try await withMetricsFactory(metrics) {
             let router = Router()
             router.middlewares.add(MetricsMiddleware())
             router.get("/hello") { _, _ -> String in
@@ -315,18 +27,17 @@ struct MetricsTests {
             try await app.test(.router) { client in
                 try await client.execute(uri: "/hello", method: .get) { _ in }
             }
-
-            let counter = try #require(Self.testMetrics.counters["hb.requests"] as? TestCounter)
-            #expect(counter.values.withLockedValue { $0 }[0].1 == 1)
-            #expect(counter.dimensions[0].0 == "http.route")
-            #expect(counter.dimensions[0].1 == "/hello")
-            #expect(counter.dimensions[1].0 == "http.request.method")
-            #expect(counter.dimensions[1].1 == "GET")
         }
+        let counter = try metrics.expectCounter(
+            "hb.requests",
+            [("http.route", "/hello"), ("http.request.method", "GET"), ("http.response.status_code", "200")]
+        )
+        #expect(counter.values[0] == 1)
     }
 
     @Test func testError() async throws {
-        try await Self.testMetrics.withUnique {
+        let metrics = TestMetrics()
+        try await withMetricsFactory(metrics) {
             let router = Router()
             router.middlewares.add(MetricsMiddleware())
             router.get("/hello") { _, _ -> String in
@@ -336,27 +47,23 @@ struct MetricsTests {
             try await app.test(.router) { client in
                 try await client.execute(uri: "/hello", method: .get) { _ in }
             }
-
-            let counter = try #require(Self.testMetrics.counters["hb.requests"] as? TestCounter)
-            #expect(counter.values.withLockedValue { $0 }[0].1 == 1)
-            #expect(counter.dimensions[0].0 == "http.route")
-            #expect(counter.dimensions[0].1 == "/hello")
-            #expect(counter.dimensions[1].0 == "http.request.method")
-            #expect(counter.dimensions[1].1 == "GET")
-            #expect(counter.dimensions[2].0 == "http.response.status_code")
-            #expect(counter.dimensions[2].1 == "400")
-            let errorCounter = try #require(Self.testMetrics.counters["hb.request.errors"] as? TestCounter)
-            #expect(errorCounter.values.withLockedValue { $0 }.count == 1)
-            #expect(errorCounter.values.withLockedValue { $0 }[0].1 == 1)
-            #expect(errorCounter.dimensions[0].0 == "http.route")
-            #expect(errorCounter.dimensions[0].1 == "/hello")
-            #expect(errorCounter.dimensions[1].0 == "http.request.method")
-            #expect(errorCounter.dimensions[1].1 == "GET")
         }
+
+        let counter = try metrics.expectCounter(
+            "hb.requests",
+            [("http.route", "/hello"), ("http.request.method", "GET"), ("http.response.status_code", "400")]
+        )
+        #expect(counter.values[0] == 1)
+        let errorCounter = try metrics.expectCounter(
+            "hb.request.errors",
+            [("http.route", "/hello"), ("http.request.method", "GET"), ("error.type", "400")]
+        )
+        #expect(errorCounter.values.count == 1)
     }
 
     @Test func testNotFoundError() async throws {
-        try await Self.testMetrics.withUnique {
+        let metrics = TestMetrics()
+        try await withMetricsFactory(metrics) {
             let router = Router()
             router.middlewares.add(MetricsMiddleware())
             router.get("/hello") { _, _ -> String in
@@ -366,30 +73,23 @@ struct MetricsTests {
             try await app.test(.router) { client in
                 try await client.execute(uri: "/hello2", method: .get) { _ in }
             }
-
-            let counter = try #require(Self.testMetrics.counters["hb.requests"] as? TestCounter)
-            #expect(counter.values.withLockedValue { $0 }[0].1 == 1)
-            #expect(counter.dimensions[0].0 == "http.route")
-            #expect(counter.dimensions[0].1 == "NotFound")
-            #expect(counter.dimensions[1].0 == "http.request.method")
-            #expect(counter.dimensions[1].1 == "GET")
-            #expect(counter.dimensions[2].0 == "http.response.status_code")
-            #expect(counter.dimensions[2].1 == "404")
-            let errorCounter = try #require(Self.testMetrics.counters["hb.request.errors"] as? TestCounter)
-            #expect(errorCounter.values.withLockedValue { $0 }.count == 1)
-            #expect(errorCounter.values.withLockedValue { $0 }[0].1 == 1)
-            #expect(errorCounter.dimensions.count == 3)
-            #expect(errorCounter.dimensions[0].0 == "http.route")
-            #expect(errorCounter.dimensions[0].1 == "NotFound")
-            #expect(errorCounter.dimensions[1].0 == "http.request.method")
-            #expect(errorCounter.dimensions[1].1 == "GET")
-            #expect(errorCounter.dimensions[2].0 == "error.type")
-            #expect(errorCounter.dimensions[2].1 == "404")
         }
+
+        let counter = try metrics.expectCounter(
+            "hb.requests",
+            [("http.route", "NotFound"), ("http.request.method", "GET"), ("http.response.status_code", "404")]
+        )
+        #expect(counter.values[0] == 1)
+        let errorCounter = try metrics.expectCounter(
+            "hb.request.errors",
+            [("http.route", "NotFound"), ("http.request.method", "GET"), ("error.type", "404")]
+        )
+        #expect(errorCounter.values.count == 1)
     }
 
     @Test func testParameterEndpoint() async throws {
-        try await Self.testMetrics.withUnique {
+        let metrics = TestMetrics()
+        try await withMetricsFactory(metrics) {
             let router = Router()
             router.middlewares.add(MetricsMiddleware())
             router.get("/user/:id") { _, _ -> String in
@@ -399,22 +99,18 @@ struct MetricsTests {
             try await app.test(.router) { client in
                 try await client.execute(uri: "/user/765", method: .get) { _ in }
             }
-
-            let counter = try #require(Self.testMetrics.counters["hb.request.errors"] as? TestCounter)
-            #expect(counter.values.withLockedValue { $0 }.count == 1)
-            #expect(counter.values.withLockedValue { $0 }[0].1 == 1)
-            #expect(counter.dimensions.count == 3)
-            #expect(counter.dimensions[0].0 == "http.route")
-            #expect(counter.dimensions[0].1 == "/user/{id}")
-            #expect(counter.dimensions[1].0 == "http.request.method")
-            #expect(counter.dimensions[1].1 == "GET")
-            #expect(counter.dimensions[2].0 == "error.type")
-            #expect(counter.dimensions[2].1 == "400")
         }
+
+        let errorCounter = try metrics.expectCounter(
+            "hb.request.errors",
+            [("http.route", "/user/{id}"), ("http.request.method", "GET"), ("error.type", "400")]
+        )
+        #expect(errorCounter.values.count == 1)
     }
 
     @Test func testRecordingBodyWriteTime() async throws {
-        try await Self.testMetrics.withUnique {
+        let metrics = TestMetrics()
+        try await withMetricsFactory(metrics) {
             let router = Router()
             router.middlewares.add(MetricsMiddleware())
             router.get("/hello") { _, _ -> Response in
@@ -429,14 +125,19 @@ struct MetricsTests {
             try await app.test(.router) { client in
                 try await client.execute(uri: "/hello", method: .get) { _ in }
             }
-
-            let timer = try #require(Self.testMetrics.timers["http.server.request.duration"] as? TestTimer)
-            #expect(timer.values.withLockedValue { $0 }[0].1 > 5_000_000)
         }
+
+        let timer = try metrics.expectTimer(
+            "http.server.request.duration",
+            [("http.route", "/hello"), ("http.request.method", "GET"), ("http.response.status_code", "200")]
+        )
+        #expect(timer.values.count == 1)
+        #expect(timer.values[0] > 5_000_000)
     }
 
     @Test func testActiveRequestsMetric() async throws {
-        try await Self.testMetrics.withUnique {
+        let metrics = TestMetrics()
+        try await withMetricsFactory(metrics) {
             let router = Router()
             router.middlewares.add(MetricsMiddleware())
             router.get("/hello") { _, _ -> Response in
@@ -446,11 +147,11 @@ struct MetricsTests {
             try await app.test(.router) { client in
                 try await client.execute(uri: "/hello", method: .get) { _ in }
             }
-
-            let meter = try #require(Self.testMetrics.meters["http.server.active_requests"] as? TestMeter)
-            let values = meter.values.withLockedValue { $0 }.map { $0.1 }
-            let maxValue = values.max() ?? 0.0
-            #expect(maxValue > 0.0)
         }
+
+        let meter = try metrics.expectMeter("http.server.active_requests", [("http.request.method", "GET")])
+        let values = meter.values
+        let maxValue = values.max() ?? 0.0
+        #expect(maxValue > 0.0)
     }
 }

--- a/Tests/HummingbirdTests/MetricsTests.swift
+++ b/Tests/HummingbirdTests/MetricsTests.swift
@@ -35,6 +35,45 @@ struct MetricsTests {
         #expect(counter.values[0] == 1)
     }
 
+    @Test func testCounter2() async throws {
+        let metrics = TestMetrics()
+        try await withMetricsFactory(metrics) {
+            let router = Router()
+            router.middlewares.add(MetricsMiddleware())
+            router.get("/hello") { _, _ -> HTTPResponse.Status in
+                switch Int.random(in: 0..<4) {
+                case 0: HTTPResponse.Status.ok
+                case 1: HTTPResponse.Status.badRequest
+                case 2: HTTPResponse.Status.forbidden
+                default: throw HTTPError(.notFound)
+                }
+            }
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                for _ in 0..<1000 {
+                    try await client.execute(uri: "/hello", method: .get) { _ in }
+                }
+            }
+        }
+        let counter1 = try metrics.expectCounter(
+            "hb.requests",
+            [("http.route", "/hello"), ("http.request.method", "GET"), ("http.response.status_code", "200")]
+        )
+        let counter2 = try metrics.expectCounter(
+            "hb.requests",
+            [("http.route", "/hello"), ("http.request.method", "GET"), ("http.response.status_code", "400")]
+        )
+        let counter3 = try metrics.expectCounter(
+            "hb.requests",
+            [("http.route", "/hello"), ("http.request.method", "GET"), ("http.response.status_code", "403")]
+        )
+        let counter4 = try metrics.expectCounter(
+            "hb.requests",
+            [("http.route", "/hello"), ("http.request.method", "GET"), ("http.response.status_code", "404")]
+        )
+        #expect(counter1.values.count + counter2.values.count + counter3.values.count + counter4.values.count == 1000)
+    }
+
     @Test func testError() async throws {
         let metrics = TestMetrics()
         try await withMetricsFactory(metrics) {


### PR DESCRIPTION
Add a cache of metrics primitives to the MetricsMiddleware to improve metrics lookup performance. While the dictionary lookup is probably similar to the underlying metrics factory, it is only done once per endpoint and will be done across a more limited hash space.

This PR also updates the metrics tests to use the MetricsTestKit from swift-metrics and uses `withMetricsFactory` to use different factories per test.