### PR TITLE
Fix URLEncodedFormTests.DecoderTests.testOverflow on Linux

### DIFF
--- a/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
@@ -346,7 +346,7 @@ extension URLEncodedFormTests {
                     form += "[a]"
                 }
                 form += "=1"
-                _ = try URLEncodedFormDecoder().decode(Input1.self, from: form)
+                _ = try? URLEncodedFormDecoder().decode(Input1.self, from: form)
             }
         }
         #endif


### PR DESCRIPTION
Throwing an error inside a `#expect(processExitsWith: .success)` closure will exit with SIGILL on Linux but exits with success on macOS 🤷 