### PR TITLE
Make ResponseBodyWriter methods nonisolated(nonsending)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        image: ["swift:6.1", "swift:6.2", "swift:6.3", "swiftlang/swift:nightly-6.4.x-noble"]
+        image: ["swift:6.2", "swift:6.3", "swiftlang/swift:nightly-6.4.x-noble"]
     container:
       image: ${{ matrix.image }}
     env:

--- a/Sources/HummingbirdCore/Response/ResponseBodyWriter.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBodyWriter.swift
@@ -13,19 +13,19 @@ public import NIOCore
 public protocol ResponseBodyWriter {
     /// Write a single ByteBuffer
     /// - Parameter buffer: single buffer to write
-    mutating func write(_ buffer: ByteBuffer) async throws
+    mutating nonisolated(nonsending) func write(_ buffer: ByteBuffer) async throws
     /// Write a sequence of ByteBuffers
     /// - Parameter buffers: Sequence of buffers
-    mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws
+    mutating nonisolated(nonsending) func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws
     /// Finish writing body
     /// - Parameter trailingHeaders: Any trailing headers you want to include at end
-    consuming func finish(_ trailingHeaders: HTTPFields?) async throws
+    consuming nonisolated(nonsending) func finish(_ trailingHeaders: HTTPFields?) async throws
 }
 
 extension ResponseBodyWriter {
     /// Default implementation of writing a sequence of ByteBuffers
     @inlinable
-    public mutating func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
+    public mutating nonisolated(nonsending) func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
         for part in buffers {
             try await self.write(part)
         }
@@ -34,7 +34,8 @@ extension ResponseBodyWriter {
     ///  Write AsyncSequence of ByteBuffers
     /// - Parameter buffers: ByteBuffer AsyncSequence
     @inlinable
-    public mutating func write<BufferSequence: AsyncSequence>(_ buffers: BufferSequence) async throws where BufferSequence.Element == ByteBuffer {
+    public mutating nonisolated(nonsending) func write<BufferSequence: AsyncSequence>(_ buffers: BufferSequence) async throws
+    where BufferSequence.Element == ByteBuffer {
         for try await buffer in buffers {
             try await self.write(buffer)
         }


### PR DESCRIPTION
This is a minor breaking change, but it allows for the ResponseBodyWriter to be used in `nonisolated(nonsending)` functions without a `Sending 'writer' risks causing data races` error. 

Without this many custom Response writers will struggle to use the ResponseBodyWriter. 