### PR TITLE
Add `FullFoundation` trait that enables code needing the full Foundation library

### DIFF
--- a/.github/workflows/verify-foundation.yml
+++ b/.github/workflows/verify-foundation.yml
@@ -1,0 +1,22 @@
+name: Verify not using Foundation
+
+on:
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-foundation
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: swift:latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: run script
+      run: ./scripts/verify-foundation.sh

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,8 @@ let package = Package(
     ],
     traits: [
         .trait(name: "ConfigurationSupport", description: "Enable support for swift-configuration package."),
-        .default(enabledTraits: ["ConfigurationSupport"]),
+        .trait(name: "FullFoundationSupport", description: "Enable support for functionality that requires all of Foundation."),
+        .default(enabledTraits: ["ConfigurationSupport", "FullFoundationSupport"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.2"),

--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
     ],
     traits: [
         .trait(name: "ConfigurationSupport", description: "Enable support for swift-configuration package."),
-        .trait(name: "FullFoundationSupport", description: "Enable support for functionality that requires all of Foundation."),
-        .default(enabledTraits: ["ConfigurationSupport", "FullFoundationSupport"]),
+        .trait(name: "FullFoundation", description: "Enable functionality that requires full Foundation."),
+        .default(enabledTraits: ["ConfigurationSupport", "FullFoundation"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.2"),

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -15,6 +15,8 @@ let swiftSettings: [SwiftSetting] = [
     // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
     .enableUpcomingFeature("InternalImportsByDefault"),
 
+    // Used to fake the trait on Swift 6.1
+    .define("FullFoundation"),
 ]
 
 let package = Package(

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -14,9 +14,6 @@ let swiftSettings: [SwiftSetting] = [
 
     // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
     .enableUpcomingFeature("InternalImportsByDefault"),
-
-    // Used to fake the trait on Swift 6.1
-    .define("FullFoundation"),
 ]
 
 let package = Package(
@@ -30,6 +27,10 @@ let package = Package(
         .library(name: "HummingbirdRouter", targets: ["HummingbirdRouter"]),
         .library(name: "HummingbirdTesting", targets: ["HummingbirdTesting"]),
         .executable(name: "PerformanceTest", targets: ["PerformanceTest"]),
+    ],
+    traits: [
+        .trait(name: "FullFoundation", description: "Enable functionality that requires full Foundation."),
+        .default(enabledTraits: ["FullFoundation"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.2"),

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#if canImport(FoundationEssentials) && !FullFoundationSupport
+#if canImport(FoundationEssentials) && !FullFoundation
 public import FoundationEssentials
 #else
 public import Foundation
@@ -29,7 +29,7 @@ public struct URLEncodedFormDecoder: Sendable {
         /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
         case iso8601
 
-        #if !canImport(FoundationEssentials) || FullFoundationSupport
+        #if !canImport(FoundationEssentials) || FullFoundation
         /// Decode the `Date` as a string parsed by the given formatter.
         case formatted(DateFormatter)
         #endif
@@ -654,7 +654,7 @@ extension _URLEncodedFormDecoder {
                 )
             }
             return date
-        #if !canImport(FoundationEssentials) || FullFoundationSupport
+        #if !canImport(FoundationEssentials) || FullFoundation
         case .formatted(let formatter):
             let dateString = try unbox(node, as: String.self)
             guard let date = formatter.date(from: dateString) else {

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -6,7 +6,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(FoundationEssentials) && !FullFoundationSupport
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 
 /// The wrapper struct for decoding URL encoded form data to Codable classes
 @available(hummingbird 2.0, *)
@@ -25,8 +29,10 @@ public struct URLEncodedFormDecoder: Sendable {
         /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
         case iso8601
 
+        #if !canImport(FoundationEssentials) || FullFoundationSupport
         /// Decode the `Date` as a string parsed by the given formatter.
         case formatted(DateFormatter)
+        #endif
 
         /// Decode the `Date` as a custom value encoded by the given closure.
         case custom(@Sendable (_ decoder: any Decoder) throws -> Date)
@@ -648,12 +654,14 @@ extension _URLEncodedFormDecoder {
                 )
             }
             return date
+        #if !canImport(FoundationEssentials) || FullFoundationSupport
         case .formatted(let formatter):
             let dateString = try unbox(node, as: String.self)
             guard let date = formatter.date(from: dateString) else {
                 throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Invalid date format"))
             }
             return date
+        #endif
         case .custom(let closure):
             self.storage.push(container: node)
             defer { self.storage.popContainer() }

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormEncoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormEncoder.swift
@@ -6,7 +6,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(FoundationEssentials) && !FullFoundationSupport
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 
 /// The wrapper struct for encoding Codable classes to URL encoded form data
 @available(hummingbird 2.0, *)
@@ -25,8 +29,10 @@ public struct URLEncodedFormEncoder: Sendable {
         /// Encode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
         case iso8601
 
+        #if !canImport(FoundationEssentials) || FullFoundationSupport
         /// Encode the `Date` as a string parsed by the given formatter.
         case formatted(DateFormatter)
+        #endif
 
         /// Encode the `Date` as a custom value encoded by the given closure.
         case custom(@Sendable (Date, any Encoder) throws -> Void)
@@ -325,8 +331,10 @@ extension _URLEncodedFormEncoder {
             try self.encode(Double(date.timeIntervalSince1970).description)
         case .iso8601:
             try self.encode(date.formatted(.iso8601))
+        #if !canImport(FoundationEssentials) || FullFoundationSupport
         case .formatted(let formatter):
             try self.encode(formatter.string(from: date))
+        #endif
         case .custom(let closure):
             try closure(date, self)
         }

--- a/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormEncoder.swift
+++ b/Sources/Hummingbird/Codable/URLEncodedForm/URLEncodedFormEncoder.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#if canImport(FoundationEssentials) && !FullFoundationSupport
+#if canImport(FoundationEssentials) && !FullFoundation
 public import FoundationEssentials
 #else
 public import Foundation
@@ -29,7 +29,7 @@ public struct URLEncodedFormEncoder: Sendable {
         /// Encode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
         case iso8601
 
-        #if !canImport(FoundationEssentials) || FullFoundationSupport
+        #if !canImport(FoundationEssentials) || FullFoundation
         /// Encode the `Date` as a string parsed by the given formatter.
         case formatted(DateFormatter)
         #endif
@@ -331,7 +331,7 @@ extension _URLEncodedFormEncoder {
             try self.encode(Double(date.timeIntervalSince1970).description)
         case .iso8601:
             try self.encode(date.formatted(.iso8601))
-        #if !canImport(FoundationEssentials) || FullFoundationSupport
+        #if !canImport(FoundationEssentials) || FullFoundation
         case .formatted(let formatter):
             try self.encode(formatter.string(from: date))
         #endif

--- a/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
@@ -224,7 +224,7 @@ extension URLEncodedFormTests {
             dateFormatter.locale = Locale(identifier: "en_US_POSIX")
             dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
             dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-            #if !canImport(FoundationEssentials) || FullFoundationSupport
+            #if !canImport(FoundationEssentials) || FullFoundation
             self.testForm(test, query: "d=2001-01-28T15%3A14%3A03.000Z", decoder: .init(dateDecodingStrategy: .formatted(dateFormatter)))
             #endif
             self.testForm(test, query: "d=2001-01-28T15%3A14%3A03Z", decoder: .init(dateDecodingStrategy: .parseStrategy(.iso8601)))

--- a/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLDecoderTests.swift
@@ -224,7 +224,9 @@ extension URLEncodedFormTests {
             dateFormatter.locale = Locale(identifier: "en_US_POSIX")
             dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
             dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+            #if !canImport(FoundationEssentials) || FullFoundationSupport
             self.testForm(test, query: "d=2001-01-28T15%3A14%3A03.000Z", decoder: .init(dateDecodingStrategy: .formatted(dateFormatter)))
+            #endif
             self.testForm(test, query: "d=2001-01-28T15%3A14%3A03Z", decoder: .init(dateDecodingStrategy: .parseStrategy(.iso8601)))
         }
 

--- a/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
@@ -176,7 +176,7 @@ extension URLEncodedFormTests {
             dateFormatter.locale = Locale(identifier: "en_US_POSIX")
             dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
             dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-            #if !canImport(FoundationEssentials) || FullFoundationSupport
+            #if !canImport(FoundationEssentials) || FullFoundation
             self.testForm(test, query: "d=2001-01-28T15:14:03.000Z", encoder: .init(dateEncodingStrategy: .formatted(dateFormatter)))
             #endif
             self.testForm(test, query: "d=2001-01-28T15:14:03Z", encoder: .init(dateEncodingStrategy: .formatStyle(.iso8601)))

--- a/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
+++ b/Tests/HummingbirdTests/URLEncodedForm/URLEncoderTests.swift
@@ -176,7 +176,9 @@ extension URLEncodedFormTests {
             dateFormatter.locale = Locale(identifier: "en_US_POSIX")
             dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
             dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+            #if !canImport(FoundationEssentials) || FullFoundationSupport
             self.testForm(test, query: "d=2001-01-28T15:14:03.000Z", encoder: .init(dateEncodingStrategy: .formatted(dateFormatter)))
+            #endif
             self.testForm(test, query: "d=2001-01-28T15:14:03Z", encoder: .init(dateEncodingStrategy: .formatStyle(.iso8601)))
         }
 

--- a/scripts/verify-foundation.sh
+++ b/scripts/verify-foundation.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Verify package with no trait does not require libFoundation.so or libFoundationInternationalization.so
+# This script only checks the dynamic libs referenced by the PerformanceTest executable.
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+
+PRODUCT=$1
+TRAITS=${2:-}
+
+echo "Build $PRODUCT"
+if [ -z "$TRAITS" ]; then
+    swift build -c release --disable-default-traits --product "$PRODUCT"
+else
+    swift build -c release --traits "$TRAITS" --product "$PRODUCT"
+fi
+
+BINPATH=$(swift build -c release --show-bin-path)
+echo "$PRODUCT can be found in $BINPATH"
+OBJDUMP=$(objdump -p "$BINPATH"/"$PRODUCT" | grep "NEEDED")
+
+LIBS_TO_CHECK="libFoundation.so libFoundationInternationalization.so lib_FoundationICU.so"
+for LIB in ${LIBS_TO_CHECK}; do
+  echo -n "Checking for ${LIB}... "
+  
+  # check if the binary has a dependency on Foundation or ICU
+  echo "${OBJDUMP}" | grep "${LIB}"  # return 1 if not found
+
+  # 1 is success (grep failed to find the lib), 0 is failure (grep successly found the lib)
+  SUCCESS=$?
+  if [ "$SUCCESS" -eq 0 ]; then
+    log "❌ ${LIB} found." && break
+  else
+    log "✅ ${LIB} not found."
+  fi
+done
+
+# exit code is the opposite of the grep exit code
+if [ "$SUCCESS" -eq 0 ]; then
+  fatal "❌ At least one foundation lib was found, reporting the error."
+else
+  log "✅ No foundation lib found, congrats!" && exit 0
+fi


### PR DESCRIPTION
This trait is enabled by default. So as long as people aren't setting traits when including hummingbird this change is non-breaking. But if someone was to set traits to something other than `.default` then the DateFormatter from URLEncodedFormEncoder/Decoder will not be available.

This PR also comes with an additional GitHub action that verifies whether the library links Foundation 
